### PR TITLE
fix: validate pagination parameters across list endpoints (#165)

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,11 +1,11 @@
 class ArticlesController < ApplicationController
+  include Pagination
+
   FETCH_RATE_LIMIT = 2.minutes
 
   def index
     @show_read = params[:show_read] == "true"
-    page = params[:page]&.to_i || 1
-    per_page = params[:per_page]&.to_i || 50
-    per_page = [ per_page, 100 ].min
+    page, per_page = pagination_params
 
     base_scope = article_index_scope
     @total_count = base_scope.count

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,8 +1,8 @@
 class BookmarksController < ApplicationController
+  include Pagination
+
   def index
-    page = params[:page]&.to_i || 1
-    per_page = params[:per_page]&.to_i || 50
-    per_page = [ per_page, 100 ].min
+    page, per_page = pagination_params
 
     @bookmarked_articles = Article.bookmarked
                                  .includes(:bookmark)

--- a/app/controllers/concerns/pagination.rb
+++ b/app/controllers/concerns/pagination.rb
@@ -1,0 +1,15 @@
+module Pagination
+  extend ActiveSupport::Concern
+
+  private
+
+  def pagination_params(default_per_page: 50, max_per_page: 100)
+    page = params[:page].presence&.to_i || 1
+    page = 1 if page < 1
+
+    per_page = params[:per_page].presence&.to_i || default_per_page
+    per_page = per_page.clamp(1, max_per_page)
+
+    [ page, per_page ]
+  end
+end

--- a/app/controllers/dismissed_articles_controller.rb
+++ b/app/controllers/dismissed_articles_controller.rb
@@ -1,8 +1,8 @@
 class DismissedArticlesController < ApplicationController
+  include Pagination
+
   def index
-    page = params[:page]&.to_i || 1
-    per_page = params[:per_page]&.to_i || 50
-    per_page = [ per_page, 100 ].min
+    page, per_page = pagination_params
 
     @dismissed_articles = Article.dismissed
                                 .includes(:dismissed_article)

--- a/app/controllers/read_articles_controller.rb
+++ b/app/controllers/read_articles_controller.rb
@@ -1,8 +1,8 @@
 class ReadArticlesController < ApplicationController
+  include Pagination
+
   def index
-    page = params[:page]&.to_i || 1
-    per_page = params[:per_page]&.to_i || 50
-    per_page = [ per_page, 100 ].min
+    page, per_page = pagination_params
 
     @read_articles = Article.read
                            .includes(:read_article)

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -270,6 +270,17 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
     assert json_response["pagination"]["per_page"] == 50
   end
 
+  test "index JSON should clamp invalid pagination params" do
+    get articles_url(page: 0, per_page: 0), as: :json
+
+    assert_response :success
+    json_response = JSON.parse(response.body)
+
+    assert_equal 1, json_response["pagination"]["current_page"]
+    assert_equal 1, json_response["pagination"]["per_page"]
+    assert json_response["pagination"]["total_pages"] >= 1
+  end
+
   test "index JSON avoids N+1 queries for article state" do
     @article.bookmark!
     @dev_to_article.mark_as_read!


### PR DESCRIPTION
## Summary
Extracts a shared `Pagination` concern that clamps `page` and `per_page` to safe minimums, preventing negative offsets and division-by-zero in pagination metadata.

Closes #165

## Test plan
- [x] Controller test covers `page=0` and `per_page=0` edge cases