### PR TITLE
feat: wire up articles feed pagination UI (#175)

### DIFF
--- a/app/frontend/components/PaginationControls.tsx
+++ b/app/frontend/components/PaginationControls.tsx
@@ -1,0 +1,71 @@
+interface PaginationControlsProps {
+  currentPage: number
+  totalPages: number
+  totalCount: number
+  perPage: number
+  onPageChange: (page: number) => void
+}
+
+export default function PaginationControls({
+  currentPage,
+  totalPages,
+  totalCount,
+  perPage,
+  onPageChange,
+}: PaginationControlsProps) {
+  if (totalPages <= 1) return null
+
+  const rangeStart = (currentPage - 1) * perPage + 1
+  const rangeEnd = Math.min(currentPage * perPage, totalCount)
+
+  const goToPage = (page: number) => {
+    if (page < 1 || page > totalPages || page === currentPage) return
+    onPageChange(page)
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }
+
+  return (
+    <nav
+      className="glass-effect rounded-2xl p-4 mt-8 flex flex-col sm:flex-row items-center justify-between gap-4"
+      aria-label="Articles pagination"
+      data-testid="articles-pagination"
+    >
+      <p className="text-sm text-gray-400">
+        Showing{' '}
+        <span className="text-gray-200 font-medium">
+          {rangeStart}–{rangeEnd}
+        </span>{' '}
+        of <span className="text-gray-200 font-medium">{totalCount}</span> articles
+      </p>
+
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          className="px-4 py-2 rounded-lg border border-dark-500 bg-dark-700 text-gray-300 font-medium transition-all duration-200 hover:bg-dark-600 hover:text-white disabled:opacity-40 disabled:hover:bg-dark-700 disabled:hover:text-gray-300"
+          onClick={() => goToPage(currentPage - 1)}
+          disabled={currentPage <= 1}
+          aria-label="Previous page"
+          data-testid="pagination-prev"
+        >
+          Previous
+        </button>
+
+        <span className="px-3 text-sm text-gray-400" data-testid="pagination-status">
+          Page <span className="text-primary-400 font-semibold">{currentPage}</span> of{' '}
+          <span className="text-gray-200">{totalPages}</span>
+        </span>
+
+        <button
+          type="button"
+          className="px-4 py-2 rounded-lg border border-dark-500 bg-dark-700 text-gray-300 font-medium transition-all duration-200 hover:bg-dark-600 hover:text-white disabled:opacity-40 disabled:hover:bg-dark-700 disabled:hover:text-gray-300"
+          onClick={() => goToPage(currentPage + 1)}
+          disabled={currentPage >= totalPages}
+          aria-label="Next page"
+          data-testid="pagination-next"
+        >
+          Next
+        </button>
+      </div>
+    </nav>
+  )
+}

--- a/app/frontend/pages/ArticlesIndexPage.tsx
+++ b/app/frontend/pages/ArticlesIndexPage.tsx
@@ -16,6 +16,7 @@ import ArticleList from '../components/ArticleList'
 import CategoryFilter from '../components/CategoryFilter'
 import DismissToast from '../components/DismissToast'
 import PageHeader from '../components/PageHeader'
+import PaginationControls from '../components/PaginationControls'
 import ScoreFilter, { scoreFilterParams, type ScoreFilterValue } from '../components/ScoreFilter'
 
 const DISMISS_TIMEOUT_SECONDS = 15
@@ -37,6 +38,7 @@ export default function ArticlesIndexPage() {
   const [error, setError] = useState<string | null>(null)
   const [activeFilter, setActiveFilter] = useState('all')
   const [activeScoreFilter, setActiveScoreFilter] = useState<ScoreFilterValue>('all')
+  const [currentPage, setCurrentPage] = useState(1)
   const [showRead, setShowRead] = useState(false)
   const [fetchingNews, setFetchingNews] = useState(false)
   const [fetchMessage, setFetchMessage] = useState<string | null>(null)
@@ -47,22 +49,27 @@ export default function ArticlesIndexPage() {
   const countdownRef = useRef<number | null>(null)
   const pendingDismissRef = useRef<{ articleId: number; title: string } | null>(null)
 
-  const loadArticles = useCallback(async () => {
+  const loadArticles = useCallback(async (options?: { page?: number }) => {
+    const page = options?.page ?? currentPage
     setLoading(true)
     setError(null)
     try {
       const response = await fetchArticles({
+        page,
         show_read: showRead,
         ...scoreFilterParams(activeScoreFilter),
       })
       setData(response)
       setRemovedIds(new Set())
+      if (options?.page !== undefined && options.page !== currentPage) {
+        setCurrentPage(options.page)
+      }
     } catch {
       setError('Failed to load articles. Please try again.')
     } finally {
       setLoading(false)
     }
-  }, [showRead, activeScoreFilter])
+  }, [showRead, activeScoreFilter, currentPage])
 
   useEffect(() => {
     loadArticles()
@@ -160,6 +167,16 @@ export default function ArticlesIndexPage() {
     }
   }, [finalizeDismiss, toast])
 
+  const handleShowReadChange = (value: boolean) => {
+    setCurrentPage(1)
+    setShowRead(value)
+  }
+
+  const handleScoreFilterChange = (value: ScoreFilterValue) => {
+    setCurrentPage(1)
+    setActiveScoreFilter(value)
+  }
+
   const handleFetchNews = async () => {
     setFetchingNews(true)
     setFetchMessage(null)
@@ -167,7 +184,7 @@ export default function ArticlesIndexPage() {
     try {
       const result = await fetchNews()
       setFetchMessage(`Fetched ${result.articles_count} articles in ${result.duration}s`)
-      await loadArticles()
+      await loadArticles({ page: 1 })
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to fetch news.')
     } finally {
@@ -248,7 +265,7 @@ export default function ArticlesIndexPage() {
         <button
           type="button"
           className="px-4 py-2 bg-primary-600 text-white rounded-lg"
-          onClick={loadArticles}
+          onClick={() => loadArticles()}
         >
           Retry
         </button>
@@ -265,7 +282,7 @@ export default function ArticlesIndexPage() {
           totalCount={data?.pagination.total_count ?? 0}
           lastUpdated={data?.last_updated ?? null}
           showRead={showRead}
-          onShowReadChange={setShowRead}
+          onShowReadChange={handleShowReadChange}
           onFetchNews={handleFetchNews}
           fetchingNews={fetchingNews}
           fetchMessage={fetchMessage}
@@ -312,7 +329,7 @@ export default function ArticlesIndexPage() {
 
       <ScoreFilter
         activeScoreFilter={activeScoreFilter}
-        onScoreFilterChange={setActiveScoreFilter}
+        onScoreFilterChange={handleScoreFilterChange}
       />
 
       <CategoryFilter
@@ -332,6 +349,14 @@ export default function ArticlesIndexPage() {
         onUndoDismiss={handleUndoDismiss}
         onBookmarkToggle={handleBookmarkToggle}
         onReadToggle={handleReadToggle}
+      />
+
+      <PaginationControls
+        currentPage={data.pagination.current_page}
+        totalPages={data.pagination.total_pages}
+        totalCount={data.pagination.total_count}
+        perPage={data.pagination.per_page}
+        onPageChange={setCurrentPage}
       />
 
       {toast && (


### PR DESCRIPTION
## Summary
- Add `PaginationControls` component (prev/next, page status, showing X-Y of Z)
- Pass `page` to `fetchArticles` from `ArticlesIndexPage`; reset to page 1 when score/read filters or fetch-news changes
- Pagination state syncs with API `current_page`, `total_pages`, and `total_count`

Closes #175

## Test plan
- [x] `npm run typecheck` passes
- [x] `bin/rails test` (194 tests)