### PR TITLE
perf(fetchers): add HTTP timeouts, retries, and parallel fetching (#168)

### DIFF
--- a/app/services/news_aggregator_service.rb
+++ b/app/services/news_aggregator_service.rb
@@ -32,17 +32,28 @@ class NewsAggregatorService
   def fetch_all_news
     Rails.logger.info "Starting news aggregation from all sources..."
     start_time = Time.current
+    mutex = Mutex.new
 
-    @fetchers.each do |fetcher|
-      begin
-        articles = fetcher.fetch_articles
-        @all_articles.concat(articles)
-        Rails.logger.info "#{fetcher.class.name}: fetched #{articles.count} articles"
+    threads = @fetchers.map do |fetcher|
+      Thread.new do
+        Rails.application.executor.wrap do
+          ActiveRecord::Base.connection_pool.with_connection do
+            articles = fetcher.fetch_articles
+            mutex.synchronize do
+              @all_articles.concat(articles)
+              Rails.logger.info "#{fetcher.class.name}: fetched #{articles.count} articles"
+            end
+          end
+        end
       rescue StandardError => e
-        Rails.logger.error "Error with #{fetcher.class.name}: #{e.message}"
-        Rails.logger.error e.backtrace.join("\n")
+        mutex.synchronize do
+          Rails.logger.error "Error with #{fetcher.class.name}: #{e.message}"
+          Rails.logger.error e.backtrace.join("\n")
+        end
       end
     end
+
+    threads.each(&:join)
 
     end_time = Time.current
     duration = (end_time - start_time).round(2)

--- a/app/services/news_fetchers/base_fetcher.rb
+++ b/app/services/news_fetchers/base_fetcher.rb
@@ -1,9 +1,30 @@
 class NewsFetchers::BaseFetcher
   include HTTParty
 
+  RETRYABLE_ERRORS = [
+    Net::OpenTimeout,
+    Net::ReadTimeout,
+    Errno::ECONNRESET,
+    Errno::ETIMEDOUT,
+    SocketError
+  ].freeze
+
   class << self
     def get(*args, **kwargs)
-      parse_http_response(super)
+      kwargs[:timeout] = NewsAggregatorConfig.request_timeout unless kwargs.key?(:timeout)
+
+      attempt = 0
+      max_attempts = NewsAggregatorConfig.max_retries + 1
+
+      begin
+        parse_http_response(super(*args, **kwargs))
+      rescue *RETRYABLE_ERRORS
+        attempt += 1
+        raise if attempt >= max_attempts
+
+        sleep(2**(attempt - 1))
+        retry
+      end
     end
 
     private

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -116,7 +116,7 @@ whenever --clear-crontab
 
 **Service-oriented architecture**: Business logic separated into service classes rather than fat models. Each news source has its own fetcher service.
 
-**Fail-safe aggregation**: If one news source fails, others continue processing. Errors are logged but don't stop the entire aggregation process.
+**Fail-safe aggregation**: If one news source fails, others continue processing. Errors are logged but don't stop the entire aggregation process. Sources run in parallel threads; each fetcher uses configured HTTP timeouts and retries with exponential backoff.
 
 **Idempotent updates**: Articles use `find_or_initialize_by(external_id, source_type)` to prevent duplicates while allowing updates to existing articles.
 

--- a/test/services/news_aggregator_service_test.rb
+++ b/test/services/news_aggregator_service_test.rb
@@ -110,6 +110,30 @@ class NewsAggregatorServiceTest < ActiveSupport::TestCase
     end
   end
 
+  test "fetch_all_news runs fetchers concurrently" do
+    slow_fetcher = Object.new
+    slow_fetcher.define_singleton_method(:fetch_articles) do
+      sleep 0.3
+      [ Article.new(title: "Slow", source_type: "slow") ]
+    end
+    slow_fetcher.define_singleton_method(:class) { OpenStruct.new(name: "SlowFetcher") }
+
+    second_slow_fetcher = Object.new
+    second_slow_fetcher.define_singleton_method(:fetch_articles) do
+      sleep 0.3
+      [ Article.new(title: "Slow2", source_type: "slow2") ]
+    end
+    second_slow_fetcher.define_singleton_method(:class) { OpenStruct.new(name: "SlowFetcherTwo") }
+
+    @service.instance_variable_set(:@fetchers, [ slow_fetcher, second_slow_fetcher ])
+
+    start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    @service.fetch_all_news
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+
+    assert_operator elapsed, :<, 0.5, "expected parallel fetch (~0.3s), took #{elapsed.round(2)}s"
+  end
+
   test "fetch_all_news should return proper structure" do
     # Mock fetchers to avoid actual API calls in this specific test
     mock_fetcher = Object.new

--- a/test/services/news_fetchers/base_fetcher_test.rb
+++ b/test/services/news_fetchers/base_fetcher_test.rb
@@ -86,6 +86,34 @@ class NewsFetchers::BaseFetcherTest < ActiveSupport::TestCase
     assert_nil result
   end
 
+  test "get retries transient network errors with backoff before succeeding" do
+    attempts = 0
+    stub_request(:get, "https://hacker-news.firebaseio.com/v0/topstories.json")
+      .to_return do
+        attempts += 1
+        raise Net::ReadTimeout if attempts < 3
+
+        { status: 200, body: [ 1, 2, 3 ].to_json, headers: { "Content-Type" => "application/json" } }
+      end
+
+    with_stubbed_sleep do
+      result = NewsFetchers::HackerNewsFetcher.get("/topstories.json")
+      assert_equal [ 1, 2, 3 ], result
+      assert_equal 3, attempts
+    end
+  end
+
+  test "get raises after exhausting configured retries" do
+    stub_request(:get, "https://hacker-news.firebaseio.com/v0/topstories.json")
+      .to_raise(Net::ReadTimeout)
+
+    with_stubbed_sleep do
+      assert_raises Net::ReadTimeout do
+        NewsFetchers::HackerNewsFetcher.get("/topstories.json")
+      end
+    end
+  end
+
   test "should skip invalid article attributes" do
     attributes = {
       title: nil,
@@ -121,5 +149,15 @@ class NewsFetchers::BaseFetcherTest < ActiveSupport::TestCase
 
     assert_equal article.id, updated_article.id
     assert_equal article.updated_at.to_i, updated_article.updated_at.to_i
+  end
+
+  private
+
+  def with_stubbed_sleep
+    original = Kernel.method(:sleep)
+    Kernel.define_singleton_method(:sleep) { |_duration = nil| }
+    yield
+  ensure
+    Kernel.define_singleton_method(:sleep, original)
   end
 end


### PR DESCRIPTION
## Summary
- Wire `request_timeout` and `max_retries` from `NewsAggregatorConfig` into `BaseFetcher.get`
- Retry transient network errors with exponential backoff (1s, 2s, 4s, ...)
- Run fetchers in parallel threads with connection pool isolation in `NewsAggregatorService`

Closes #168

## Test plan
- [x] Retry and exhaustion tests via WebMock
- [x] Parallel fetch timing test (~0.3s vs ~0.6s sequential)
- [x] All fetcher and aggregator tests pass