### PR TITLE
chore: implement NewsSource registry wired to YAML config (#145)

### DIFF
--- a/app/models/news_source.rb
+++ b/app/models/news_source.rb
@@ -1,11 +1,7 @@
+# Database-backed source registry. When any enabled records exist,
+# NewsAggregatorService uses them instead of config/news_aggregator.yml defaults.
 class NewsSource < ApplicationRecord
   SOURCE_TYPES = %w[hacker_news dev_to reddit].freeze
-
-  REDDIT_SUBREDDITS = %w[
-    programming webdev javascript ruby rust
-    netsec cybersecurity technology
-    MachineLearning artificial LocalLLaMA
-  ].freeze
 
   validates :name, presence: true, uniqueness: { scope: :source_type }
   validates :source_type, inclusion: { in: SOURCE_TYPES }
@@ -24,7 +20,7 @@ class NewsSource < ApplicationRecord
       source.config = {}
     end
 
-    REDDIT_SUBREDDITS.each do |subreddit|
+    NewsAggregatorConfig.reddit_subreddits.each do |subreddit|
       find_or_create_by!(source_type: "reddit", name: subreddit) do |source|
         source.active = true
         source.config = { "subreddit" => subreddit }

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -109,7 +109,7 @@ whenever --clear-crontab
 **Data models**:
 - `Article`: Stores aggregated news with unified schema (title, url, published_at, description, external_id, source_type, score, comment_count)
 - `Bookmark`: Tracks bookmarked articles for personal reading list functionality
-- `NewsSource`: Optional database-backed source registry; when enabled records exist, they override the YAML default fetcher list
+- `NewsSource`: Database-backed source registry with admin UI at `/sources`. `bootstrap_defaults!` seeds Hacker News, Dev.to, and Reddit subreddits from `config/news_aggregator.yml`. When any enabled records exist, they override the YAML default fetcher list
 
 **Scheduled jobs**: Uses `whenever` gem to run `news:fetch` hourly during business hours (9 AM - 6 PM) and `news:clean` daily at 2 AM. `news:fetch` enqueues `FetchNewsJob` so cron exits immediately; workers process the fetch asynchronously. Logs to `log/cron.log`.
 
@@ -130,9 +130,11 @@ whenever --clear-crontab
 ```
 app/
   controllers/articles_controller.rb    # Main web interface
+  controllers/sources_controller.rb     # Enable/disable sources, add Reddit subreddits
   models/
     article.rb                          # Article data model
     news_aggregator_config.rb           # YAML config loader for news fetching
+    news_source.rb                      # Database-backed source registry
   services/
     news_aggregator_service.rb          # Main orchestrator
     news_fetchers/

--- a/test/models/news_source_test.rb
+++ b/test/models/news_source_test.rb
@@ -30,6 +30,7 @@ class NewsSourceTest < ActiveSupport::TestCase
 
     assert NewsSource.exists?(source_type: "hacker_news")
     assert NewsSource.exists?(source_type: "dev_to")
-    assert_operator NewsSource.where(source_type: "reddit").count, :>, 1
+    assert_equal NewsAggregatorConfig.reddit_subreddits.length,
+                 NewsSource.where(source_type: "reddit").count
   end
 end


### PR DESCRIPTION
## Summary
- **Decision: implement** (not remove). NewsSource is already integrated: admin UI at /sources, SourcesController, seeds, and NewsAggregatorService prefers enabled DB records over YAML defaults.
- Remove duplicated hardcoded REDDIT_SUBREDDITS constant; bootstrap_defaults! now reads subreddits from NewsAggregatorConfig (config/news_aggregator.yml).
- Update DEVELOPMENT.md to reflect implemented status.

Closes #145

## Test plan
- [x] bin/rails test test/models/news_source_test.rb test/services/news_aggregator_service_test.rb test/controllers/sources_controller_test.rb
- [ ] CI green