### PR TITLE
refactor: extract shared Article JSON serializer (#143)

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -19,7 +19,7 @@ class ArticlesController < ApplicationController
       format.html
       format.json do
         render json: {
-          articles: @articles.map { |article| article_json(article) },
+          articles: @articles.map { |article| ArticleSerializer.as_json(article) },
           articles_by_category: @articles_by_category.transform_values { |articles| articles.map(&:id) },
           categories: @articles_by_category.keys.map { |name| { name: name, icon: helpers.category_icon(name) } },
           pagination: {
@@ -54,7 +54,7 @@ class ArticlesController < ApplicationController
 
     respond_to do |format|
       format.html
-      format.json { render json: article_json(@article) }
+      format.json { render json: ArticleSerializer.as_json(@article) }
     end
   rescue ActiveRecord::RecordNotFound
     respond_to do |format|
@@ -152,25 +152,5 @@ class ArticlesController < ApplicationController
 
     Rails.cache.write(key, Time.current, expires_in: FETCH_RATE_LIMIT)
     false
-  end
-
-  def article_json(article)
-    {
-      id: article.id,
-      title: article.title,
-      url: article.url,
-      description: article.description,
-      source_type: article.source_type,
-      score: article.score,
-      comment_count: article.comment_count,
-      external_id: article.external_id,
-      published_at: article.published_at,
-      created_at: article.created_at,
-      updated_at: article.updated_at,
-      bookmarked: article.bookmarked?,
-      read: article.read?,
-      dismissed: article.dismissed?,
-      pending_dismissal: article.pending_dismissal?
-    }
   end
 end

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -16,7 +16,7 @@ class BookmarksController < ApplicationController
       format.html
       format.json do
         render json: {
-          articles: @bookmarked_articles.map { |article| article_json(article) },
+          articles: @bookmarked_articles.map { |article| ArticleSerializer.as_bookmark_json(article) },
           articles_by_source: @bookmarks_by_source.transform_keys(&:to_s).transform_values { |articles| articles.map(&:id) },
           pagination: {
             current_page: page,
@@ -27,23 +27,5 @@ class BookmarksController < ApplicationController
         }
       end
     end
-  end
-
-  private
-
-  def article_json(article)
-    {
-      id: article.id,
-      title: article.title,
-      url: article.url,
-      description: article.description,
-      source_type: article.source_type,
-      score: article.score,
-      comment_count: article.comment_count,
-      external_id: article.external_id,
-      published_at: article.published_at,
-      bookmarked_at: article.bookmark&.bookmarked_at,
-      read: article.read?
-    }
   end
 end

--- a/app/controllers/dismissed_articles_controller.rb
+++ b/app/controllers/dismissed_articles_controller.rb
@@ -15,7 +15,7 @@ class DismissedArticlesController < ApplicationController
       format.html
       format.json do
         render json: {
-          articles: @dismissed_articles.map { |article| article_json(article) },
+          articles: @dismissed_articles.map { |article| ArticleSerializer.as_dismissed_json(article) },
           pagination: {
             current_page: page,
             per_page: per_page,
@@ -38,27 +38,9 @@ class DismissedArticlesController < ApplicationController
       format.html
       format.json do
         render json: {
-          articles: @articles.map { |article| article_json(article) }
+          articles: @articles.map { |article| ArticleSerializer.as_dismissed_json(article) }
         }
       end
     end
-  end
-
-  private
-
-  def article_json(article)
-    {
-      id: article.id,
-      title: article.title,
-      url: article.url,
-      description: article.description,
-      source_type: article.source_type,
-      score: article.score,
-      comment_count: article.comment_count,
-      external_id: article.external_id,
-      published_at: article.published_at,
-      dismissed_at: article.dismissed_article&.dismissed_at,
-      permanent: article.dismissed_article&.permanent
-    }
   end
 end

--- a/app/controllers/read_articles_controller.rb
+++ b/app/controllers/read_articles_controller.rb
@@ -16,7 +16,7 @@ class ReadArticlesController < ApplicationController
       format.html
       format.json do
         render json: {
-          articles: @read_articles.map { |article| read_article_json(article) },
+          articles: @read_articles.map { |article| ArticleSerializer.as_read_json(article) },
           articles_by_source: @read_articles_by_source.transform_keys(&:to_s).transform_values { |articles| articles.map(&:id) },
           pagination: {
             current_page: page,
@@ -66,23 +66,5 @@ class ReadArticlesController < ApplicationController
       format.html { redirect_to read_articles_path, alert: "Article not found" }
       format.json { render json: { error: "Article not found" }, status: :not_found }
     end
-  end
-
-  private
-
-  def read_article_json(article)
-    {
-      id: article.id,
-      title: article.title,
-      url: article.url,
-      description: article.description,
-      source_type: article.source_type,
-      score: article.score,
-      comment_count: article.comment_count,
-      external_id: article.external_id,
-      published_at: article.published_at,
-      read_at: article.read_article&.read_at,
-      bookmarked: article.bookmarked?
-    }
   end
 end

--- a/app/serializers/article_serializer.rb
+++ b/app/serializers/article_serializer.rb
@@ -1,0 +1,42 @@
+class ArticleSerializer
+  BASE_ATTRIBUTES = %i[
+    id title url description source_type score comment_count external_id published_at
+  ].freeze
+
+  def self.as_json(article)
+    base_attributes(article).merge(
+      created_at: article.created_at,
+      updated_at: article.updated_at,
+      bookmarked: article.bookmarked?,
+      read: article.read?,
+      dismissed: article.dismissed?,
+      pending_dismissal: article.pending_dismissal?
+    )
+  end
+
+  def self.as_bookmark_json(article)
+    base_attributes(article).merge(
+      bookmarked_at: article.bookmark&.bookmarked_at,
+      read: article.read?
+    )
+  end
+
+  def self.as_read_json(article)
+    base_attributes(article).merge(
+      read_at: article.read_article&.read_at,
+      bookmarked: article.bookmarked?
+    )
+  end
+
+  def self.as_dismissed_json(article)
+    base_attributes(article).merge(
+      dismissed_at: article.dismissed_article&.dismissed_at,
+      permanent: article.dismissed_article&.permanent
+    )
+  end
+
+  def self.base_attributes(article)
+    BASE_ATTRIBUTES.index_with { |attribute| article.public_send(attribute) }
+  end
+  private_class_method :base_attributes
+end


### PR DESCRIPTION
## Summary
Extracts a shared `ArticleSerializer` used by all article list and detail JSON endpoints, removing duplicated `article_json` helpers.

Closes #143

## Test plan
- [x] Existing controller tests pass with unchanged API response shapes