### PR TITLE
feat(config): wire news_aggregator.yml into fetchers and service (#153)

### DIFF
--- a/app/models/news_aggregator_config.rb
+++ b/app/models/news_aggregator_config.rb
@@ -1,5 +1,47 @@
 module NewsAggregatorConfig
-  def self.retention_days
-    Rails.application.config_for(:news_aggregator).dig(:retention, :article_retention_days) || 30
+  class << self
+    def config
+      @config ||= Rails.application.config_for(:news_aggregator).deep_symbolize_keys
+    end
+
+    def reset!
+      @config = nil
+    end
+
+    def fetching
+      config.fetch(:fetching, {})
+    end
+
+    def retention_days
+      config.dig(:retention, :article_retention_days) || 30
+    end
+
+    def max_articles_per_source
+      fetching[:max_articles_per_source] || 30
+    end
+
+    def request_timeout
+      fetching[:request_timeout] || 30
+    end
+
+    def max_retries
+      fetching[:max_retries] || 3
+    end
+
+    def reddit_subreddits
+      Array(config.dig(:apis, :reddit, :subreddits))
+    end
+
+    def hacker_news_base_url
+      config.dig(:apis, :hacker_news, :base_url)
+    end
+
+    def devto_base_url
+      config.dig(:apis, :devto, :base_url)
+    end
+
+    def reddit_base_url
+      config.dig(:apis, :reddit, :base_url)
+    end
   end
 end

--- a/app/services/news_aggregator_service.rb
+++ b/app/services/news_aggregator_service.rb
@@ -17,21 +17,16 @@ class NewsAggregatorService
   end
 
   def self.default_fetchers
-    [
+    fetchers = [
       NewsFetchers::HackerNewsFetcher.new,
-      NewsFetchers::DevToFetcher.new,
-      NewsFetchers::RedditFetcher.new(subreddit: "programming"),
-      NewsFetchers::RedditFetcher.new(subreddit: "webdev"),
-      NewsFetchers::RedditFetcher.new(subreddit: "javascript"),
-      NewsFetchers::RedditFetcher.new(subreddit: "ruby"),
-      NewsFetchers::RedditFetcher.new(subreddit: "rust"),
-      NewsFetchers::RedditFetcher.new(subreddit: "netsec"),
-      NewsFetchers::RedditFetcher.new(subreddit: "cybersecurity"),
-      NewsFetchers::RedditFetcher.new(subreddit: "technology"),
-      NewsFetchers::RedditFetcher.new(subreddit: "MachineLearning"),
-      NewsFetchers::RedditFetcher.new(subreddit: "artificial"),
-      NewsFetchers::RedditFetcher.new(subreddit: "LocalLLaMA")
+      NewsFetchers::DevToFetcher.new
     ]
+
+    NewsAggregatorConfig.reddit_subreddits.each do |subreddit|
+      fetchers << NewsFetchers::RedditFetcher.new(subreddit: subreddit)
+    end
+
+    fetchers
   end
 
   def fetch_all_news

--- a/app/services/news_fetchers/dev_to_fetcher.rb
+++ b/app/services/news_fetchers/dev_to_fetcher.rb
@@ -6,7 +6,10 @@ class NewsFetchers::DevToFetcher < NewsFetchers::BaseFetcher
     Rails.logger.info "Fetching articles from Dev.to..."
 
     # Get latest articles
-    articles_data = self.class.get("/articles", query: { per_page: 30, top: 7 })
+    articles_data = self.class.get(
+      "/articles",
+      query: { per_page: NewsAggregatorConfig.max_articles_per_source, top: 7 }
+    )
     return [] unless articles_data.is_a?(Array)
 
     articles_data.each do |article_data|

--- a/app/services/news_fetchers/hacker_news_fetcher.rb
+++ b/app/services/news_fetchers/hacker_news_fetcher.rb
@@ -9,8 +9,7 @@ class NewsFetchers::HackerNewsFetcher < NewsFetchers::BaseFetcher
     top_story_ids = self.class.get("/topstories.json")
     return [] unless top_story_ids.is_a?(Array)
 
-    # Limit to first 30 stories to avoid rate limits
-    top_story_ids.first(30).each do |story_id|
+    top_story_ids.first(NewsAggregatorConfig.max_articles_per_source).each do |story_id|
       fetch_story(story_id)
     end
 

--- a/app/services/news_fetchers/reddit_fetcher.rb
+++ b/app/services/news_fetchers/reddit_fetcher.rb
@@ -12,7 +12,10 @@ class NewsFetchers::RedditFetcher < NewsFetchers::BaseFetcher
     Rails.logger.info "Fetching articles from Reddit r/#{@subreddit}..."
 
     # Get hot posts from subreddit
-    response = self.class.get("/r/#{@subreddit}.json", query: { limit: 25 })
+    response = self.class.get(
+      "/r/#{@subreddit}.json",
+      query: { limit: NewsAggregatorConfig.max_articles_per_source }
+    )
     return [] unless response.is_a?(Hash) && response["data"]
 
     posts_data = response.dig("data", "children")

--- a/config/news_aggregator.yml
+++ b/config/news_aggregator.yml
@@ -34,10 +34,16 @@ development: &default
       format: ".json"
       subreddits:
         - programming
-        - webdev  
+        - webdev
         - javascript
-        - reactjs
-        - nodejs
+        - ruby
+        - rust
+        - netsec
+        - cybersecurity
+        - technology
+        - MachineLearning
+        - artificial
+        - LocalLLaMA
 
 test:
   <<: *default

--- a/test/models/news_aggregator_config_test.rb
+++ b/test/models/news_aggregator_config_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class NewsAggregatorConfigTest < ActiveSupport::TestCase
+  test "loads fetching limits from news_aggregator.yml" do
+    assert_equal 5, NewsAggregatorConfig.max_articles_per_source
+    assert_equal 10, NewsAggregatorConfig.request_timeout
+    assert_equal 3, NewsAggregatorConfig.max_retries
+  end
+
+  test "loads retention days from news_aggregator.yml" do
+    assert_equal 7, NewsAggregatorConfig.retention_days
+  end
+
+  test "loads reddit subreddits from news_aggregator.yml" do
+    subreddits = NewsAggregatorConfig.reddit_subreddits
+
+    assert_includes subreddits, "programming"
+    assert_includes subreddits, "LocalLLaMA"
+    assert_operator subreddits.length, :>=, 10
+  end
+
+  test "loads API base URLs from news_aggregator.yml" do
+    assert_equal "https://hacker-news.firebaseio.com/v0", NewsAggregatorConfig.hacker_news_base_url
+    assert_equal "https://dev.to/api", NewsAggregatorConfig.devto_base_url
+    assert_equal "https://www.reddit.com/r", NewsAggregatorConfig.reddit_base_url
+  end
+end

--- a/test/services/news_aggregator_service_test.rb
+++ b/test/services/news_aggregator_service_test.rb
@@ -14,6 +14,17 @@ class NewsAggregatorServiceTest < ActiveSupport::TestCase
     assert fetchers.any? { |f| f.is_a?(NewsFetchers::RedditFetcher) }
   end
 
+  test "builds default fetchers from news aggregator config when database sources are absent" do
+    NewsSource.delete_all
+
+    fetchers = NewsAggregatorService.build_fetchers
+
+    assert fetchers.any? { |f| f.is_a?(NewsFetchers::HackerNewsFetcher) }
+    assert fetchers.any? { |f| f.is_a?(NewsFetchers::DevToFetcher) }
+    reddit_fetchers = fetchers.select { |f| f.is_a?(NewsFetchers::RedditFetcher) }
+    assert_equal NewsAggregatorConfig.reddit_subreddits.length, reddit_fetchers.length
+  end
+
   test "uses enabled database sources when present" do
     NewsSource.update_all(active: false)
     news_sources(:hacker_news).update!(active: true)

--- a/test/services/news_fetchers/reddit_fetcher_test.rb
+++ b/test/services/news_fetchers/reddit_fetcher_test.rb
@@ -7,7 +7,7 @@ class NewsFetchers::RedditFetcherTest < ActiveSupport::TestCase
 
   test "fetch_articles creates articles from link posts" do
     stub_request(:get, "https://www.reddit.com/r/programming.json")
-      .with(query: { limit: 25 })
+      .with(query: { limit: NewsAggregatorConfig.max_articles_per_source })
       .to_return(
         status: 200,
         body: {
@@ -41,7 +41,7 @@ class NewsFetchers::RedditFetcherTest < ActiveSupport::TestCase
 
   test "fetch_articles skips self posts without external URL" do
     stub_request(:get, "https://www.reddit.com/r/programming.json")
-      .with(query: { limit: 25 })
+      .with(query: { limit: NewsAggregatorConfig.max_articles_per_source })
       .to_return(
         status: 200,
         body: {
@@ -71,7 +71,7 @@ class NewsFetchers::RedditFetcherTest < ActiveSupport::TestCase
 
   test "fetch_articles uses overridden URL for self posts with external link" do
     stub_request(:get, "https://www.reddit.com/r/programming.json")
-      .with(query: { limit: 25 })
+      .with(query: { limit: NewsAggregatorConfig.max_articles_per_source })
       .to_return(
         status: 200,
         body: {
@@ -103,7 +103,7 @@ class NewsFetchers::RedditFetcherTest < ActiveSupport::TestCase
 
   test "fetch_articles returns empty array when API response is invalid" do
     stub_request(:get, "https://www.reddit.com/r/programming.json")
-      .with(query: { limit: 25 })
+      .with(query: { limit: NewsAggregatorConfig.max_articles_per_source })
       .to_return(status: 200, body: {}.to_json, headers: { "Content-Type" => "application/json" })
 
     assert_no_difference "Article.count" do


### PR DESCRIPTION
## Summary
- Expand `NewsAggregatorConfig` to load fetching limits, retention, API URLs, and Reddit subreddit lists from `config/news_aggregator.yml`
- Build default fetcher list from config instead of hardcoding 12 subreddits in `NewsAggregatorService`
- Use `max_articles_per_source` in Hacker News, Dev.to, and Reddit fetchers
- Align YAML subreddit list with current runtime defaults

## Test plan
- [x] `NewsAggregatorConfigTest` covers config loading
- [x] `NewsAggregatorServiceTest` verifies config-driven default fetchers
- [x] Fetcher tests pass with test env limit of 5

Closes #153