### PR TITLE
fix: resolve N+1 queries on ArticlesController#index (#151)

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -50,7 +50,7 @@ class ArticlesController < ApplicationController
   end
 
   def show
-    @article = Article.find(params[:id])
+    @article = Article.includes(:bookmark, :read_article, :dismissed_article).find(params[:id])
 
     respond_to do |format|
       format.html
@@ -127,7 +127,8 @@ class ArticlesController < ApplicationController
     end
 
     scope = apply_score_filter(scope)
-    scope.order(published_at: :desc)
+    scope.includes(:bookmark, :read_article, :dismissed_article)
+         .order(published_at: :desc)
   end
 
   def apply_score_filter(scope)

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -7,6 +7,15 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
     @rust_article = articles(:reddit_rust_article)
   end
 
+  def count_queries
+    count = 0
+    subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") { count += 1 }
+    yield
+    count
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber)
+  end
+
   test "should get index" do
     get articles_url
     assert_response :success
@@ -259,6 +268,18 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
     assert json_response["articles"].is_a?(Array)
     assert json_response["pagination"]["current_page"] == 1
     assert json_response["pagination"]["per_page"] == 50
+  end
+
+  test "index JSON avoids N+1 queries for article state" do
+    @article.bookmark!
+    @dev_to_article.mark_as_read!
+
+    query_count = count_queries do
+      get articles_url, as: :json
+    end
+
+    assert_response :success
+    assert_operator query_count, :<=, 15
   end
 
   test "index JSON should support pagination" do


### PR DESCRIPTION
## Summary
Eager-loads bookmark, read, and dismissed associations on the articles index and show actions to avoid per-row queries when serializing article state.

Closes #151

## Test plan
- [x] Controller test asserts query count stays bounded on index JSON