### PR TITLE
fix: standardize JSON API error responses across controllers (#169)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,15 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+
+  private
+
+  def record_not_found
+    respond_to do |format|
+      format.html { redirect_back(fallback_location: articles_path, alert: "Article not found.") }
+      format.json { render json: { error: "Article not found" }, status: :not_found }
+    end
+  end
 end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -56,11 +56,6 @@ class ArticlesController < ApplicationController
       format.html
       format.json { render json: article_json(@article) }
     end
-  rescue ActiveRecord::RecordNotFound
-    respond_to do |format|
-      format.html { redirect_to articles_path, alert: "Article not found." }
-      format.json { render json: { error: "Article not found" }, status: :not_found }
-    end
   end
 
   def bookmark
@@ -71,8 +66,6 @@ class ArticlesController < ApplicationController
       format.html { redirect_back(fallback_location: articles_path) }
       format.json { render json: { bookmarked: @article.bookmarked? } }
     end
-  rescue ActiveRecord::RecordNotFound
-    redirect_to articles_path, alert: "Article not found."
   end
 
   def unbookmark
@@ -83,8 +76,6 @@ class ArticlesController < ApplicationController
       format.html { redirect_back(fallback_location: articles_path) }
       format.json { render json: { bookmarked: @article.bookmarked? } }
     end
-  rescue ActiveRecord::RecordNotFound
-    redirect_to articles_path, alert: "Article not found."
   end
 
   def dismiss
@@ -98,8 +89,6 @@ class ArticlesController < ApplicationController
       format.json { render json: { status: "dismissed", timeout: 15 } }
       format.html { redirect_back(fallback_location: articles_path) }
     end
-  rescue ActiveRecord::RecordNotFound
-    redirect_to articles_path, alert: "Article not found."
   end
 
   def undismiss
@@ -109,11 +98,6 @@ class ArticlesController < ApplicationController
     respond_to do |format|
       format.json { render json: { status: "restored" } }
       format.html { redirect_back(fallback_location: articles_path) }
-    end
-  rescue ActiveRecord::RecordNotFound
-    respond_to do |format|
-      format.html { redirect_to articles_path, alert: "Article not found." }
-      format.json { render json: { error: "Article not found" }, status: :not_found }
     end
   end
 

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -180,6 +180,14 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to articles_path
   end
 
+  test "should handle bookmark of non-existent article as JSON" do
+    post bookmark_article_path(id: 999999), as: :json
+
+    assert_response :not_found
+    json_response = JSON.parse(response.body)
+    assert_equal "Article not found", json_response["error"]
+  end
+
   test "should handle bookmark of non-existent article" do
     post bookmark_article_path(id: 999999)
 
@@ -212,8 +220,9 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
   test "should handle dismiss with missing article" do
     post dismiss_article_path(99999), headers: { "Accept" => "application/json" }
 
-    assert_redirected_to articles_path
-    assert_equal "Article not found.", flash[:alert]
+    assert_response :not_found
+    json_response = JSON.parse(response.body)
+    assert_equal "Article not found", json_response["error"]
   end
 
   test "should handle undismiss with missing article" do


### PR DESCRIPTION
## Summary
Adds a global `rescue_from ActiveRecord::RecordNotFound` handler so JSON clients receive consistent 404 responses instead of HTML redirects.

Closes #169

## Test plan
- [x] Bookmark and dismiss missing-article JSON requests return 404 with a consistent error shape