### PR TITLE
feat(observability): add structured logging and FetchRun records (#191)

### DIFF
--- a/app/models/fetch_run.rb
+++ b/app/models/fetch_run.rb
@@ -1,0 +1,31 @@
+class FetchRun < ApplicationRecord
+  STATUSES = %w[success failure].freeze
+
+  validates :source_key, presence: true, uniqueness: true
+  validates :status, inclusion: { in: STATUSES }
+  validates :articles_count, numericality: { greater_than_or_equal_to: 0 }
+  validates :finished_at, presence: true
+
+  scope :failed, -> { where(status: "failure") }
+  scope :successful, -> { where(status: "success") }
+  scope :recent, -> { order(finished_at: :desc) }
+
+  def failure?
+    status == "failure"
+  end
+
+  def self.record_outcome(source_key:, status:, articles_count: 0, duration_seconds: nil, error: nil)
+    run = find_or_initialize_by(source_key: source_key)
+    run.assign_attributes(
+      status: status,
+      articles_count: articles_count,
+      duration_seconds: duration_seconds,
+      error_class: error&.class&.name,
+      error_message: error&.message,
+      finished_at: Time.current
+    )
+    run.save!
+    NewsFetchObservability.log_source_outcome(run)
+    run
+  end
+end

--- a/app/services/news_aggregator_service.rb
+++ b/app/services/news_aggregator_service.rb
@@ -30,41 +30,72 @@ class NewsAggregatorService
   end
 
   def fetch_all_news
-    Rails.logger.info "Starting news aggregation from all sources..."
-    start_time = Time.current
+    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     mutex = Mutex.new
 
     threads = @fetchers.map do |fetcher|
       Thread.new do
         Rails.application.executor.wrap do
           ActiveRecord::Base.connection_pool.with_connection do
-            articles = fetcher.fetch_articles
-            mutex.synchronize do
-              @all_articles.concat(articles)
-              Rails.logger.info "#{fetcher.class.name}: fetched #{articles.count} articles"
-            end
+            articles = run_fetcher(fetcher)
+            mutex.synchronize { @all_articles.concat(articles) }
           end
-        end
-      rescue StandardError => e
-        mutex.synchronize do
-          Rails.logger.error "Error with #{fetcher.class.name}: #{e.message}"
-          Rails.logger.error e.backtrace.join("\n")
         end
       end
     end
 
     threads.each(&:join)
 
-    end_time = Time.current
-    duration = (end_time - start_time).round(2)
+    duration = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time).round(2)
+    finished_at = Time.current
 
-    Rails.logger.info "News aggregation completed in #{duration}s. Total articles processed: #{@all_articles.count}"
+    NewsFetchObservability.log_aggregation_completed(
+      articles_count: @all_articles.count,
+      duration_seconds: duration,
+      source_count: @fetchers.length
+    )
 
     {
       articles_count: @all_articles.count,
       duration: duration,
       sources: @fetchers.map { |f| f.class.name.demodulize },
-      timestamp: end_time
+      timestamp: finished_at
     }
+  end
+
+  private
+
+  def run_fetcher(fetcher)
+    source_key = fetcher_source_key(fetcher)
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    articles = fetcher.fetch_articles
+    duration = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - started).round(2)
+
+    FetchRun.record_outcome(
+      source_key: source_key,
+      status: "success",
+      articles_count: articles.count,
+      duration_seconds: duration
+    )
+
+    articles
+  rescue StandardError => e
+    duration = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - started).round(2)
+
+    FetchRun.record_outcome(
+      source_key: source_key,
+      status: "failure",
+      duration_seconds: duration,
+      error: e
+    )
+
+    Rails.logger.error e.backtrace.join("\n")
+    []
+  end
+
+  def fetcher_source_key(fetcher)
+    return fetcher.source_key if fetcher.respond_to?(:source_key)
+
+    fetcher.class.name.demodulize.underscore
   end
 end

--- a/app/services/news_fetch_observability.rb
+++ b/app/services/news_fetch_observability.rb
@@ -1,0 +1,32 @@
+module NewsFetchObservability
+  module_function
+
+  def log_source_outcome(run)
+    payload = {
+      event: "news_fetch.source_completed",
+      source: run.source_key,
+      status: run.status,
+      articles_count: run.articles_count,
+      duration_seconds: run.duration_seconds,
+      finished_at: run.finished_at.iso8601
+    }
+    payload[:error_class] = run.error_class if run.error_class.present?
+    payload[:error_message] = run.error_message if run.error_message.present?
+
+    if run.failure?
+      Rails.logger.error(payload.to_json)
+    else
+      Rails.logger.info(payload.to_json)
+    end
+  end
+
+  def log_aggregation_completed(articles_count:, duration_seconds:, source_count:)
+    Rails.logger.info({
+      event: "news_fetch.completed",
+      articles_count: articles_count,
+      duration_seconds: duration_seconds,
+      source_count: source_count,
+      finished_at: Time.current.iso8601
+    }.to_json)
+  end
+end

--- a/app/services/news_fetchers/base_fetcher.rb
+++ b/app/services/news_fetchers/base_fetcher.rb
@@ -42,6 +42,10 @@ class NewsFetchers::BaseFetcher
     @articles = []
   end
 
+  def source_key
+    self.class.name.demodulize.delete_suffix("Fetcher").underscore
+  end
+
   def fetch_articles
     raise NotImplementedError, "Subclasses must implement fetch_articles method"
   end

--- a/app/services/news_fetchers/reddit_fetcher.rb
+++ b/app/services/news_fetchers/reddit_fetcher.rb
@@ -8,6 +8,10 @@ class NewsFetchers::RedditFetcher < NewsFetchers::BaseFetcher
     @subreddit = subreddit
   end
 
+  def source_key
+    "reddit_#{@subreddit}"
+  end
+
   def fetch_articles
     Rails.logger.info "Fetching articles from Reddit r/#{@subreddit}..."
 

--- a/db/migrate/20260703160000_create_fetch_runs.rb
+++ b/db/migrate/20260703160000_create_fetch_runs.rb
@@ -1,0 +1,19 @@
+class CreateFetchRuns < ActiveRecord::Migration[8.1]
+  def change
+    create_table :fetch_runs do |t|
+      t.string :source_key, null: false
+      t.string :status, null: false
+      t.integer :articles_count, null: false, default: 0
+      t.decimal :duration_seconds, precision: 8, scale: 2
+      t.string :error_class
+      t.text :error_message
+      t.datetime :finished_at, null: false
+
+      t.timestamps
+    end
+
+    add_index :fetch_runs, :source_key, unique: true
+    add_index :fetch_runs, :status
+    add_index :fetch_runs, :finished_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_03_150200) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_03_160000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -47,6 +47,21 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_03_150200) do
     t.index ["article_id"], name: "index_dismissed_articles_on_article_id"
     t.index ["dismissed_at"], name: "index_dismissed_articles_on_dismissed_at"
     t.index ["permanent"], name: "index_dismissed_articles_on_permanent"
+  end
+
+  create_table "fetch_runs", force: :cascade do |t|
+    t.integer "articles_count", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.decimal "duration_seconds", precision: 8, scale: 2
+    t.string "error_class"
+    t.text "error_message"
+    t.datetime "finished_at", null: false
+    t.string "source_key", null: false
+    t.string "status", null: false
+    t.datetime "updated_at", null: false
+    t.index ["finished_at"], name: "index_fetch_runs_on_finished_at"
+    t.index ["source_key"], name: "index_fetch_runs_on_source_key", unique: true
+    t.index ["status"], name: "index_fetch_runs_on_status"
   end
 
   create_table "news_sources", force: :cascade do |t|

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -44,6 +44,9 @@ bin/dev
 # Enqueue background job to fetch news from all sources (non-blocking)
 bin/rails news:fetch
 
+# Show last fetch outcome per source
+bin/rails news:fetch_status
+
 # Show latest 10 articles
 bin/rails news:latest
 

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -82,11 +82,13 @@ dev-news-aggregator/
 | `dismissed_article.rb` | `dismissed_articles` | Article hidden from feed |
 | `news_source.rb` | `news_sources` | Optional DB-backed source registry; overrides YAML defaults when enabled |
 | `news_aggregator_config.rb` | — | Loads `config/news_aggregator.yml` (limits, retention, subreddits) |
+| `fetch_run.rb` | `fetch_runs` | Latest per-source news fetch outcome (status, duration, errors) |
 
 ### Services
 
 | File | Purpose |
 |------|---------|
+| `news_fetch_observability.rb` | Structured JSON logging for fetch outcomes |
 | `news_aggregator_service.rb` | Runs all fetchers, handles errors, aggregates results |
 | `news_fetchers/base_fetcher.rb` | Abstract fetcher — fetch, transform, upsert article |
 | `news_fetchers/hacker_news_fetcher.rb` | Hacker News Firebase API |
@@ -141,12 +143,13 @@ dev-news-aggregator/
 | `create_bookmarks` | `bookmarks` |
 | `create_read_articles` | `read_articles` |
 | `create_dismissed_articles` | `dismissed_articles` |
+| `create_fetch_runs` | `fetch_runs` |
 
 ## `lib/`
 
 | Path | Purpose |
 |------|---------|
-| `lib/tasks/news.rake` | `news:fetch`, `news:latest`, `news:clean` rake tasks |
+| `lib/tasks/news.rake` | `news:fetch`, `news:fetch_status`, `news:latest`, `news:clean` rake tasks |
 
 ## `test/`
 

--- a/lib/tasks/news.rake
+++ b/lib/tasks/news.rake
@@ -5,6 +5,26 @@ namespace :news do
     puts "Enqueued FetchNewsJob (job_id: #{job.job_id})"
   end
 
+  desc "Show last fetch outcome per source"
+  task fetch_status: :environment do
+    runs = FetchRun.order(:source_key)
+
+    if runs.none?
+      puts "No fetch runs recorded yet. Run 'rake news:fetch' first."
+    else
+      runs.each do |run|
+        line = "#{run.source_key}: #{run.status} (#{run.articles_count} articles"
+        line += ", #{run.duration_seconds}s" if run.duration_seconds
+        line += ") at #{run.finished_at}"
+        puts line
+        puts "  #{run.error_class}: #{run.error_message}" if run.failure?
+      end
+
+      failed = FetchRun.failed.count
+      puts "\n#{failed} source(s) failed on last fetch." if failed.positive?
+    end
+  end
+
   desc "Show latest articles"
   task latest: :environment do
     articles = Article.order(published_at: :desc).limit(10)

--- a/test/models/fetch_run_test.rb
+++ b/test/models/fetch_run_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class FetchRunTest < ActiveSupport::TestCase
+  test "record_outcome upserts latest success per source" do
+    FetchRun.record_outcome(
+      source_key: "hacker_news",
+      status: "success",
+      articles_count: 5,
+      duration_seconds: 1.2
+    )
+
+    assert_difference "FetchRun.count", 0 do
+      run = FetchRun.record_outcome(
+        source_key: "hacker_news",
+        status: "success",
+        articles_count: 8,
+        duration_seconds: 0.9
+      )
+
+      assert_equal 8, run.articles_count
+      assert_equal "success", run.status
+    end
+  end
+
+  test "record_outcome stores failure details" do
+    error = StandardError.new("API down")
+    run = FetchRun.record_outcome(
+      source_key: "dev_to",
+      status: "failure",
+      duration_seconds: 2.5,
+      error: error
+    )
+
+    assert run.failure?
+    assert_equal "StandardError", run.error_class
+    assert_equal "API down", run.error_message
+  end
+
+  test "failed scope returns only failed sources" do
+    FetchRun.record_outcome(source_key: "hacker_news", status: "success", articles_count: 1)
+    FetchRun.record_outcome(
+      source_key: "reddit_rust",
+      status: "failure",
+      error: StandardError.new("timeout")
+    )
+
+    assert_equal [ "reddit_rust" ], FetchRun.failed.pluck(:source_key)
+  end
+end

--- a/test/services/news_aggregator_service_test.rb
+++ b/test/services/news_aggregator_service_test.rb
@@ -49,6 +49,9 @@ class NewsAggregatorServiceTest < ActiveSupport::TestCase
     def failing_fetcher.fetch_articles
       raise StandardError, "API is down"
     end
+    def failing_fetcher.source_key
+      "test_failing_fetcher"
+    end
 
     def failing_fetcher.class
       @class ||= Class.new do
@@ -62,6 +65,9 @@ class NewsAggregatorServiceTest < ActiveSupport::TestCase
     successful_fetcher = Object.new
     def successful_fetcher.fetch_articles
       [ Article.new(title: "Test", source_type: "test") ]
+    end
+    def successful_fetcher.source_key
+      "test_successful_fetcher"
     end
 
     def successful_fetcher.class
@@ -88,6 +94,9 @@ class NewsAggregatorServiceTest < ActiveSupport::TestCase
 
     assert_equal 1, result[:articles_count]
     assert_includes result[:sources], "TestSuccessfulFetcher"
+
+    assert_equal "success", FetchRun.find_by(source_key: "test_successful_fetcher").status
+    assert_equal "failure", FetchRun.find_by(source_key: "test_failing_fetcher").status
   end
 
   test "class method fetch_all_news should work without live API calls" do

--- a/test/services/news_fetch_observability_test.rb
+++ b/test/services/news_fetch_observability_test.rb
@@ -1,0 +1,55 @@
+require "test_helper"
+
+class NewsFetchObservabilityTest < ActiveSupport::TestCase
+  test "log_source_outcome emits structured json for success" do
+    run = FetchRun.create!(
+      source_key: "hacker_news",
+      status: "success",
+      articles_count: 3,
+      duration_seconds: 1.1,
+      finished_at: Time.current
+    )
+
+    io = StringIO.new
+    with_logger(io) do
+      NewsFetchObservability.log_source_outcome(run)
+    end
+
+    payload = JSON.parse(io.string.lines.last)
+    assert_equal "news_fetch.source_completed", payload["event"]
+    assert_equal "hacker_news", payload["source"]
+    assert_equal "success", payload["status"]
+    assert_equal 3, payload["articles_count"]
+  end
+
+  test "log_source_outcome emits structured json for failure" do
+    run = FetchRun.create!(
+      source_key: "dev_to",
+      status: "failure",
+      articles_count: 0,
+      duration_seconds: 0.5,
+      error_class: "Net::ReadTimeout",
+      error_message: "execution expired",
+      finished_at: Time.current
+    )
+
+    io = StringIO.new
+    with_logger(io) do
+      NewsFetchObservability.log_source_outcome(run)
+    end
+
+    payload = JSON.parse(io.string.lines.last)
+    assert_equal "failure", payload["status"]
+    assert_equal "Net::ReadTimeout", payload["error_class"]
+  end
+
+  private
+
+  def with_logger(io)
+    original = Rails.logger
+    Rails.logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(io))
+    yield
+  ensure
+    Rails.logger = original
+  end
+end

--- a/test/tasks/news_rake_test.rb
+++ b/test/tasks/news_rake_test.rb
@@ -11,6 +11,23 @@ class NewsRakeTest < ActiveSupport::TestCase
     @article.bookmark!
   end
 
+  test "news:fetch_status reports recorded fetch outcomes" do
+    FetchRun.record_outcome(
+      source_key: "hacker_news",
+      status: "success",
+      articles_count: 2,
+      duration_seconds: 1.0
+    )
+
+    output = capture_io do
+      Rake::Task["news:fetch_status"].invoke
+    end
+
+    assert_match(/hacker_news: success \(2 articles/, output.join)
+  ensure
+    Rake::Task["news:fetch_status"].reenable
+  end
+
   test "news:fetch enqueues FetchNewsJob instead of fetching synchronously" do
     assert_enqueued_with(job: FetchNewsJob) do
       capture_io do


### PR DESCRIPTION
## Summary
- Add `FetchRun` model to persist latest outcome per source (status, count, duration, errors)
- Add `NewsFetchObservability` for structured JSON log events
- Record outcomes from `NewsAggregatorService` on success and failure
- Add `news:fetch_status` rake task to inspect failures without grepping logs
- Add `source_key` to fetchers for consistent source identification

Closes #191

## Test plan
- [x] `FetchRunTest` covers upsert, failure details, and scopes
- [x] `NewsAggregatorServiceTest` verifies outcome recording
- [x] Full suite passes (193 tests)