### PR TITLE
fix: news:clean rake task FK errors and retention mismatch (#152)

### DIFF
--- a/app/models/news_aggregator_config.rb
+++ b/app/models/news_aggregator_config.rb
@@ -1,0 +1,5 @@
+module NewsAggregatorConfig
+  def self.retention_days
+    Rails.application.config_for(:news_aggregator).dig(:retention, :article_retention_days) || 30
+  end
+end

--- a/lib/tasks/news.rake
+++ b/lib/tasks/news.rake
@@ -29,11 +29,13 @@ namespace :news do
     end
   end
 
-  desc "Clean old articles (older than 7 days)"
+  desc "Clean old articles past the configured retention period"
   task clean: :environment do
-    old_articles = Article.where("published_at < ?", 7.days.ago)
+    retention_days = NewsAggregatorConfig.retention_days
+    cutoff = retention_days.days.ago
+    old_articles = Article.where("published_at < ?", cutoff)
     count = old_articles.count
-    old_articles.delete_all
-    puts "Removed #{count} old articles"
+    old_articles.destroy_all
+    puts "Removed #{count} articles older than #{retention_days} days (before #{cutoff.to_date})"
   end
 end

--- a/test/tasks/news_rake_test.rb
+++ b/test/tasks/news_rake_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+require "rake"
+
+class NewsRakeTest < ActiveSupport::TestCase
+  def setup
+    Rails.application.load_tasks
+    @article = articles(:hacker_news_article)
+    @article.update!(published_at: 10.days.ago)
+    @article.bookmark!
+  end
+
+  test "news:clean removes old articles and dependent records" do
+    assert_difference "Article.count", -1 do
+      assert_difference "Bookmark.count", -1 do
+        capture_io do
+          Rake::Task["news:clean"].invoke
+        end
+      end
+    end
+  ensure
+    Rake::Task["news:clean"].reenable
+  end
+end


### PR DESCRIPTION
## Summary
Uses `destroy_all` so dependent bookmarks/read/dismissed records are removed safely, and reads retention days from `config/news_aggregator.yml` instead of a hardcoded 7-day cutoff.

Closes #152

## Test plan
- [x] Rake task test verifies cleanup succeeds for bookmarked articles past retention