### PR TITLE
feat(jobs): run news aggregation as Solid Queue background job (#192)

### DIFF
--- a/app/jobs/fetch_news_job.rb
+++ b/app/jobs/fetch_news_job.rb
@@ -1,0 +1,7 @@
+class FetchNewsJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    NewsAggregatorService.fetch_all_news
+  end
+end

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -41,7 +41,7 @@ bin/dev
 ### News operations
 
 ```bash
-# Fetch news from all sources
+# Enqueue background job to fetch news from all sources (non-blocking)
 bin/rails news:fetch
 
 # Show latest 10 articles
@@ -50,7 +50,7 @@ bin/rails news:latest
 # Clean old articles (uses retention from config/news_aggregator.yml)
 bin/rails news:clean
 
-# Manual service call
+# Run fetch synchronously (e.g. debugging)
 bin/rails runner "NewsAggregatorService.fetch_all_news"
 ```
 
@@ -108,7 +108,7 @@ whenever --clear-crontab
 - `Bookmark`: Tracks bookmarked articles for personal reading list functionality
 - `NewsSource`: Optional database-backed source registry; when enabled records exist, they override the YAML default fetcher list
 
-**Scheduled jobs**: Uses `whenever` gem to run `news:fetch` hourly during business hours (9 AM - 6 PM) and `news:clean` daily at 2 AM. Logs to `log/cron.log`.
+**Scheduled jobs**: Uses `whenever` gem to run `news:fetch` hourly during business hours (9 AM - 6 PM) and `news:clean` daily at 2 AM. `news:fetch` enqueues `FetchNewsJob` so cron exits immediately; workers process the fetch asynchronously. Logs to `log/cron.log`.
 
 **Background jobs (Solid Queue)**: Active Job uses Solid Queue in development and production. `MakeDismissalPermanentJob` runs 15 seconds after an article is dismissed. In development, start the app with `SOLID_QUEUE_IN_PUMA=1 bin/rails server` (or run `bin/jobs` in a separate terminal). Production uses a dedicated queue database and `SOLID_QUEUE_IN_PUMA=true` in Kamal deploy config.
 

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -98,6 +98,7 @@ dev-news-aggregator/
 | File | Purpose |
 |------|---------|
 | `make_dismissal_permanent_job.rb` | Converts temporary dismissals to permanent |
+| `fetch_news_job.rb` | Fetches news from all sources asynchronously |
 
 ### Frontend
 

--- a/lib/tasks/news.rake
+++ b/lib/tasks/news.rake
@@ -1,15 +1,8 @@
 namespace :news do
-  desc "Fetch news from all sources"
+  desc "Enqueue background job to fetch news from all sources"
   task fetch: :environment do
-    puts "Starting news aggregation..."
-
-    result = NewsAggregatorService.fetch_all_news
-
-    puts "News aggregation completed!"
-    puts "Articles processed: #{result[:articles_count]}"
-    puts "Duration: #{result[:duration]}s"
-    puts "Sources: #{result[:sources].join(', ')}"
-    puts "Timestamp: #{result[:timestamp]}"
+    job = FetchNewsJob.perform_later
+    puts "Enqueued FetchNewsJob (job_id: #{job.job_id})"
   end
 
   desc "Show latest articles"

--- a/test/jobs/fetch_news_job_test.rb
+++ b/test/jobs/fetch_news_job_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class FetchNewsJobTest < ActiveJob::TestCase
+  test "perform delegates to NewsAggregatorService.fetch_all_news" do
+    expected = {
+      articles_count: 2,
+      duration: 1.2,
+      sources: [ "MockFetcher" ],
+      timestamp: Time.current
+    }
+
+    original = NewsAggregatorService.method(:fetch_all_news)
+    NewsAggregatorService.define_singleton_method(:fetch_all_news) { expected }
+    begin
+      result = FetchNewsJob.perform_now
+      assert_equal expected, result
+    ensure
+      NewsAggregatorService.define_singleton_method(:fetch_all_news, original)
+    end
+  end
+end

--- a/test/tasks/news_rake_test.rb
+++ b/test/tasks/news_rake_test.rb
@@ -1,12 +1,24 @@
 require "test_helper"
 require "rake"
+require "active_job/test_helper"
 
 class NewsRakeTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
   def setup
     Rails.application.load_tasks
     @article = articles(:hacker_news_article)
     @article.update!(published_at: 10.days.ago)
     @article.bookmark!
+  end
+
+  test "news:fetch enqueues FetchNewsJob instead of fetching synchronously" do
+    assert_enqueued_with(job: FetchNewsJob) do
+      capture_io do
+        Rake::Task["news:fetch"].invoke
+      end
+    end
+  ensure
+    Rake::Task["news:fetch"].reenable
   end
 
   test "news:clean removes old articles and dependent records" do


### PR DESCRIPTION
## Summary
- Add `FetchNewsJob` that delegates to `NewsAggregatorService.fetch_all_news`
- Change `news:fetch` rake task to enqueue the job and return immediately
- Web UI fetch (`POST /articles/fetch`) remains synchronous for instant feedback
- Document async cron behavior and synchronous runner alternative

Closes #192

## Test plan
- [x] `FetchNewsJobTest` verifies service delegation
- [x] `NewsRakeTest` verifies `news:fetch` enqueues job without blocking