### PR TITLE
docs: replace WARP.md with development guide and repo structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ No manual intervention needed for routine security patches and minor updates!
 
 ## Development
 
-See [WARP.md](WARP.md) for detailed development guidelines, architecture overview, and project-specific conventions.
+See [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) for development guidelines and [docs/REPO_STRUCTURE.md](docs/REPO_STRUCTURE.md) for the repository map (keep it updated when structure changes).
 
 ### Pre-commit Hooks
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,15 +1,13 @@
-# WARP.md
+# Development Guide
 
-This file provides guidance to WARP (warp.dev) when working with code in this repository.
+Project-specific commands, architecture, and conventions for dev-news-aggregator.
 
-## Warp AI Behavior
+For the directory map, see [REPO_STRUCTURE.md](REPO_STRUCTURE.md). **Update that file whenever you change project structure** (new folders, models, routes, migrations, etc.).
 
-- **At the start of every new chat session**: Read this WARP.md file and confirm you've read it and will follow the guidelines
-- **When user makes suggestions**: Ask if they want the suggestion added to WARP.md for future reference
+## Development commands
 
-## Development Commands
+### Setup & database
 
-### Setup & Database
 ```bash
 # Install dependencies
 bundle install
@@ -25,7 +23,8 @@ bin/rails db:seed
 bin/rails runner "NewsAggregatorService.fetch_all_news"
 ```
 
-### Running the Application
+### Running the application
+
 ```bash
 # Start Rails server
 bin/rails server
@@ -36,7 +35,8 @@ bin/dev
 # Access application at http://localhost:3000
 ```
 
-### News Operations
+### News operations
+
 ```bash
 # Fetch news from all sources
 bin/rails news:fetch
@@ -52,6 +52,7 @@ bin/rails runner "NewsAggregatorService.fetch_all_news"
 ```
 
 ### Testing
+
 ```bash
 # Run all tests
 bin/rails test
@@ -63,7 +64,8 @@ bin/rails test test/models/article_test.rb
 bin/rails test test/controllers/articles_controller_test.rb -n test_index
 ```
 
-### Code Quality
+### Code quality
+
 ```bash
 # Run RuboCop linter
 bin/rubocop
@@ -75,44 +77,45 @@ bin/rubocop -a
 bin/brakeman
 ```
 
-### Cron Jobs
+### Cron jobs
+
 ```bash
 # Update crontab with scheduled jobs
 whenever --update-crontab
 
-# View current cron schedule  
+# View current cron schedule
 crontab -l
 
 # Clear crontab
 whenever --clear-crontab
 ```
 
-## Architecture Overview
+## Architecture overview
 
-### Core Components
+### Core components
 
 **NewsAggregatorService**: Central orchestrator that coordinates all news fetchers. Initializes fetchers for Hacker News, Dev.to, and multiple Reddit subreddits covering programming languages (Ruby, Rust, JavaScript), web development, cybersecurity, AI/ML, and general tech. Handles error logging and aggregates results.
 
-**Fetcher Architecture**: Modular fetcher system with `NewsFetchers::BaseFetcher` as the abstract base class. Each fetcher (HackerNews, DevTo, Reddit) inherits and implements `fetch_articles`. Common pattern: fetch from API, transform data, call `create_or_update_article`.
+**Fetcher architecture**: Modular fetcher system with `NewsFetchers::BaseFetcher` as the abstract base class. Each fetcher (HackerNews, DevTo, Reddit) inherits and implements `fetch_articles`. Common pattern: fetch from API, transform data, call `create_or_update_article`.
 
-**Data Models**:
+**Data models**:
 - `Article`: Stores aggregated news with unified schema (title, url, published_at, description, external_id, source_type, score, comment_count)
 - `Bookmark`: Tracks bookmarked articles for personal reading list functionality
 - `NewsSource`: Configuration table for news sources (currently unused in favor of hard-coded fetchers)
 
-**Scheduled Jobs**: Uses `whenever` gem to run `news:fetch` hourly during business hours (9 AM - 6 PM) and `news:clean` daily at 2 AM. Logs to `log/cron.log`.
+**Scheduled jobs**: Uses `whenever` gem to run `news:fetch` hourly during business hours (9 AM - 6 PM) and `news:clean` daily at 2 AM. Logs to `log/cron.log`.
 
-### Key Design Patterns
+### Key design patterns
 
-**Service-Oriented Architecture**: Business logic separated into service classes rather than fat models. Each news source has its own fetcher service.
+**Service-oriented architecture**: Business logic separated into service classes rather than fat models. Each news source has its own fetcher service.
 
-**Fail-Safe Aggregation**: If one news source fails, others continue processing. Errors are logged but don't stop the entire aggregation process.
+**Fail-safe aggregation**: If one news source fails, others continue processing. Errors are logged but don't stop the entire aggregation process.
 
-**Idempotent Updates**: Articles use `find_or_initialize_by(external_id, source_type)` to prevent duplicates while allowing updates to existing articles.
+**Idempotent updates**: Articles use `find_or_initialize_by(external_id, source_type)` to prevent duplicates while allowing updates to existing articles.
 
-**Rate Limiting Awareness**: Limits API calls (e.g., first 30 HN stories) and includes proper error handling for API failures.
+**Rate limiting awareness**: Limits API calls (e.g., first 30 HN stories) and includes proper error handling for API failures.
 
-### File Structure
+### File structure
 
 ```
 app/
@@ -123,13 +126,13 @@ app/
     news_fetchers/
       base_fetcher.rb                   # Abstract fetcher base class
       hacker_news_fetcher.rb            # HN API integration
-      dev_to_fetcher.rb                 # Dev.to API integration  
+      dev_to_fetcher.rb                 # Dev.to API integration
       reddit_fetcher.rb                 # Reddit API integration
 lib/tasks/news.rake                     # Rake tasks for news operations
 config/schedule.rb                      # Cron job definitions
 ```
 
-### API Integration Details
+### API integration details
 
 **Hacker News**: Uses Firebase API (`hacker-news.firebaseio.com/v0`). Fetches top stories, then individual story details. Filters out Ask HN posts without URLs.
 
@@ -137,44 +140,33 @@ config/schedule.rb                      # Cron job definitions
 
 **Reddit**: Multiple instances for different subreddits. Each subreddit is treated as a separate source type in the database.
 
-### Database Schema
+### Database schema
 
 Articles table uses generic fields to accommodate all news sources:
 - `source_type`: String identifier (hacker_news, dev_to, reddit_programming, etc.)
-- `external_id`: Source-specific unique identifier 
+- `external_id`: Source-specific unique identifier
 - `score`: Votes/reactions from source (HN score, Dev.to reactions, Reddit upvotes)
 - `comment_count`: Source-specific comment counts
 
-### Environment Configuration
+### Environment configuration
 
 Uses Docker Compose for PostgreSQL with environment variables:
 - `POSTGRES_USER`: devnews
-- `POSTGRES_PASSWORD`: password  
+- `POSTGRES_PASSWORD`: password
 - `POSTGRES_DB`: dev_news_aggregator
 
-### Key Features
+### Key features
 
-**Article Bookmarking**: Users can bookmark articles for later reading. Bookmarks are displayed in a dedicated reading list with category filtering.
+**Article bookmarking**: Users can bookmark articles for later reading. Bookmarks are displayed in a dedicated reading list with category filtering.
 
-**Category Filtering**: Articles are grouped into logical categories (Programming Languages, Web Development, Security, AI & Machine Learning, General Tech) for easier browsing.
+**Category filtering**: Articles are grouped into logical categories (Programming Languages, Web Development, Security, AI & Machine Learning, General Tech) for easier browsing.
 
-**Multi-Source Aggregation**: Fetches from 12+ different sources including:
+**Multi-source aggregation**: Fetches from 12+ different sources including:
 - Hacker News (hacker_news)
-- Dev.to (dev_to) 
+- Dev.to (dev_to)
 - Reddit subreddits: ruby, rust, javascript, programming, webdev, netsec, cybersecurity, technology, MachineLearning, artificial, LocalLLaMA
 
-### Key Features
-
-**Article Bookmarking**: Users can bookmark articles for later reading. Bookmarks are displayed in a dedicated reading list with category filtering.
-
-**Category Filtering**: Articles are grouped into logical categories (Programming Languages, Web Development, Security, AI & Machine Learning, General Tech) for easier browsing.
-
-**Multi-Source Aggregation**: Fetches from 12+ different sources including:
-- Hacker News (hacker_news)
-- Dev.to (dev_to) 
-- Reddit subreddits: ruby, rust, javascript, programming, webdev, netsec, cybersecurity, technology, MachineLearning, artificial, LocalLLaMA
-
-### Adding New News Sources
+### Adding new news sources
 
 1. Create fetcher in `app/services/news_fetchers/` inheriting from `BaseFetcher`
 2. Implement `fetch_articles` method
@@ -182,19 +174,19 @@ Uses Docker Compose for PostgreSQL with environment variables:
 4. Use consistent `source_type` naming pattern
 5. Update category grouping in `articles_helper.rb` if needed
 
-## Coding Guidelines
+## Coding guidelines
 
-### General Principles
-- Follow SOLID principles (Single responsibility, Open/closed, Liskov substitution, Interface segregation, Dependency inversion)
-- Follow KISS convention (Keep It Simple, Stupid)
-- Follow DRY principle (Don't Repeat Yourself)
+### General principles
+
+- Follow **SOLID**, **KISS**, and **DRY**
 - Use descriptive method and variable names
 - Keep methods small and focused on a single responsibility
 - Prefer composition over inheritance
 - Prefer early returns over ternary operators for better readability
-- **Do not add comments to code** - code should be self-documenting through clear naming and structure
+- **Do not add comments to code** — code should be self-documenting through clear naming and structure
 
-### Ruby/Rails Conventions
+### Ruby/Rails conventions
+
 - Follow RuboCop conventions (run `bin/rubocop` to check)
 - Use consistent indentation (2 spaces)
 - Follow Rails naming conventions
@@ -204,17 +196,18 @@ Uses Docker Compose for PostgreSQL with environment variables:
 - Prefer `find_by` over `where.first`
 - Use scopes for reusable queries
 
-### Testing Standards
-- **FOR EVERY CHANGE CREATE TESTS** - This is mandatory, no exceptions
-- **PREFER TDD APPROACH** - Write tests first when possible, then implement functionality
-- All tests start with 'should' (e.g., `test "should create bookmark when valid"`) 
-- Do not use `send` in tests - test public interface only
+### Testing standards
+
+- **For every change, create tests** — mandatory, no exceptions
+- **Prefer TDD** — write tests first when possible, then implement functionality
+- All tests start with `should` (e.g., `test "should create bookmark when valid"`)
+- Do not use `send` in tests — test public interface only
 - Always prefer fixtures over `create` methods for consistency
 - Mock only when necessary (external APIs, slow operations) and use mocha gem for mocking
-- Do not use comments in tests - test names should be self-descriptive
+- Do not use comments in tests — test names should be self-descriptive
 - Follow RuboCop conventions in test files
 - Apply SOLID and KISS principles to test code
-- One assertion per concept, multiple assertions per test are acceptable if related
+- One assertion per concept; multiple assertions per test are acceptable if related
 - Use `setup` method for common test data initialization
 - Prefer integration tests over unit tests when testing user workflows
 - Use `parallelize(workers: :number_of_processors)` in test_helper.rb for faster test runs
@@ -222,17 +215,19 @@ Uses Docker Compose for PostgreSQL with environment variables:
 - When adding new models, controllers, or features, create comprehensive test coverage immediately
 - Test both happy path and edge cases (error conditions, boundary values, invalid inputs)
 
-### Git Commit Guidelines
-- **ALWAYS run tests and RuboCop before committing** - Run `bin/rails test` and `bin/rubocop` to ensure all tests pass and code follows style guidelines
+### Git commit guidelines
+
+- **Always run tests and RuboCop before committing** — run `bin/rails test` and `bin/rubocop`
 - Use conventional commit format (e.g., `feat:`, `fix:`, `test:`, `refactor:`)
-- One line commit messages only - no body or additional description
+- One line commit messages only — no body or additional description
 - One commit per file (exceptions allowed for large PRs with same context)
 - No co-authored comments
 - Keep commit messages concise and descriptive
-- Commit frequently to save changes - don't wait until everything is perfect
+- Commit frequently to save changes — don't wait until everything is perfect
 - Push commits regularly to avoid losing work
 
-### GitHub Issue and Branch Workflow
+### GitHub issue and branch workflow
+
 - When creating issues, use `gh` CLI and conventional commits format
 - **Always add appropriate labels to issues** using `--label` option with `gh` CLI
 - Required issue labels:
@@ -241,11 +236,11 @@ Uses Docker Compose for PostgreSQL with environment variables:
   - Status: `todo`, `in-progress`, `review-needed`, etc.
 - Example issue creation: `gh issue create --title "feat: new feature" --body "Description" --label "feature,medium,todo"`
 - Use available issue templates when creating new issues
-- **When working on an issue, ALWAYS follow this workflow:**
+- **When working on an issue, always follow this workflow:**
   1. Create a new branch based on the issue name
   2. Make changes and commit following conventional commits format
   3. Push branch to origin
-  4. **Create Pull Request using `gh` CLI - NEVER commit directly to master**
+  4. **Create Pull Request using `gh` CLI — never commit directly to master**
   5. Wait for review/approval before merging
 - Branch naming convention: use descriptive names related to the issue (e.g., `fix-ci-bundler-cache`, `feat-deployment-automation`)
 - **Example PR workflow:**

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -1,0 +1,201 @@
+# Repository Structure
+
+Living map of this codebase. **Keep this file in sync with the repo** — see [Maintenance](#maintenance) below.
+
+Last updated: 2026-07-02
+
+## Maintenance
+
+Update this file in the **same PR or commit** whenever you change project structure, including:
+
+- New, renamed, moved, or removed directories or top-level files
+- New models, controllers, services, jobs, or fetchers
+- New migrations or meaningful schema changes
+- New routes or major feature areas
+- New config files that define app behavior
+- New docs, CI workflows, or tooling entry points
+
+**Do not** update for trivial edits (bug fixes, copy changes, test-only changes inside existing files).
+
+When updating:
+
+1. Adjust the tree and tables below to match reality.
+2. Add or revise the one-line purpose for anything new.
+3. Set **Last updated** at the top to today's date.
+
+Agents and contributors: if you make a structural change and this file was not updated, update it before finishing the task (or flag it to the user).
+
+## Overview
+
+Rails 8 news aggregator with a React (Vite) frontend, PostgreSQL, and scheduled news fetching from Hacker News, Dev.to, and Reddit.
+
+```
+dev-news-aggregator/
+├── app/                    # Application code (MVC, services, jobs, frontend)
+├── bin/                    # Executables (rails, dev, rubocop, brakeman, …)
+├── config/                 # Rails and app configuration
+├── db/                     # Migrations, schema, seeds
+├── docs/                   # Project documentation
+├── lib/                    # Rake tasks and non-autoloaded code
+├── public/                 # Static assets and error pages
+├── test/                   # Minitest suite (models, controllers, system, integration)
+├── .github/                # CI/CD and Dependabot
+├── docker-compose.yml      # Local PostgreSQL
+├── Dockerfile              # Container build
+├── Gemfile                 # Ruby dependencies
+├── package.json            # Node dependencies (Vite, React)
+└── vite.config.ts          # Vite bundler config
+```
+
+## `app/`
+
+| Path | Purpose |
+|------|---------|
+| `app/controllers/` | HTTP layer — articles, bookmarks, read/dismissed lists |
+| `app/models/` | ActiveRecord models |
+| `app/services/` | Business logic — news aggregation orchestration |
+| `app/services/news_fetchers/` | Per-source API fetchers (HN, Dev.to, Reddit) |
+| `app/jobs/` | Background jobs (e.g. permanent dismissal) |
+| `app/helpers/` | View helpers (categories, formatting) |
+| `app/views/` | ERB templates |
+| `app/frontend/` | React app (Vite entrypoint + components) |
+| `app/javascript/` | Stimulus controllers and legacy JS hooks |
+| `app/assets/stylesheets/` | CSS |
+| `app/mailers/` | Action Mailer base |
+
+### Controllers
+
+| File | Responsibility |
+|------|----------------|
+| `articles_controller.rb` | Article list/show, bookmark, dismiss actions |
+| `bookmarks_controller.rb` | Saved articles index |
+| `read_articles_controller.rb` | Mark articles as read |
+| `dismissed_articles_controller.rb` | Dismissed and recently dismissed lists |
+
+### Models
+
+| File | Table | Purpose |
+|------|-------|---------|
+| `article.rb` | `articles` | Aggregated news item from any source |
+| `bookmark.rb` | `bookmarks` | User-saved article |
+| `read_article.rb` | `read_articles` | Article marked as read |
+| `dismissed_article.rb` | `dismissed_articles` | Article hidden from feed |
+| `news_source.rb` | `news_sources` | Source config (mostly unused; fetchers are hard-coded) |
+
+### Services
+
+| File | Purpose |
+|------|---------|
+| `news_aggregator_service.rb` | Runs all fetchers, handles errors, aggregates results |
+| `news_fetchers/base_fetcher.rb` | Abstract fetcher — fetch, transform, upsert article |
+| `news_fetchers/hacker_news_fetcher.rb` | Hacker News Firebase API |
+| `news_fetchers/dev_to_fetcher.rb` | Dev.to REST API |
+| `news_fetchers/reddit_fetcher.rb` | Reddit API (one instance per subreddit) |
+
+### Jobs
+
+| File | Purpose |
+|------|---------|
+| `make_dismissal_permanent_job.rb` | Converts temporary dismissals to permanent |
+
+### Frontend
+
+| Path | Purpose |
+|------|---------|
+| `app/frontend/entrypoints/application.tsx` | Vite/React mount point |
+| `app/frontend/components/App.tsx` | Root React component |
+
+## `config/`
+
+| File | Purpose |
+|------|---------|
+| `routes.rb` | URL routing |
+| `database.yml` | PostgreSQL connection |
+| `schedule.rb` | Cron definitions (`whenever` gem) |
+| `news_aggregator.yml` | News source configuration |
+| `deploy.yml` | Kamal deployment |
+| `vite.json` | Vite-Rails integration |
+| `environments/` | Per-env Rails settings (development, test, production) |
+| `initializers/` | Boot-time Ruby configuration |
+
+## `db/`
+
+| Path | Purpose |
+|------|---------|
+| `migrate/` | Schema migrations |
+| `schema.rb` | Current DB schema (generated) |
+| `seeds.rb` | Seed data |
+
+### Migrations (in order)
+
+| Migration | Creates |
+|-----------|---------|
+| `create_news_sources` | `news_sources` |
+| `create_articles` | `articles` |
+| `create_bookmarks` | `bookmarks` |
+| `create_read_articles` | `read_articles` |
+| `create_dismissed_articles` | `dismissed_articles` |
+
+## `lib/`
+
+| Path | Purpose |
+|------|---------|
+| `lib/tasks/news.rake` | `news:fetch`, `news:latest`, `news:clean` rake tasks |
+
+## `test/`
+
+| Path | Purpose |
+|------|---------|
+| `test/models/` | Model unit tests |
+| `test/controllers/` | Controller tests |
+| `test/services/` | Service and fetcher tests |
+| `test/jobs/` | Job tests |
+| `test/helpers/` | Helper tests |
+| `test/integration/` | Multi-step workflow tests |
+| `test/system/` | Browser/system tests (Capybara) |
+| `test/fixtures/` | YAML test data |
+
+## `docs/`
+
+| File | Purpose |
+|------|---------|
+| `DEVELOPMENT.md` | Commands, architecture, coding and git conventions |
+| `REPO_STRUCTURE.md` | This file — directory map and maintenance rules |
+| `PRE_COMMIT_HOOKS.md` | Overcommit setup and usage |
+| `REACT_SETUP.md` | React/Vite frontend setup |
+
+## `.github/`
+
+| Path | Purpose |
+|------|---------|
+| `workflows/ci.yml` | CI pipeline (tests, lint, security) |
+| `workflows/dependabot-auto-merge.yml` | Auto-merge for patch/minor Dependabot PRs |
+| `dependabot.yml` | Dependency update schedule |
+| `ISSUE_TEMPLATE/` | GitHub issue templates |
+
+## Key root files
+
+| File | Purpose |
+|------|---------|
+| `README.md` | Project overview and quick start |
+| `Gemfile` / `Gemfile.lock` | Ruby gems |
+| `package.json` / `package-lock.json` | Node packages |
+| `docker-compose.yml` | Local PostgreSQL container |
+| `Dockerfile` | Production/container image |
+| `.overcommit.yml` | Git hook configuration |
+| `.rubocop.yml` | Ruby style rules |
+| `tsconfig.json` | TypeScript config for frontend |
+
+## Routes (summary)
+
+| Path | Controller#action |
+|------|-------------------|
+| `/` | `articles#index` |
+| `/articles/:id` | `articles#show` |
+| `/bookmarks` | `bookmarks#index` |
+| `/read` | `read_articles#index` |
+| `/dismissed` | `dismissed_articles#index` |
+| `/recently_dismissed` | `dismissed_articles#recently_dismissed` |
+| `/up` | Rails health check |
+
+See `config/routes.rb` for member routes (bookmark, dismiss, mark as read, etc.).


### PR DESCRIPTION
## Summary

- Remove root-level WARP.md and move project guidance into docs/DEVELOPMENT.md
- Add docs/REPO_STRUCTURE.md as a living map of the repository with maintenance rules
- Update README.md to link to the new docs

## Test plan

- [ ] Verify docs/DEVELOPMENT.md covers setup, architecture, and coding conventions
- [ ] Verify docs/REPO_STRUCTURE.md matches current repo layout
- [ ] Confirm README.md links resolve correctly

Made with [Cursor](https://cursor.com)