### PR TITLE
fix: add unique index on articles (external_id, source_type) (#141)

### DIFF
--- a/db/migrate/20260703150100_add_unique_index_on_articles.rb
+++ b/db/migrate/20260703150100_add_unique_index_on_articles.rb
@@ -1,0 +1,25 @@
+class AddUniqueIndexOnArticles < ActiveRecord::Migration[8.1]
+  def up
+    deduplicate_articles
+
+    add_index :articles, [ :external_id, :source_type ], unique: true unless index_exists?(:articles, [ :external_id, :source_type ])
+  end
+
+  def down
+    remove_index :articles, column: [ :external_id, :source_type ]
+  end
+
+  private
+
+  def deduplicate_articles
+    execute <<~SQL.squish
+      DELETE FROM articles a
+      USING articles b
+      WHERE a.id < b.id
+        AND a.external_id = b.external_id
+        AND a.source_type = b.source_type
+        AND a.external_id IS NOT NULL
+        AND a.source_type IS NOT NULL
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_03_140000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_03_150100) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -25,6 +25,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_03_140000) do
     t.string "title"
     t.datetime "updated_at", null: false
     t.string "url"
+    t.index ["external_id", "source_type"], name: "index_articles_on_external_id_and_source_type", unique: true
+    t.index ["published_at"], name: "index_articles_on_published_at"
+    t.index ["source_type"], name: "index_articles_on_source_type"
   end
 
   create_table "bookmarks", force: :cascade do |t|


### PR DESCRIPTION
## Summary
Adds a unique database constraint on `(external_id, source_type)` to match the upsert key used by fetchers and prevent duplicate rows from concurrent fetches.

## Changes
- Migration deduplicates existing rows before adding the index
- Updates `schema.rb`

Closes #141

## Test plan
- [x] Migration runs cleanly on a fresh database
- [x] Migration is idempotent when the index already exists locally