### PR TITLE
perf: add query indexes on articles published_at and source_type (#195)

### DIFF
--- a/db/migrate/20260703150200_add_article_query_indexes.rb
+++ b/db/migrate/20260703150200_add_article_query_indexes.rb
@@ -1,0 +1,6 @@
+class AddArticleQueryIndexes < ActiveRecord::Migration[8.1]
+  def change
+    add_index :articles, :published_at unless index_exists?(:articles, :published_at)
+    add_index :articles, :source_type unless index_exists?(:articles, :source_type)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_03_150100) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_03_150200) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 


### PR DESCRIPTION
## Summary
Adds indexes on `published_at` and `source_type` to speed up list queries that sort and filter by these columns.

Closes #195

## Test plan
- [x] Migration is reversible
- [x] Migration is idempotent when indexes already exist