### PR TITLE
feat(frontend): replace window.confirm with ConfirmDialog (#177)

### DIFF
--- a/app/frontend/components/BookmarkCard.tsx
+++ b/app/frontend/components/BookmarkCard.tsx
@@ -1,5 +1,6 @@
 import type { BookmarkArticle } from '../types/bookmark'
 import { formatBookmarkedDate } from '../utils/format'
+import { useConfirmDialog } from '../hooks/useConfirmDialog'
 import ArticleCardBase from './ArticleCardBase'
 
 interface BookmarkCardProps {
@@ -15,70 +16,79 @@ export default function BookmarkCard({
   onRemoveBookmark,
   onReadToggle,
 }: BookmarkCardProps) {
-  const handleRemove = () => {
-    if (window.confirm('Remove this article from your reading list?')) {
+  const { confirm, dialog } = useConfirmDialog()
+
+  const handleRemove = async () => {
+    const confirmed = await confirm({
+      message: 'Remove this article from your reading list?',
+      confirmLabel: 'Remove',
+    })
+    if (confirmed) {
       onRemoveBookmark(article)
     }
   }
 
   return (
-    <ArticleCardBase
-      article={article}
-      index={index}
-      extraMetadata={
-        article.bookmarked_at ? (
-          <span className="flex items-center text-primary-400">
-            <svg className="w-4 h-4 mr-1.5" fill="currentColor" viewBox="0 0 24 24">
-              <path d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
-            </svg>
-            Bookmarked {formatBookmarkedDate(article.bookmarked_at)}
-          </span>
-        ) : undefined
-      }
-      actions={
-        <>
-          <button
-            type="button"
-            className={
-              article.read
-                ? 'group/read p-2 bg-gradient-to-r from-green-600 to-green-700 text-white rounded-lg transition-all duration-200 hover:from-orange-600 hover:to-orange-700 hover:scale-110 hover:shadow-lg hover:shadow-orange-500/25'
-                : 'group/read p-2 bg-dark-700 border border-dark-600 text-gray-400 rounded-lg transition-all duration-200 hover:bg-green-600 hover:border-green-500 hover:text-white hover:scale-110 hover:shadow-lg hover:shadow-green-500/25'
-            }
-            title={article.read ? 'Mark as unread' : 'Mark as read'}
-            onClick={() => onReadToggle(article)}
-          >
-            <svg
-              className="w-4 h-4 transition-transform group-hover/read:scale-110"
-              fill={article.read ? 'currentColor' : 'none'}
-              stroke="currentColor"
-              viewBox="0 0 24 24"
+    <>
+      <ArticleCardBase
+        article={article}
+        index={index}
+        extraMetadata={
+          article.bookmarked_at ? (
+            <span className="flex items-center text-primary-400">
+              <svg className="w-4 h-4 mr-1.5" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
+              </svg>
+              Bookmarked {formatBookmarkedDate(article.bookmarked_at)}
+            </span>
+          ) : undefined
+        }
+        actions={
+          <>
+            <button
+              type="button"
+              className={
+                article.read
+                  ? 'group/read p-2 bg-gradient-to-r from-green-600 to-green-700 text-white rounded-lg transition-all duration-200 hover:from-orange-600 hover:to-orange-700 hover:scale-110 hover:shadow-lg hover:shadow-orange-500/25'
+                  : 'group/read p-2 bg-dark-700 border border-dark-600 text-gray-400 rounded-lg transition-all duration-200 hover:bg-green-600 hover:border-green-500 hover:text-white hover:scale-110 hover:shadow-lg hover:shadow-green-500/25'
+              }
+              title={article.read ? 'Mark as unread' : 'Mark as read'}
+              onClick={() => onReadToggle(article)}
             >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2"
-                d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-              />
-            </svg>
-          </button>
+              <svg
+                className="w-4 h-4 transition-transform group-hover/read:scale-110"
+                fill={article.read ? 'currentColor' : 'none'}
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+            </button>
 
-          <button
-            type="button"
-            className="group/bookmark p-2 bg-gradient-to-r from-red-600 to-red-700 text-white rounded-lg transition-all duration-200 hover:from-red-700 hover:to-red-800 hover:scale-110 hover:shadow-lg hover:shadow-red-500/25"
-            title="Remove from reading list"
-            onClick={handleRemove}
-          >
-            <svg
-              className="w-4 h-4 transition-transform group-hover/bookmark:scale-110"
-              fill="currentColor"
-              viewBox="0 0 24 24"
+            <button
+              type="button"
+              className="group/bookmark p-2 bg-gradient-to-r from-red-600 to-red-700 text-white rounded-lg transition-all duration-200 hover:from-red-700 hover:to-red-800 hover:scale-110 hover:shadow-lg hover:shadow-red-500/25"
+              title="Remove from reading list"
+              onClick={handleRemove}
             >
-              <path d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
-            </svg>
-          </button>
-        </>
-      }
-      detailsHref={`/articles/${article.id}`}
-    />
+              <svg
+                className="w-4 h-4 transition-transform group-hover/bookmark:scale-110"
+                fill="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
+              </svg>
+            </button>
+          </>
+        }
+        detailsHref={`/articles/${article.id}`}
+      />
+      {dialog}
+    </>
   )
 }

--- a/app/frontend/components/ConfirmDialog.tsx
+++ b/app/frontend/components/ConfirmDialog.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useRef } from 'react'
+
+interface ConfirmDialogProps {
+  open: boolean
+  title?: string
+  message: string
+  confirmLabel?: string
+  cancelLabel?: string
+  confirmTone?: 'danger' | 'primary'
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export default function ConfirmDialog({
+  open,
+  title = 'Confirm action',
+  message,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  confirmTone = 'danger',
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const cancelRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+
+    const previouslyFocused = document.activeElement as HTMLElement | null
+    cancelRef.current?.focus()
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        onCancel()
+        return
+      }
+
+      if (event.key !== 'Tab' || !dialogRef.current) return
+
+      const focusable = Array.from(
+        dialogRef.current.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        )
+      )
+
+      if (focusable.length === 0) return
+
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault()
+        last.focus()
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault()
+        first.focus()
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+      previouslyFocused?.focus()
+    }
+  }, [open, onCancel])
+
+  if (!open) return null
+
+  const confirmButtonClass =
+    confirmTone === 'primary'
+      ? 'px-4 py-2 rounded-lg bg-gradient-to-r from-primary-600 to-primary-700 text-white font-medium hover:from-primary-700 hover:to-primary-800 transition-colors'
+      : 'px-4 py-2 rounded-lg bg-gradient-to-r from-red-600 to-red-700 text-white font-medium hover:from-red-700 hover:to-red-800 transition-colors'
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="presentation"
+      data-testid="confirm-dialog-backdrop"
+      onClick={onCancel}
+    >
+      <div
+        ref={dialogRef}
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="confirm-dialog-title"
+        aria-describedby="confirm-dialog-message"
+        className="glass-effect rounded-2xl p-6 w-full max-w-md shadow-2xl border border-dark-600 animate-fade-in"
+        data-testid="confirm-dialog"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <h2 id="confirm-dialog-title" className="text-xl font-bold text-gray-100 mb-3">
+          {title}
+        </h2>
+        <p id="confirm-dialog-message" className="text-gray-400 mb-6 leading-relaxed">
+          {message}
+        </p>
+        <div className="flex justify-end gap-3">
+          <button
+            ref={cancelRef}
+            type="button"
+            className="px-4 py-2 rounded-lg border border-dark-500 bg-dark-700 text-gray-300 font-medium hover:bg-dark-600 hover:text-white transition-colors"
+            onClick={onCancel}
+            data-testid="confirm-dialog-cancel"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            className={confirmButtonClass}
+            onClick={onConfirm}
+            data-testid="confirm-dialog-confirm"
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/frontend/components/DismissedArticleCard.tsx
+++ b/app/frontend/components/DismissedArticleCard.tsx
@@ -1,5 +1,6 @@
 import type { DismissedArticle } from '../types/dismissedArticle'
 import { formatBookmarkedDate, formatTimeAgo } from '../utils/format'
+import { useConfirmDialog } from '../hooks/useConfirmDialog'
 import ArticleCardBase from './ArticleCardBase'
 
 interface DismissedArticleCardProps {
@@ -15,14 +16,20 @@ export default function DismissedArticleCard({
   variant,
   onRestore,
 }: DismissedArticleCardProps) {
+  const { confirm, dialog } = useConfirmDialog()
   const isRecent = variant === 'recent'
   const theme = isRecent ? 'orange' : 'red'
   const borderClass = isRecent ? 'border-orange-500/20' : 'border-red-500/20'
   const restoreLabel = isRecent ? 'Quick Restore' : 'Restore'
 
-  const handleRestore = () => {
-    if (!isRecent && !window.confirm('Restore this article to your main feed?')) {
-      return
+  const handleRestore = async () => {
+    if (!isRecent) {
+      const confirmed = await confirm({
+        message: 'Restore this article to your main feed?',
+        confirmLabel: 'Restore',
+        confirmTone: 'primary',
+      })
+      if (!confirmed) return
     }
     onRestore(article)
   }
@@ -40,42 +47,45 @@ export default function DismissedArticleCard({
     : 'bg-gradient-to-r from-red-600/20 to-red-700/20 text-red-300 border border-red-500/30'
 
   return (
-    <ArticleCardBase
-      article={article}
-      index={index}
-      theme={theme}
-      borderClass={borderClass}
-      showSourceBadge={false}
-      badge={
-        <span className={`inline-block px-3 py-1.5 text-xs font-semibold rounded-full ${styles}`}>
-          {badgeText}
-        </span>
-      }
-      actions={
-        <button
-          type="button"
-          className="group/restore px-4 py-2 bg-gradient-to-r from-green-600 to-green-700 text-white rounded-lg font-medium transition-all duration-200 hover:from-green-700 hover:to-green-800 hover:scale-105 hover:shadow-lg hover:shadow-green-500/25"
-          title="Restore article"
-          onClick={handleRestore}
-        >
-          <span className="flex items-center">
-            <svg
-              className="w-4 h-4 mr-2 transition-transform group-hover/restore:scale-110"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2"
-                d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
-              />
-            </svg>
-            {restoreLabel}
+    <>
+      <ArticleCardBase
+        article={article}
+        index={index}
+        theme={theme}
+        borderClass={borderClass}
+        showSourceBadge={false}
+        badge={
+          <span className={`inline-block px-3 py-1.5 text-xs font-semibold rounded-full ${styles}`}>
+            {badgeText}
           </span>
-        </button>
-      }
-    />
+        }
+        actions={
+          <button
+            type="button"
+            className="group/restore px-4 py-2 bg-gradient-to-r from-green-600 to-green-700 text-white rounded-lg font-medium transition-all duration-200 hover:from-green-700 hover:to-green-800 hover:scale-105 hover:shadow-lg hover:shadow-green-500/25"
+            title="Restore article"
+            onClick={handleRestore}
+          >
+            <span className="flex items-center">
+              <svg
+                className="w-4 h-4 mr-2 transition-transform group-hover/restore:scale-110"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+                />
+              </svg>
+              {restoreLabel}
+            </span>
+          </button>
+        }
+      />
+      {dialog}
+    </>
   )
 }

--- a/app/frontend/components/ReadArticleCard.tsx
+++ b/app/frontend/components/ReadArticleCard.tsx
@@ -1,5 +1,6 @@
 import type { ReadArticle } from '../types/readArticle'
 import { formatBookmarkedDate } from '../utils/format'
+import { useConfirmDialog } from '../hooks/useConfirmDialog'
 import ArticleCardBase from './ArticleCardBase'
 
 interface ReadArticleCardProps {
@@ -9,21 +10,53 @@ interface ReadArticleCardProps {
 }
 
 export default function ReadArticleCard({ article, index, onUnmarkRead }: ReadArticleCardProps) {
-  const handleUnmark = () => {
-    if (window.confirm('Mark this article as unread?')) {
+  const { confirm, dialog } = useConfirmDialog()
+
+  const handleUnmark = async () => {
+    const confirmed = await confirm({
+      message: 'Mark this article as unread?',
+      confirmLabel: 'Mark unread',
+      confirmTone: 'primary',
+    })
+    if (confirmed) {
       onUnmarkRead(article)
     }
   }
 
   return (
-    <ArticleCardBase
-      article={article}
-      index={index}
-      theme="green"
-      extraMetadata={
-        article.read_at ? (
-          <span className="flex items-center text-green-400">
-            <svg className="w-4 h-4 mr-1.5" fill="currentColor" viewBox="0 0 24 24">
+    <>
+      <ArticleCardBase
+        article={article}
+        index={index}
+        theme="green"
+        extraMetadata={
+          article.read_at ? (
+            <span className="flex items-center text-green-400">
+              <svg className="w-4 h-4 mr-1.5" fill="currentColor" viewBox="0 0 24 24">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+              Read {formatBookmarkedDate(article.read_at)}
+            </span>
+          ) : undefined
+        }
+        actions={
+          <button
+            type="button"
+            className="group/read p-2 bg-gradient-to-r from-orange-600 to-orange-700 text-white rounded-lg transition-all duration-200 hover:from-orange-700 hover:to-orange-800 hover:scale-110 hover:shadow-lg hover:shadow-orange-500/25"
+            title="Mark as unread"
+            onClick={handleUnmark}
+          >
+            <svg
+              className="w-4 h-4 transition-transform group-hover/read:scale-110"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
               <path
                 strokeLinecap="round"
                 strokeLinejoin="round"
@@ -31,33 +64,11 @@ export default function ReadArticleCard({ article, index, onUnmarkRead }: ReadAr
                 d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
               />
             </svg>
-            Read {formatBookmarkedDate(article.read_at)}
-          </span>
-        ) : undefined
-      }
-      actions={
-        <button
-          type="button"
-          className="group/read p-2 bg-gradient-to-r from-orange-600 to-orange-700 text-white rounded-lg transition-all duration-200 hover:from-orange-700 hover:to-orange-800 hover:scale-110 hover:shadow-lg hover:shadow-orange-500/25"
-          title="Mark as unread"
-          onClick={handleUnmark}
-        >
-          <svg
-            className="w-4 h-4 transition-transform group-hover/read:scale-110"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-            />
-          </svg>
-        </button>
-      }
-      detailsHref={`/articles/${article.id}`}
-    />
+          </button>
+        }
+        detailsHref={`/articles/${article.id}`}
+      />
+      {dialog}
+    </>
   )
 }

--- a/app/frontend/hooks/useConfirmDialog.tsx
+++ b/app/frontend/hooks/useConfirmDialog.tsx
@@ -1,0 +1,49 @@
+import { useCallback, useState, type ReactNode } from 'react'
+import ConfirmDialog from '../components/ConfirmDialog'
+
+export interface ConfirmOptions {
+  title?: string
+  message: string
+  confirmLabel?: string
+  cancelLabel?: string
+  confirmTone?: 'danger' | 'primary'
+}
+
+interface PendingConfirm extends ConfirmOptions {
+  resolve: (value: boolean) => void
+}
+
+export function useConfirmDialog(): {
+  confirm: (options: ConfirmOptions) => Promise<boolean>
+  dialog: ReactNode
+} {
+  const [pending, setPending] = useState<PendingConfirm | null>(null)
+
+  const confirm = useCallback((options: ConfirmOptions) => {
+    return new Promise<boolean>((resolve) => {
+      setPending({ ...options, resolve })
+    })
+  }, [])
+
+  const close = useCallback((result: boolean) => {
+    setPending((current) => {
+      current?.resolve(result)
+      return null
+    })
+  }, [])
+
+  const dialog = pending ? (
+    <ConfirmDialog
+      open
+      title={pending.title}
+      message={pending.message}
+      confirmLabel={pending.confirmLabel}
+      cancelLabel={pending.cancelLabel}
+      confirmTone={pending.confirmTone}
+      onConfirm={() => close(true)}
+      onCancel={() => close(false)}
+    />
+  ) : null
+
+  return { confirm, dialog }
+}

--- a/app/frontend/pages/ArticleShowPage.tsx
+++ b/app/frontend/pages/ArticleShowPage.tsx
@@ -13,6 +13,7 @@ import {
   humanizeSourceType,
   safeExternalUrl,
 } from '../utils/format'
+import { useConfirmDialog } from '../hooks/useConfirmDialog'
 
 export default function ArticleShowPage() {
   const { id } = useParams<{ id: string }>()
@@ -22,6 +23,7 @@ export default function ArticleShowPage() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [actionError, setActionError] = useState<string | null>(null)
+  const { confirm, dialog } = useConfirmDialog()
 
   const loadArticle = useCallback(async () => {
     if (!articleId || Number.isNaN(articleId)) {
@@ -65,8 +67,12 @@ export default function ArticleShowPage() {
 
   const handleBookmarkToggle = async () => {
     if (!article) return
-    if (article.bookmarked && !window.confirm('Remove this article from your reading list?')) {
-      return
+    if (article.bookmarked) {
+      const confirmed = await confirm({
+        message: 'Remove this article from your reading list?',
+        confirmLabel: 'Remove',
+      })
+      if (!confirmed) return
     }
 
     setActionError(null)
@@ -258,6 +264,7 @@ export default function ArticleShowPage() {
           </div>
         </div>
       </article>
+      {dialog}
     </div>
   )
 }

--- a/app/frontend/pages/SourcesIndexPage.tsx
+++ b/app/frontend/pages/SourcesIndexPage.tsx
@@ -6,6 +6,7 @@ import {
   updateSource,
   type NewsSource,
 } from '../api/sources'
+import { useConfirmDialog } from '../hooks/useConfirmDialog'
 
 function sourceLabel(source: NewsSource): string {
   if (source.source_type === 'reddit') {
@@ -21,6 +22,7 @@ export default function SourcesIndexPage() {
   const [subredditInput, setSubredditInput] = useState('')
   const [adding, setAdding] = useState(false)
   const [validationError, setValidationError] = useState<string | null>(null)
+  const { confirm, dialog } = useConfirmDialog()
 
   const loadSources = useCallback(async () => {
     setLoading(true)
@@ -67,7 +69,11 @@ export default function SourcesIndexPage() {
   }
 
   const handleRemove = async (source: NewsSource) => {
-    if (!window.confirm(`Remove r/${source.subreddit ?? source.name} from sources?`)) return
+    const confirmed = await confirm({
+      message: `Remove r/${source.subreddit ?? source.name} from sources?`,
+      confirmLabel: 'Remove',
+    })
+    if (!confirmed) return
 
     try {
       await removeSource(source.id)
@@ -180,6 +186,7 @@ export default function SourcesIndexPage() {
           )}
         </div>
       </section>
+      {dialog}
     </div>
   )
 }

--- a/test/system/bookmark_functionality_test.rb
+++ b/test/system/bookmark_functionality_test.rb
@@ -125,8 +125,8 @@ class BookmarkFunctionalityTest < ApplicationSystemTestCase
 
     if page.has_selector?("article.article-card[data-source='reddit_rust']")
       within("article.article-card[data-source='reddit_rust']") do
-        page.execute_script("window.confirm = function() { return true; }")
         find("button[title='Remove from reading list']").click
+        find("[data-testid='confirm-dialog-confirm']").click
       end
       sleep 0.5
       assert_not @bookmarked_article.reload.bookmarked?

--- a/test/system/bookmark_functionality_test.rb
+++ b/test/system/bookmark_functionality_test.rb
@@ -110,9 +110,8 @@ class BookmarkFunctionalityTest < ApplicationSystemTestCase
     visit_article_show(@bookmarked_article)
 
     if page.has_button?("Remove from Reading List")
-      accept_confirm do
-        click_button "Remove from Reading List"
-      end
+      click_button "Remove from Reading List"
+      find("[data-testid='confirm-dialog-confirm']").click
       sleep 0.5
       assert_not @bookmarked_article.reload.bookmarked?
     else
@@ -126,8 +125,8 @@ class BookmarkFunctionalityTest < ApplicationSystemTestCase
     if page.has_selector?("article.article-card[data-source='reddit_rust']")
       within("article.article-card[data-source='reddit_rust']") do
         find("button[title='Remove from reading list']").click
-        find("[data-testid='confirm-dialog-confirm']").click
       end
+      find("[data-testid='confirm-dialog-confirm']").click
       sleep 0.5
       assert_not @bookmarked_article.reload.bookmarked?
     else

--- a/test/system/read_articles_functionality_test.rb
+++ b/test/system/read_articles_functionality_test.rb
@@ -138,10 +138,9 @@ class ReadArticlesFunctionalityTest < ApplicationSystemTestCase
     visit_read_articles_index
 
     within("article.article-card[data-source='#{@read_article.source_type}']") do
-      accept_confirm do
-        find("button[title='Mark as unread']").click
-      end
+      find("button[title='Mark as unread']").click
     end
+    find("[data-testid='confirm-dialog-confirm']").click
 
     sleep 0.5
     assert_not @read_article.reload.read?


### PR DESCRIPTION
## Summary
- Add accessible `ConfirmDialog` component with focus trap, Escape/backdrop dismiss, and `data-testid` hooks
- Add `useConfirmDialog` hook returning a promise-based `confirm()` API
- Replace all five `window.confirm` call sites (bookmark remove, unmark read, restore dismissed, article unbookmark, remove source)
- Update bookmark system test to click the in-app confirm button

## Test plan
- [x] `npm run typecheck`
- [x] `bin/rails test` (194 runs, 0 failures)
- [ ] CI green

Closes #177