### PR TITLE
test: add unit tests for news fetchers (#142)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,9 @@ group :test do
   # Time manipulation for tests
   gem "timecop"
 
+  # Stub HTTP requests in fetcher tests
+  gem "webmock"
+
   # Test coverage reporting
   gem "simplecov", require: false
   gem "simplecov-lcov", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,9 @@ GEM
     chronic (0.10.2)
     concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
+    crack (1.0.1)
+      bigdecimal
+      rexml
     crass (1.0.7)
     csv (3.3.5)
     date (3.5.1)
@@ -125,6 +128,7 @@ GEM
       raabro (~> 1.4)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    hashdiff (1.2.1)
     httparty (0.24.2)
       csv
       mini_mime (>= 1.0.0)
@@ -370,6 +374,10 @@ GEM
       actionview (>= 8.0.0)
       bindex (>= 0.4.0)
       railties (>= 8.0.0)
+    webmock (3.26.2)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket (1.2.11)
     websocket-driver (0.8.0)
       base64
@@ -413,6 +421,7 @@ DEPENDENCIES
   tzinfo-data
   vite_rails
   web-console
+  webmock
   whenever (~> 1.1)
 
 BUNDLED WITH

--- a/app/services/news_fetchers/dev_to_fetcher.rb
+++ b/app/services/news_fetchers/dev_to_fetcher.rb
@@ -1,5 +1,6 @@
 class NewsFetchers::DevToFetcher < NewsFetchers::BaseFetcher
   base_uri "https://dev.to/api"
+  format :json
 
   def fetch_articles
     Rails.logger.info "Fetching articles from Dev.to..."

--- a/app/services/news_fetchers/hacker_news_fetcher.rb
+++ b/app/services/news_fetchers/hacker_news_fetcher.rb
@@ -1,5 +1,6 @@
 class NewsFetchers::HackerNewsFetcher < NewsFetchers::BaseFetcher
   base_uri "https://hacker-news.firebaseio.com/v0"
+  format :json
 
   def fetch_articles
     Rails.logger.info "Fetching articles from Hacker News..."

--- a/app/services/news_fetchers/reddit_fetcher.rb
+++ b/app/services/news_fetchers/reddit_fetcher.rb
@@ -1,5 +1,6 @@
 class NewsFetchers::RedditFetcher < NewsFetchers::BaseFetcher
   base_uri "https://www.reddit.com"
+  format :json
   headers "User-Agent" => "DevNewsAggregator/1.0"
 
   def initialize(subreddit: "programming")

--- a/test/services/news_aggregator_service_test.rb
+++ b/test/services/news_aggregator_service_test.rb
@@ -79,15 +79,24 @@ class NewsAggregatorServiceTest < ActiveSupport::TestCase
     assert_includes result[:sources], "TestSuccessfulFetcher"
   end
 
-  test "class method fetch_all_news should work" do
-    # This will actually run the service but that's okay for integration testing
-    result = NewsAggregatorService.fetch_all_news
+  test "class method fetch_all_news should work without live API calls" do
+    mock_fetcher = Object.new
+    def mock_fetcher.fetch_articles; []; end
+    def mock_fetcher.class; OpenStruct.new(name: "MockFetcher"); end
 
-    assert_kind_of Hash, result
-    assert result.key?(:articles_count)
-    assert result.key?(:duration)
-    assert result.key?(:sources)
-    assert result.key?(:timestamp)
+    original = NewsAggregatorService.method(:build_fetchers)
+    NewsAggregatorService.define_singleton_method(:build_fetchers) { [ mock_fetcher ] }
+    begin
+      result = NewsAggregatorService.fetch_all_news
+
+      assert_kind_of Hash, result
+      assert result.key?(:articles_count)
+      assert result.key?(:duration)
+      assert result.key?(:sources)
+      assert result.key?(:timestamp)
+    ensure
+      NewsAggregatorService.define_singleton_method(:build_fetchers, original)
+    end
   end
 
   test "fetch_all_news should return proper structure" do

--- a/test/services/news_fetchers/dev_to_fetcher_test.rb
+++ b/test/services/news_fetchers/dev_to_fetcher_test.rb
@@ -1,0 +1,62 @@
+require "test_helper"
+
+class NewsFetchers::DevToFetcherTest < ActiveSupport::TestCase
+  def setup
+    @fetcher = NewsFetchers::DevToFetcher.new
+  end
+
+  test "fetch_articles creates articles from API response" do
+    payload = [
+      {
+        "id" => 101,
+        "title" => "Dev.to Post",
+        "url" => "https://dev.to/user/post",
+        "published_at" => "2024-01-15T12:00:00Z",
+        "description" => "Summary",
+        "positive_reactions_count" => 12,
+        "comments_count" => 4
+      }
+    ]
+
+    with_stubbed_get(NewsFetchers::DevToFetcher, lambda { |path, **_options|
+      path == "/articles" ? payload : nil
+    }) do
+      assert_difference "Article.count", 1 do
+        articles = @fetcher.fetch_articles
+        assert_equal 1, articles.length
+        assert_equal "Dev.to Post", articles.first.title
+        assert_equal "dev_to", articles.first.source_type
+        assert_equal 12, articles.first.score
+      end
+    end
+  end
+
+  test "fetch_articles returns empty array for invalid response" do
+    stub_request(:get, %r{https://dev\.to/api/articles})
+      .to_return(status: 200, body: { error: "bad" }.to_json, headers: { "Content-Type" => "application/json" })
+
+    assert_no_difference "Article.count" do
+      assert_empty @fetcher.fetch_articles
+    end
+  end
+
+  test "fetch_articles does not abort the run for malformed article payloads" do
+    with_stubbed_get(NewsFetchers::DevToFetcher, lambda { |path, **_options|
+      path == "/articles" ? [ { "id" => 202, "title" => nil, "url" => "https://dev.to/user/bad", "published_at" => "2024-01-15T12:00:00Z" } ] : nil
+    }) do
+      assert_nothing_raised do
+        assert_kind_of Array, @fetcher.fetch_articles
+      end
+    end
+  end
+
+  private
+
+  def with_stubbed_get(fetcher_class, implementation)
+    original = fetcher_class.method(:get)
+    fetcher_class.define_singleton_method(:get, implementation)
+    yield
+  ensure
+    fetcher_class.define_singleton_method(:get, original)
+  end
+end

--- a/test/services/news_fetchers/hacker_news_fetcher_test.rb
+++ b/test/services/news_fetchers/hacker_news_fetcher_test.rb
@@ -1,0 +1,73 @@
+require "test_helper"
+
+class NewsFetchers::HackerNewsFetcherTest < ActiveSupport::TestCase
+  def setup
+    @fetcher = NewsFetchers::HackerNewsFetcher.new
+  end
+
+  test "fetch_articles creates articles from story payloads" do
+    story = {
+      "id" => 88_001,
+      "type" => "story",
+      "title" => "HN Story",
+      "url" => "https://example.com/story",
+      "time" => 1_700_000_000,
+      "score" => 10,
+      "descendants" => 3
+    }
+
+    with_stubbed_get(NewsFetchers::HackerNewsFetcher, lambda { |path, **_options|
+      case path
+      when "/topstories.json" then [ 88_001 ]
+      when "/item/88001.json" then story
+      end
+    }) do
+      assert_difference "Article.count", 1 do
+        articles = @fetcher.fetch_articles
+        assert_equal 1, articles.length
+        assert_equal "HN Story", articles.first.title
+        assert_equal "hacker_news", articles.first.source_type
+      end
+    end
+  end
+
+  test "fetch_articles skips stories without URLs" do
+    stub_request(:get, "https://hacker-news.firebaseio.com/v0/topstories.json")
+      .to_return(status: 200, body: [ 99 ].to_json, headers: { "Content-Type" => "application/json" })
+
+    stub_request(:get, "https://hacker-news.firebaseio.com/v0/item/99.json")
+      .to_return(
+        status: 200,
+        body: {
+          id: 99,
+          type: "story",
+          title: "Ask HN: Question",
+          time: 1_700_000_000
+        }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+
+    assert_no_difference "Article.count" do
+      assert_empty @fetcher.fetch_articles
+    end
+  end
+
+  test "fetch_articles returns empty array when top stories request fails" do
+    stub_request(:get, "https://hacker-news.firebaseio.com/v0/topstories.json")
+      .to_return(status: 500, body: "error")
+
+    assert_no_difference "Article.count" do
+      assert_empty @fetcher.fetch_articles
+    end
+  end
+
+  private
+
+  def with_stubbed_get(fetcher_class, implementation)
+    original = fetcher_class.method(:get)
+    fetcher_class.define_singleton_method(:get, implementation)
+    yield
+  ensure
+    fetcher_class.define_singleton_method(:get, original)
+  end
+end

--- a/test/services/news_fetchers/reddit_fetcher_test.rb
+++ b/test/services/news_fetchers/reddit_fetcher_test.rb
@@ -1,0 +1,113 @@
+require "test_helper"
+
+class NewsFetchers::RedditFetcherTest < ActiveSupport::TestCase
+  def setup
+    @fetcher = NewsFetchers::RedditFetcher.new(subreddit: "programming")
+  end
+
+  test "fetch_articles creates articles from link posts" do
+    stub_request(:get, "https://www.reddit.com/r/programming.json")
+      .with(query: { limit: 25 })
+      .to_return(
+        status: 200,
+        body: {
+          data: {
+            children: [
+              {
+                data: {
+                  id: "abc123",
+                  title: "Reddit Link",
+                  url_overridden_by_dest: "https://example.com/article",
+                  created_utc: 1_700_000_000,
+                  selftext: "",
+                  is_self: false,
+                  score: 50,
+                  num_comments: 8
+                }
+              }
+            ]
+          }
+        }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+
+    assert_difference "Article.count", 1 do
+      articles = @fetcher.fetch_articles
+      assert_equal 1, articles.length
+      assert_equal "Reddit Link", articles.first.title
+      assert_equal "reddit_programming", articles.first.source_type
+    end
+  end
+
+  test "fetch_articles skips self posts without external URL" do
+    stub_request(:get, "https://www.reddit.com/r/programming.json")
+      .with(query: { limit: 25 })
+      .to_return(
+        status: 200,
+        body: {
+          data: {
+            children: [
+              {
+                data: {
+                  id: "self1",
+                  title: "Self post",
+                  is_self: true,
+                  permalink: "/r/programming/comments/self1/title/",
+                  created_utc: 1_700_000_000,
+                  score: 1,
+                  num_comments: 0
+                }
+              }
+            ]
+          }
+        }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+
+    assert_no_difference "Article.count" do
+      assert_empty @fetcher.fetch_articles
+    end
+  end
+
+  test "fetch_articles uses overridden URL for self posts with external link" do
+    stub_request(:get, "https://www.reddit.com/r/programming.json")
+      .with(query: { limit: 25 })
+      .to_return(
+        status: 200,
+        body: {
+          data: {
+            children: [
+              {
+                data: {
+                  id: "self2",
+                  title: "Self with link",
+                  is_self: true,
+                  url_overridden_by_dest: "https://example.com/linked",
+                  permalink: "/r/programming/comments/self2/title/",
+                  created_utc: 1_700_000_000,
+                  score: 2,
+                  num_comments: 1
+                }
+              }
+            ]
+          }
+        }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+
+    assert_difference "Article.count", 1 do
+      article = @fetcher.fetch_articles.first
+      assert_equal "https://example.com/linked", article.url
+    end
+  end
+
+  test "fetch_articles returns empty array when API response is invalid" do
+    stub_request(:get, "https://www.reddit.com/r/programming.json")
+      .with(query: { limit: 25 })
+      .to_return(status: 200, body: {}.to_json, headers: { "Content-Type" => "application/json" })
+
+    assert_no_difference "Article.count" do
+      assert_empty @fetcher.fetch_articles
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -34,6 +34,9 @@ require_relative "../config/environment"
 require "rails/test_help"
 require "timecop"
 require "ostruct"
+require "webmock/minitest"
+
+WebMock.disable_net_connect!(allow_localhost: true)
 
 module ActiveSupport
   class TestCase


### PR DESCRIPTION
## Summary
Adds WebMock-backed and stubbed unit tests for Hacker News, Dev.to, and Reddit fetchers. Mocks the aggregator service class method to avoid live API calls in CI.

Also adds `format :json` to fetcher HTTParty clients for consistent response parsing.

Closes #142

## Test plan
- [x] All fetcher tests pass without network access
- [x] Aggregator integration test no longer hits live APIs