### PR TITLE
refactor: consolidate duplicate article card components (#174)

### DIFF
--- a/app/frontend/components/ArticleCard.tsx
+++ b/app/frontend/components/ArticleCard.tsx
@@ -1,9 +1,5 @@
 import type { Article } from '../types/article'
-import {
-  formatPublishedDate,
-  humanizeSourceType,
-  truncate,
-} from '../utils/format'
+import ArticleCardBase from './ArticleCardBase'
 
 interface ArticleCardProps {
   article: Article
@@ -27,82 +23,42 @@ export default function ArticleCard({
   onReadToggle,
 }: ArticleCardProps) {
   return (
-    <article
-      className="article-card group glass-effect rounded-2xl p-6 transition-all duration-300 hover:scale-[1.02] hover:shadow-2xl hover:shadow-primary-500/10 animate-fade-in"
-      data-source={article.source_type}
-      data-category={categorySlug}
-      style={{
-        animationDelay: `${index * 50}ms`,
+    <ArticleCardBase
+      article={article}
+      index={index}
+      categorySlug={categorySlug}
+      onArticleClick={isDismissing ? () => onUndoDismiss?.(article) : undefined}
+      articleStyle={{
         opacity: isDismissing ? 0.5 : 1,
         cursor: isDismissing ? 'pointer' : undefined,
       }}
-      onClick={isDismissing ? () => onUndoDismiss?.(article) : undefined}
-    >
-      <div className="flex justify-between items-start mb-4">
-        <div className="flex-1">
-          <h2 className="text-xl font-bold text-gray-100 mb-2 leading-tight group-hover:text-primary-300 transition-colors duration-200">
-            <a
-              href={article.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="hover:text-primary-400 transition-colors duration-200 flex items-start group/link"
-            >
-              <span className="flex-1">{article.title}</span>
-              <svg className="w-4 h-4 ml-2 mt-1 opacity-60 group-hover/link:opacity-100 transition-all duration-200 group-hover/link:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-              </svg>
-            </a>
-          </h2>
-        </div>
-        <div className="ml-4 flex items-center space-x-2">
-          <span className="inline-block px-3 py-1.5 text-xs font-semibold bg-gradient-to-r from-primary-600/20 to-primary-700/20 text-primary-300 border border-primary-500/30 rounded-full">
-            {humanizeSourceType(article.source_type)}
-          </span>
-          <button
-            type="button"
-            className="group/dismiss p-1.5 text-gray-500 hover:text-red-400 hover:bg-red-400/10 rounded-lg transition-all duration-200 hover:scale-110"
-            title="Dismiss article"
-            onClick={(event) => {
-              event.stopPropagation()
-              onDismiss(article)
-            }}
+      headerActions={
+        <button
+          type="button"
+          className="group/dismiss p-1.5 text-gray-500 hover:text-red-400 hover:bg-red-400/10 rounded-lg transition-all duration-200 hover:scale-110"
+          title="Dismiss article"
+          onClick={(event) => {
+            event.stopPropagation()
+            onDismiss(article)
+          }}
+        >
+          <svg
+            className="w-4 h-4 transition-transform group-hover/dismiss:scale-110"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
           >
-            <svg className="w-4 h-4 transition-transform group-hover/dismiss:scale-110" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
-        </div>
-      </div>
-
-      {article.description && (
-        <p className="text-gray-400 mb-6 line-clamp-3 leading-relaxed">
-          {truncate(article.description, 280)}
-        </p>
-      )}
-
-      <div className="flex justify-between items-center text-sm border-t border-dark-700 pt-4">
-        <div className="flex items-center space-x-6 text-gray-500">
-          <span className="flex items-center">
-            <svg className="w-4 h-4 mr-1.5 text-primary-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-            </svg>
-            {formatPublishedDate(article.published_at)}
-          </span>
-          <span className="flex items-center">
-            <svg className="w-4 h-4 mr-1.5 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M14 10h4.764a2 2 0 011.789 2.894l-3.5 7A2 2 0 0115.263 21h-4.017c-.163 0-.326-.02-.485-.06L7 20m7-10V5a2 2 0 00-2-2h-.095c-.5 0-.905.405-.905.905 0 .714-.211 1.412-.608 2.006L7 11v9m7-10h-2M7 20H5a2 2 0 01-2-2v-6a2 2 0 012-2h2.5" />
-            </svg>
-            {article.score}
-          </span>
-          <span className="flex items-center">
-            <svg className="w-4 h-4 mr-1.5 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-            </svg>
-            {article.comment_count}
-          </span>
-        </div>
-
-        <div className="flex items-center space-x-3">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+      }
+      actions={
+        <>
           <button
             type="button"
             className={
@@ -116,8 +72,18 @@ export default function ArticleCard({
               onBookmarkToggle(article)
             }}
           >
-            <svg className="w-4 h-4 transition-transform group-hover/bookmark:scale-110" fill={article.bookmarked ? 'currentColor' : 'none'} stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
+            <svg
+              className="w-4 h-4 transition-transform group-hover/bookmark:scale-110"
+              fill={article.bookmarked ? 'currentColor' : 'none'}
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"
+              />
             </svg>
           </button>
 
@@ -134,25 +100,23 @@ export default function ArticleCard({
               onReadToggle(article)
             }}
           >
-            <svg className="w-4 h-4 transition-transform group-hover/read:scale-110" fill={article.read ? 'currentColor' : 'none'} stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+            <svg
+              className="w-4 h-4 transition-transform group-hover/read:scale-110"
+              fill={article.read ? 'currentColor' : 'none'}
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
             </svg>
           </button>
-
-          <a
-            href={`/articles/${article.id}`}
-            className="group/detail px-4 py-2 bg-gradient-to-r from-dark-700 to-dark-600 border border-dark-500 text-gray-300 rounded-lg font-medium transition-all duration-200 hover:from-primary-600 hover:to-primary-700 hover:border-primary-500 hover:text-white hover:scale-105 hover:shadow-lg hover:shadow-primary-500/20"
-            onClick={(event) => event.stopPropagation()}
-          >
-            <span className="flex items-center">
-              Details
-              <svg className="w-4 h-4 ml-2 transition-transform group-hover/detail:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
-              </svg>
-            </span>
-          </a>
-        </div>
-      </div>
-    </article>
+        </>
+      }
+      detailsHref={`/articles/${article.id}`}
+    />
   )
 }

--- a/app/frontend/components/ArticleCardBase.tsx
+++ b/app/frontend/components/ArticleCardBase.tsx
@@ -1,0 +1,253 @@
+import type { CSSProperties, MouseEvent, ReactNode } from 'react'
+import {
+  formatPublishedDate,
+  humanizeSourceType,
+  truncate,
+} from '../utils/format'
+
+export interface ArticleCardData {
+  id: number
+  title: string
+  url: string
+  description: string | null
+  source_type: string
+  score: number
+  comment_count: number
+  published_at: string
+}
+
+export type ArticleCardTheme = 'primary' | 'green' | 'red' | 'orange'
+
+const CARD_THEMES: Record<
+  ArticleCardTheme,
+  {
+    titleHover: string
+    linkHover: string
+    shadowHover: string
+    badge: string
+    detailsHover: string
+    dateAccent: string
+  }
+> = {
+  primary: {
+    titleHover: 'group-hover:text-primary-300',
+    linkHover: 'hover:text-primary-400',
+    shadowHover: 'hover:shadow-primary-500/10',
+    badge:
+      'bg-gradient-to-r from-primary-600/20 to-primary-700/20 text-primary-300 border border-primary-500/30',
+    detailsHover:
+      'hover:from-primary-600 hover:to-primary-700 hover:border-primary-500 hover:shadow-primary-500/20',
+    dateAccent: 'text-primary-400',
+  },
+  green: {
+    titleHover: 'group-hover:text-green-300',
+    linkHover: 'hover:text-green-400',
+    shadowHover: 'hover:shadow-green-500/10',
+    badge:
+      'bg-gradient-to-r from-green-600/20 to-green-700/20 text-green-300 border border-green-500/30',
+    detailsHover:
+      'hover:from-green-600 hover:to-green-700 hover:border-green-500 hover:shadow-green-500/20',
+    dateAccent: 'text-primary-400',
+  },
+  red: {
+    titleHover: 'group-hover:text-red-300',
+    linkHover: 'hover:text-red-400',
+    shadowHover: 'hover:shadow-red-500/10',
+    badge:
+      'bg-gradient-to-r from-red-600/20 to-red-700/20 text-red-300 border border-red-500/30',
+    detailsHover:
+      'hover:from-primary-600 hover:to-primary-700 hover:border-primary-500 hover:shadow-primary-500/20',
+    dateAccent: 'text-red-400',
+  },
+  orange: {
+    titleHover: 'group-hover:text-orange-300',
+    linkHover: 'hover:text-orange-400',
+    shadowHover: 'hover:shadow-orange-500/10',
+    badge:
+      'bg-gradient-to-r from-orange-600/20 to-orange-700/20 text-orange-300 border border-orange-500/30',
+    detailsHover:
+      'hover:from-primary-600 hover:to-primary-700 hover:border-primary-500 hover:shadow-primary-500/20',
+    dateAccent: 'text-orange-400',
+  },
+}
+
+interface ArticleCardBaseProps {
+  article: ArticleCardData
+  index: number
+  theme?: ArticleCardTheme
+  categorySlug?: string
+  borderClass?: string
+  badge?: ReactNode
+  showSourceBadge?: boolean
+  headerActions?: ReactNode
+  extraMetadata?: ReactNode
+  actions?: ReactNode
+  detailsHref?: string
+  onArticleClick?: () => void
+  articleStyle?: CSSProperties
+}
+
+function stopPropagation(event: MouseEvent) {
+  event.stopPropagation()
+}
+
+export default function ArticleCardBase({
+  article,
+  index,
+  theme = 'primary',
+  categorySlug,
+  borderClass = '',
+  badge,
+  showSourceBadge = true,
+  headerActions,
+  extraMetadata,
+  actions,
+  detailsHref,
+  onArticleClick,
+  articleStyle,
+}: ArticleCardBaseProps) {
+  const styles = CARD_THEMES[theme]
+
+  return (
+    <article
+      className={`article-card group glass-effect rounded-2xl p-6 transition-all duration-300 hover:scale-[1.02] hover:shadow-2xl ${styles.shadowHover} animate-fade-in ${borderClass}`}
+      data-source={article.source_type}
+      data-category={categorySlug}
+      style={{
+        animationDelay: `${index * 50}ms`,
+        ...articleStyle,
+      }}
+      onClick={onArticleClick}
+    >
+      <div className="flex justify-between items-start mb-4">
+        <div className="flex-1">
+          <h2
+            className={`text-xl font-bold text-gray-100 mb-2 leading-tight ${styles.titleHover} transition-colors duration-200`}
+          >
+            <a
+              href={article.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={`${styles.linkHover} transition-colors duration-200 flex items-start group/link`}
+              onClick={stopPropagation}
+            >
+              <span className="flex-1">{article.title}</span>
+              <svg
+                className="w-4 h-4 ml-2 mt-1 opacity-60 group-hover/link:opacity-100 transition-all duration-200 group-hover/link:translate-x-1"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                />
+              </svg>
+            </a>
+          </h2>
+        </div>
+        <div className="ml-4 flex items-center space-x-2">
+          {badge}
+          {showSourceBadge && !badge && (
+            <span
+              className={`inline-block px-3 py-1.5 text-xs font-semibold rounded-full ${styles.badge}`}
+            >
+              {humanizeSourceType(article.source_type)}
+            </span>
+          )}
+          {headerActions}
+        </div>
+      </div>
+
+      {article.description && (
+        <p className="text-gray-400 mb-6 line-clamp-3 leading-relaxed">
+          {truncate(article.description, 280)}
+        </p>
+      )}
+
+      <div className="flex justify-between items-center text-sm border-t border-dark-700 pt-4">
+        <div className="flex items-center space-x-6 text-gray-500">
+          <span className="flex items-center">
+            <svg
+              className={`w-4 h-4 mr-1.5 ${styles.dateAccent}`}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+              />
+            </svg>
+            {formatPublishedDate(article.published_at)}
+          </span>
+          <span className="flex items-center">
+            <svg
+              className="w-4 h-4 mr-1.5 text-green-400"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M14 10h4.764a2 2 0 011.789 2.894l-3.5 7A2 2 0 0115.263 21h-4.017c-.163 0-.326-.02-.485-.06L7 20m7-10V5a2 2 0 00-2-2h-.095c-.5 0-.905.405-.905.905 0 .714-.211 1.412-.608 2.006L7 11v9m7-10h-2M7 20H5a2 2 0 01-2-2v-6a2 2 0 012-2h2.5"
+              />
+            </svg>
+            {article.score}
+          </span>
+          <span className="flex items-center">
+            <svg
+              className="w-4 h-4 mr-1.5 text-blue-400"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
+              />
+            </svg>
+            {article.comment_count}
+          </span>
+          {extraMetadata}
+        </div>
+
+        <div className="flex items-center space-x-3">
+          {actions}
+          {detailsHref && (
+            <a
+              href={detailsHref}
+              className={`group/detail px-4 py-2 bg-gradient-to-r from-dark-700 to-dark-600 border border-dark-500 text-gray-300 rounded-lg font-medium transition-all duration-200 ${styles.detailsHover} hover:text-white hover:scale-105 hover:shadow-lg`}
+              onClick={stopPropagation}
+            >
+              <span className="flex items-center">
+                Details
+                <svg
+                  className="w-4 h-4 ml-2 transition-transform group-hover/detail:translate-x-1"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="M9 5l7 7-7 7"
+                  />
+                </svg>
+              </span>
+            </a>
+          )}
+        </div>
+      </div>
+    </article>
+  )
+}

--- a/app/frontend/components/BookmarkCard.tsx
+++ b/app/frontend/components/BookmarkCard.tsx
@@ -1,10 +1,6 @@
 import type { BookmarkArticle } from '../types/bookmark'
-import {
-  formatBookmarkedDate,
-  formatPublishedDate,
-  humanizeSourceType,
-  truncate,
-} from '../utils/format'
+import { formatBookmarkedDate } from '../utils/format'
+import ArticleCardBase from './ArticleCardBase'
 
 interface BookmarkCardProps {
   article: BookmarkArticle
@@ -26,71 +22,21 @@ export default function BookmarkCard({
   }
 
   return (
-    <article
-      className="article-card group glass-effect rounded-2xl p-6 transition-all duration-300 hover:scale-[1.02] hover:shadow-2xl hover:shadow-primary-500/10 animate-fade-in"
-      data-source={article.source_type}
-      style={{ animationDelay: `${index * 50}ms` }}
-    >
-      <div className="flex justify-between items-start mb-4">
-        <div className="flex-1">
-          <h2 className="text-xl font-bold text-gray-100 mb-2 leading-tight group-hover:text-primary-300 transition-colors duration-200">
-            <a
-              href={article.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="hover:text-primary-400 transition-colors duration-200 flex items-start group/link"
-            >
-              <span className="flex-1">{article.title}</span>
-              <svg className="w-4 h-4 ml-2 mt-1 opacity-60 group-hover/link:opacity-100 transition-all duration-200 group-hover/link:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-              </svg>
-            </a>
-          </h2>
-        </div>
-        <div className="ml-4">
-          <span className="inline-block px-3 py-1.5 text-xs font-semibold bg-gradient-to-r from-primary-600/20 to-primary-700/20 text-primary-300 border border-primary-500/30 rounded-full">
-            {humanizeSourceType(article.source_type)}
-          </span>
-        </div>
-      </div>
-
-      {article.description && (
-        <p className="text-gray-400 mb-6 line-clamp-3 leading-relaxed">
-          {truncate(article.description, 280)}
-        </p>
-      )}
-
-      <div className="flex justify-between items-center text-sm border-t border-dark-700 pt-4">
-        <div className="flex items-center space-x-6 text-gray-500">
-          <span className="flex items-center">
-            <svg className="w-4 h-4 mr-1.5 text-primary-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+    <ArticleCardBase
+      article={article}
+      index={index}
+      extraMetadata={
+        article.bookmarked_at ? (
+          <span className="flex items-center text-primary-400">
+            <svg className="w-4 h-4 mr-1.5" fill="currentColor" viewBox="0 0 24 24">
+              <path d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
             </svg>
-            {formatPublishedDate(article.published_at)}
+            Bookmarked {formatBookmarkedDate(article.bookmarked_at)}
           </span>
-          <span className="flex items-center">
-            <svg className="w-4 h-4 mr-1.5 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M14 10h4.764a2 2 0 011.789 2.894l-3.5 7A2 2 0 0115.263 21h-4.017c-.163 0-.326-.02-.485-.06L7 20m7-10V5a2 2 0 00-2-2h-.095c-.5 0-.905.405-.905.905 0 .714-.211 1.412-.608 2.006L7 11v9m7-10h-2M7 20H5a2 2 0 01-2-2v-6a2 2 0 012-2h2.5" />
-            </svg>
-            {article.score}
-          </span>
-          <span className="flex items-center">
-            <svg className="w-4 h-4 mr-1.5 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-            </svg>
-            {article.comment_count}
-          </span>
-          {article.bookmarked_at && (
-            <span className="flex items-center text-primary-400">
-              <svg className="w-4 h-4 mr-1.5" fill="currentColor" viewBox="0 0 24 24">
-                <path d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
-              </svg>
-              🔖 Bookmarked {formatBookmarkedDate(article.bookmarked_at)}
-            </span>
-          )}
-        </div>
-
-        <div className="flex items-center space-x-3">
+        ) : undefined
+      }
+      actions={
+        <>
           <button
             type="button"
             className={
@@ -101,8 +47,18 @@ export default function BookmarkCard({
             title={article.read ? 'Mark as unread' : 'Mark as read'}
             onClick={() => onReadToggle(article)}
           >
-            <svg className="w-4 h-4 transition-transform group-hover/read:scale-110" fill={article.read ? 'currentColor' : 'none'} stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+            <svg
+              className="w-4 h-4 transition-transform group-hover/read:scale-110"
+              fill={article.read ? 'currentColor' : 'none'}
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
             </svg>
           </button>
 
@@ -112,24 +68,17 @@ export default function BookmarkCard({
             title="Remove from reading list"
             onClick={handleRemove}
           >
-            <svg className="w-4 h-4 transition-transform group-hover/bookmark:scale-110" fill="currentColor" viewBox="0 0 24 24">
+            <svg
+              className="w-4 h-4 transition-transform group-hover/bookmark:scale-110"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+            >
               <path d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
             </svg>
           </button>
-
-          <a
-            href={`/articles/${article.id}`}
-            className="group/detail px-4 py-2 bg-gradient-to-r from-dark-700 to-dark-600 border border-dark-500 text-gray-300 rounded-lg font-medium transition-all duration-200 hover:from-primary-600 hover:to-primary-700 hover:border-primary-500 hover:text-white hover:scale-105 hover:shadow-lg hover:shadow-primary-500/20"
-          >
-            <span className="flex items-center">
-              Details
-              <svg className="w-4 h-4 ml-2 transition-transform group-hover/detail:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
-              </svg>
-            </span>
-          </a>
-        </div>
-      </div>
-    </article>
+        </>
+      }
+      detailsHref={`/articles/${article.id}`}
+    />
   )
 }

--- a/app/frontend/components/DismissedArticleCard.tsx
+++ b/app/frontend/components/DismissedArticleCard.tsx
@@ -1,10 +1,6 @@
 import type { DismissedArticle } from '../types/dismissedArticle'
-import {
-  formatBookmarkedDate,
-  formatPublishedDate,
-  formatTimeAgo,
-  truncate,
-} from '../utils/format'
+import { formatBookmarkedDate, formatTimeAgo } from '../utils/format'
+import ArticleCardBase from './ArticleCardBase'
 
 interface DismissedArticleCardProps {
   article: DismissedArticle
@@ -20,14 +16,8 @@ export default function DismissedArticleCard({
   onRestore,
 }: DismissedArticleCardProps) {
   const isRecent = variant === 'recent'
-  const accentHover = isRecent ? 'group-hover:text-orange-300' : 'group-hover:text-red-300'
-  const linkHover = isRecent ? 'hover:text-orange-400' : 'hover:text-red-400'
-  const shadowHover = isRecent ? 'hover:shadow-orange-500/10' : 'hover:shadow-red-500/10'
+  const theme = isRecent ? 'orange' : 'red'
   const borderClass = isRecent ? 'border-orange-500/20' : 'border-red-500/20'
-  const badgeClasses = isRecent
-    ? 'bg-gradient-to-r from-orange-600/20 to-orange-700/20 text-orange-300 border border-orange-500/30'
-    : 'bg-gradient-to-r from-red-600/20 to-red-700/20 text-red-300 border border-red-500/30'
-  const dateAccent = isRecent ? 'text-orange-400' : 'text-red-400'
   const restoreLabel = isRecent ? 'Quick Restore' : 'Restore'
 
   const handleRestore = () => {
@@ -45,78 +35,47 @@ export default function DismissedArticleCard({
       ? `Dismissed ${formatBookmarkedDate(article.dismissed_at)}`
       : 'Dismissed'
 
+  const styles = isRecent
+    ? 'bg-gradient-to-r from-orange-600/20 to-orange-700/20 text-orange-300 border border-orange-500/30'
+    : 'bg-gradient-to-r from-red-600/20 to-red-700/20 text-red-300 border border-red-500/30'
+
   return (
-    <article
-      className={`article-card group glass-effect rounded-2xl p-6 transition-all duration-300 hover:scale-[1.02] hover:shadow-2xl ${shadowHover} animate-fade-in ${borderClass}`}
-      style={{ animationDelay: `${index * 50}ms` }}
-    >
-      <div className="flex justify-between items-start mb-4">
-        <div className="flex-1">
-          <h2 className={`text-xl font-bold text-gray-100 mb-2 leading-tight ${accentHover} transition-colors duration-200`}>
-            <a
-              href={article.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className={`${linkHover} transition-colors duration-200 flex items-start group/link`}
+    <ArticleCardBase
+      article={article}
+      index={index}
+      theme={theme}
+      borderClass={borderClass}
+      showSourceBadge={false}
+      badge={
+        <span className={`inline-block px-3 py-1.5 text-xs font-semibold rounded-full ${styles}`}>
+          {badgeText}
+        </span>
+      }
+      actions={
+        <button
+          type="button"
+          className="group/restore px-4 py-2 bg-gradient-to-r from-green-600 to-green-700 text-white rounded-lg font-medium transition-all duration-200 hover:from-green-700 hover:to-green-800 hover:scale-105 hover:shadow-lg hover:shadow-green-500/25"
+          title="Restore article"
+          onClick={handleRestore}
+        >
+          <span className="flex items-center">
+            <svg
+              className="w-4 h-4 mr-2 transition-transform group-hover/restore:scale-110"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
             >
-              <span className="flex-1">{article.title}</span>
-              <svg className="w-4 h-4 ml-2 mt-1 opacity-60 group-hover/link:opacity-100 transition-all duration-200 group-hover/link:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-              </svg>
-            </a>
-          </h2>
-        </div>
-        <div className="ml-4 flex items-center space-x-2">
-          <span className={`inline-block px-3 py-1.5 text-xs font-semibold rounded-full ${badgeClasses}`}>
-            {badgeText}
-          </span>
-        </div>
-      </div>
-
-      {article.description && (
-        <p className="text-gray-400 mb-6 line-clamp-3 leading-relaxed">
-          {truncate(article.description, 280)}
-        </p>
-      )}
-
-      <div className="flex justify-between items-center text-sm border-t border-dark-700 pt-4">
-        <div className="flex items-center space-x-6 text-gray-500">
-          <span className="flex items-center">
-            <svg className={`w-4 h-4 mr-1.5 ${dateAccent}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+              />
             </svg>
-            {formatPublishedDate(article.published_at)}
+            {restoreLabel}
           </span>
-          <span className="flex items-center">
-            <svg className="w-4 h-4 mr-1.5 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M14 10h4.764a2 2 0 011.789 2.894l-3.5 7A2 2 0 0115.263 21h-4.017c-.163 0-.326-.02-.485-.06L7 20m7-10V5a2 2 0 00-2-2h-.095c-.5 0-.905.405-.905.905 0 .714-.211 1.412-.608 2.006L7 11v9m7-10h-2M7 20H5a2 2 0 01-2-2v-6a2 2 0 012-2h2.5" />
-            </svg>
-            {article.score}
-          </span>
-          <span className="flex items-center">
-            <svg className="w-4 h-4 mr-1.5 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-            </svg>
-            {article.comment_count}
-          </span>
-        </div>
-
-        <div className="flex items-center space-x-3">
-          <button
-            type="button"
-            className="group/restore px-4 py-2 bg-gradient-to-r from-green-600 to-green-700 text-white rounded-lg font-medium transition-all duration-200 hover:from-green-700 hover:to-green-800 hover:scale-105 hover:shadow-lg hover:shadow-green-500/25"
-            title="Restore article"
-            onClick={handleRestore}
-          >
-            <span className="flex items-center">
-              <svg className="w-4 h-4 mr-2 transition-transform group-hover/restore:scale-110" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-              </svg>
-              {restoreLabel}
-            </span>
-          </button>
-        </div>
-      </div>
-    </article>
+        </button>
+      }
+    />
   )
 }

--- a/app/frontend/components/ReadArticleCard.tsx
+++ b/app/frontend/components/ReadArticleCard.tsx
@@ -1,10 +1,6 @@
 import type { ReadArticle } from '../types/readArticle'
-import {
-  formatBookmarkedDate,
-  formatPublishedDate,
-  humanizeSourceType,
-  truncate,
-} from '../utils/format'
+import { formatBookmarkedDate } from '../utils/format'
+import ArticleCardBase from './ArticleCardBase'
 
 interface ReadArticleCardProps {
   article: ReadArticle
@@ -20,95 +16,48 @@ export default function ReadArticleCard({ article, index, onUnmarkRead }: ReadAr
   }
 
   return (
-    <article
-      className="article-card group glass-effect rounded-2xl p-6 transition-all duration-300 hover:scale-[1.02] hover:shadow-2xl hover:shadow-green-500/10 animate-fade-in"
-      data-source={article.source_type}
-      style={{ animationDelay: `${index * 50}ms` }}
-    >
-      <div className="flex justify-between items-start mb-4">
-        <div className="flex-1">
-          <h2 className="text-xl font-bold text-gray-100 mb-2 leading-tight group-hover:text-green-300 transition-colors duration-200">
-            <a
-              href={article.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="hover:text-green-400 transition-colors duration-200 flex items-start group/link"
-            >
-              <span className="flex-1">{article.title}</span>
-              <svg className="w-4 h-4 ml-2 mt-1 opacity-60 group-hover/link:opacity-100 transition-all duration-200 group-hover/link:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-              </svg>
-            </a>
-          </h2>
-        </div>
-        <div className="ml-4">
-          <span className="inline-block px-3 py-1.5 text-xs font-semibold bg-gradient-to-r from-green-600/20 to-green-700/20 text-green-300 border border-green-500/30 rounded-full">
-            {humanizeSourceType(article.source_type)}
-          </span>
-        </div>
-      </div>
-
-      {article.description && (
-        <p className="text-gray-400 mb-6 line-clamp-3 leading-relaxed">
-          {truncate(article.description, 280)}
-        </p>
-      )}
-
-      <div className="flex justify-between items-center text-sm border-t border-dark-700 pt-4">
-        <div className="flex items-center space-x-6 text-gray-500">
-          <span className="flex items-center">
-            <svg className="w-4 h-4 mr-1.5 text-primary-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+    <ArticleCardBase
+      article={article}
+      index={index}
+      theme="green"
+      extraMetadata={
+        article.read_at ? (
+          <span className="flex items-center text-green-400">
+            <svg className="w-4 h-4 mr-1.5" fill="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
             </svg>
-            {formatPublishedDate(article.published_at)}
+            Read {formatBookmarkedDate(article.read_at)}
           </span>
-          <span className="flex items-center">
-            <svg className="w-4 h-4 mr-1.5 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M14 10h4.764a2 2 0 011.789 2.894l-3.5 7A2 2 0 0115.263 21h-4.017c-.163 0-.326-.02-.485-.06L7 20m7-10V5a2 2 0 00-2-2h-.095c-.5 0-.905.405-.905.905 0 .714-.211 1.412-.608 2.006L7 11v9m7-10h-2M7 20H5a2 2 0 01-2-2v-6a2 2 0 012-2h2.5" />
-            </svg>
-            {article.score}
-          </span>
-          <span className="flex items-center">
-            <svg className="w-4 h-4 mr-1.5 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-            </svg>
-            {article.comment_count}
-          </span>
-          {article.read_at && (
-            <span className="flex items-center text-green-400">
-              <svg className="w-4 h-4 mr-1.5" fill="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-              Read {formatBookmarkedDate(article.read_at)}
-            </span>
-          )}
-        </div>
-
-        <div className="flex items-center space-x-3">
-          <button
-            type="button"
-            className="group/read p-2 bg-gradient-to-r from-orange-600 to-orange-700 text-white rounded-lg transition-all duration-200 hover:from-orange-700 hover:to-orange-800 hover:scale-110 hover:shadow-lg hover:shadow-orange-500/25"
-            title="Mark as unread"
-            onClick={handleUnmark}
+        ) : undefined
+      }
+      actions={
+        <button
+          type="button"
+          className="group/read p-2 bg-gradient-to-r from-orange-600 to-orange-700 text-white rounded-lg transition-all duration-200 hover:from-orange-700 hover:to-orange-800 hover:scale-110 hover:shadow-lg hover:shadow-orange-500/25"
+          title="Mark as unread"
+          onClick={handleUnmark}
+        >
+          <svg
+            className="w-4 h-4 transition-transform group-hover/read:scale-110"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
           >
-            <svg className="w-4 h-4 transition-transform group-hover/read:scale-110" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-          </button>
-
-          <a
-            href={`/articles/${article.id}`}
-            className="group/detail px-4 py-2 bg-gradient-to-r from-dark-700 to-dark-600 border border-dark-500 text-gray-300 rounded-lg font-medium transition-all duration-200 hover:from-green-600 hover:to-green-700 hover:border-green-500 hover:text-white hover:scale-105 hover:shadow-lg hover:shadow-green-500/20"
-          >
-            <span className="flex items-center">
-              Details
-              <svg className="w-4 h-4 ml-2 transition-transform group-hover/detail:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
-              </svg>
-            </span>
-          </a>
-        </div>
-      </div>
-    </article>
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          </svg>
+        </button>
+      }
+      detailsHref={`/articles/${article.id}`}
+    />
   )
 }

--- a/test/system/bookmark_functionality_test.rb
+++ b/test/system/bookmark_functionality_test.rb
@@ -48,7 +48,7 @@ class BookmarkFunctionalityTest < ApplicationSystemTestCase
     assert_selector "article.article-card[data-source='reddit_ruby']"
     within("article.article-card[data-source='reddit_rust']") do
       assert_text @bookmarked_article.title
-      assert_selector "span", text: /🔖 Bookmarked/
+      assert_selector "span", text: /Bookmarked/
     end
   end
 


### PR DESCRIPTION
## Summary
- Add composable `ArticleCardBase` with theme variants (primary, green, red, orange) and slot props for badges, metadata, and actions
- Refactor `ArticleCard`, `BookmarkCard`, `ReadArticleCard`, and `DismissedArticleCard` into thin wrappers
- Remove emoji from bookmark metadata row (SVG-only, consistent with other cards)

Closes #174

## Test plan
- [x] `npm run typecheck` passes
- [x] `bin/rails test` (194 tests)