### PR TITLE
perf(frontend): add route-level code splitting and AppLayout (#178)

### DIFF
--- a/app/frontend/components/App.tsx
+++ b/app/frontend/components/App.tsx
@@ -1,25 +1,33 @@
+import { lazy, Suspense } from 'react'
 import { BrowserRouter, Route, Routes } from 'react-router-dom'
-import ArticlesIndexPage from '../pages/ArticlesIndexPage'
-import ArticleShowPage from '../pages/ArticleShowPage'
-import BookmarksIndexPage from '../pages/BookmarksIndexPage'
-import DismissedArticlesIndexPage from '../pages/DismissedArticlesIndexPage'
-import ReadArticlesIndexPage from '../pages/ReadArticlesIndexPage'
-import RecentlyDismissedPage from '../pages/RecentlyDismissedPage'
-import SourcesIndexPage from '../pages/SourcesIndexPage'
+import AppLayout from './AppLayout'
+import RouteFallback from './RouteFallback'
+
+const ArticlesIndexPage = lazy(() => import('../pages/ArticlesIndexPage'))
+const ArticleShowPage = lazy(() => import('../pages/ArticleShowPage'))
+const BookmarksIndexPage = lazy(() => import('../pages/BookmarksIndexPage'))
+const DismissedArticlesIndexPage = lazy(() => import('../pages/DismissedArticlesIndexPage'))
+const ReadArticlesIndexPage = lazy(() => import('../pages/ReadArticlesIndexPage'))
+const RecentlyDismissedPage = lazy(() => import('../pages/RecentlyDismissedPage'))
+const SourcesIndexPage = lazy(() => import('../pages/SourcesIndexPage'))
 
 export default function App() {
   return (
     <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<ArticlesIndexPage />} />
-        <Route path="/articles" element={<ArticlesIndexPage />} />
-        <Route path="/articles/:id" element={<ArticleShowPage />} />
-        <Route path="/bookmarks" element={<BookmarksIndexPage />} />
-        <Route path="/read" element={<ReadArticlesIndexPage />} />
-        <Route path="/dismissed" element={<DismissedArticlesIndexPage />} />
-        <Route path="/recently_dismissed" element={<RecentlyDismissedPage />} />
-        <Route path="/sources" element={<SourcesIndexPage />} />
-      </Routes>
+      <Suspense fallback={<RouteFallback />}>
+        <Routes>
+          <Route element={<AppLayout />}>
+            <Route path="/" element={<ArticlesIndexPage />} />
+            <Route path="/articles" element={<ArticlesIndexPage />} />
+            <Route path="/articles/:id" element={<ArticleShowPage />} />
+            <Route path="/bookmarks" element={<BookmarksIndexPage />} />
+            <Route path="/read" element={<ReadArticlesIndexPage />} />
+            <Route path="/dismissed" element={<DismissedArticlesIndexPage />} />
+            <Route path="/recently_dismissed" element={<RecentlyDismissedPage />} />
+            <Route path="/sources" element={<SourcesIndexPage />} />
+          </Route>
+        </Routes>
+      </Suspense>
     </BrowserRouter>
   )
 }

--- a/app/frontend/components/AppLayout.tsx
+++ b/app/frontend/components/AppLayout.tsx
@@ -1,0 +1,17 @@
+import { Outlet } from 'react-router-dom'
+
+export default function AppLayout() {
+  return (
+    <>
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-primary-600 focus:text-white focus:rounded-lg"
+      >
+        Skip to main content
+      </a>
+      <main id="main-content">
+        <Outlet />
+      </main>
+    </>
+  )
+}

--- a/app/frontend/components/RouteFallback.tsx
+++ b/app/frontend/components/RouteFallback.tsx
@@ -1,0 +1,12 @@
+export default function RouteFallback() {
+  return (
+    <div
+      className="container mx-auto px-4 py-8 max-w-7xl text-center text-gray-400"
+      data-testid="route-loading"
+      role="status"
+      aria-live="polite"
+    >
+      Loading page...
+    </div>
+  )
+}

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -25,6 +25,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
       visit articles_path
     end
     assert_selector "[data-testid='articles-page']", wait: 12
+    assert_selector "main#main-content", wait: 12
     assert_no_text "Loading articles...", wait: 12
   end
 

--- a/test/integration/react_shell_test.rb
+++ b/test/integration/react_shell_test.rb
@@ -18,6 +18,19 @@ class ReactShellTest < ActionDispatch::IntegrationTest
     assert manifest.key?("entrypoints/application.tsx")
   end
 
+  test "vite test manifest lazy-loads route page chunks" do
+    manifest_path = Rails.root.join("public/vite-test/.vite/manifest.json")
+    skip "Run npm run build:test before this test" unless manifest_path.exist?
+
+    entry = JSON.parse(manifest_path.read).fetch("entrypoints/application.tsx")
+    dynamic_imports = entry.fetch("dynamicImports")
+
+    assert_includes dynamic_imports, "pages/ArticlesIndexPage.tsx"
+    assert_includes dynamic_imports, "pages/ArticleShowPage.tsx"
+    assert_includes dynamic_imports, "pages/BookmarksIndexPage.tsx"
+    assert_equal 7, dynamic_imports.size
+  end
+
   test "bookmarks index renders react mount point" do
     get bookmarks_path
 


### PR DESCRIPTION
Summary: lazy-load route pages with React.lazy and Suspense; add AppLayout with skip link and main#main-content. Tests: typecheck, full suite, manifest dynamicImports assertion. Closes #178