### PR TITLE
feat: add Article model validations for ingested data quality (#166)

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,4 +1,8 @@
 class Article < ApplicationRecord
+  validates :title, :url, :external_id, :source_type, presence: true
+  validates :external_id, uniqueness: { scope: :source_type }
+  validates :url, format: { with: URI::DEFAULT_PARSER.make_regexp(%w[http https]) }
+
   has_one :bookmark, dependent: :destroy
   has_one :read_article, dependent: :destroy
   has_one :dismissed_article, dependent: :destroy

--- a/app/services/news_fetchers/base_fetcher.rb
+++ b/app/services/news_fetchers/base_fetcher.rb
@@ -21,7 +21,11 @@ class NewsFetchers::BaseFetcher
 
     if article.new_record? || article.changed?
       is_new_record = article.new_record?
-      article.save!
+      unless article.save
+        Rails.logger.warn "Skipping invalid article (#{attributes[:source_type]}/#{attributes[:external_id]}): #{article.errors.full_messages.join(', ')}"
+        return article
+      end
+
       if is_new_record
         Rails.logger.info "Created article: #{article.title}"
       else

--- a/test/models/article_test.rb
+++ b/test/models/article_test.rb
@@ -260,4 +260,39 @@ class ArticleTest < ActiveSupport::TestCase
     not_dismissed = Article.not_dismissed
     assert_includes not_dismissed, temporary_dismissed
   end
+
+  test "requires title url external_id and source_type" do
+    article = Article.new
+    assert_not article.valid?
+    assert_includes article.errors[:title], "can't be blank"
+    assert_includes article.errors[:url], "can't be blank"
+    assert_includes article.errors[:external_id], "can't be blank"
+    assert_includes article.errors[:source_type], "can't be blank"
+  end
+
+  test "requires unique external_id per source_type" do
+    duplicate = Article.new(
+      title: "Duplicate",
+      url: "https://example.com/dup",
+      external_id: @article.external_id,
+      source_type: @article.source_type,
+      published_at: Time.current
+    )
+
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:external_id], "has already been taken"
+  end
+
+  test "rejects invalid URLs" do
+    article = Article.new(
+      title: "Bad URL",
+      url: "not-a-url",
+      external_id: "bad-url",
+      source_type: "test",
+      published_at: Time.current
+    )
+
+    assert_not article.valid?
+    assert_includes article.errors[:url], "is invalid"
+  end
 end

--- a/test/services/news_fetchers/base_fetcher_test.rb
+++ b/test/services/news_fetchers/base_fetcher_test.rb
@@ -68,6 +68,24 @@ class NewsFetchers::BaseFetcherTest < ActiveSupport::TestCase
     end
   end
 
+  test "should skip invalid article attributes" do
+    attributes = {
+      title: nil,
+      url: "https://example.com",
+      published_at: Time.current,
+      description: "Test description",
+      external_id: "invalid123",
+      source_type: "test_source",
+      score: 100,
+      comment_count: 10
+    }
+
+    assert_no_difference "Article.count" do
+      article = @fetcher.instance_eval { create_or_update_article(attributes) }
+      assert_not article.persisted?
+    end
+  end
+
   test "should not update article when no changes detected" do
     attributes = {
       title: "Test Article",


### PR DESCRIPTION
## Summary
Adds model-layer validations for ingested article data and updates fetchers to skip invalid records instead of raising.

Closes #166

Related: #141

## Test plan
- [x] Model validation tests cover required fields, uniqueness, and URL format
- [x] BaseFetcher skips invalid records without aborting the run