### PR TITLE
a11y(frontend): add aria semantics to controls and loading states (#172)

### DIFF
--- a/app/frontend/components/ArticleCard.tsx
+++ b/app/frontend/components/ArticleCard.tsx
@@ -37,6 +37,7 @@ export default function ArticleCard({
           type="button"
           className="group/dismiss p-1.5 text-gray-500 hover:text-red-400 hover:bg-red-400/10 rounded-lg transition-all duration-200 hover:scale-110"
           title="Dismiss article"
+          aria-label="Dismiss article"
           onClick={(event) => {
             event.stopPropagation()
             onDismiss(article)
@@ -67,6 +68,7 @@ export default function ArticleCard({
                 : 'group/bookmark p-2 bg-dark-700 border border-dark-600 text-gray-400 rounded-lg transition-all duration-200 hover:bg-primary-600 hover:border-primary-500 hover:text-white hover:scale-110 hover:shadow-lg hover:shadow-primary-500/25'
             }
             title={article.bookmarked ? 'Remove from reading list' : 'Add to reading list'}
+            aria-label={article.bookmarked ? 'Remove from reading list' : 'Add to reading list'}
             onClick={(event) => {
               event.stopPropagation()
               onBookmarkToggle(article)
@@ -95,6 +97,7 @@ export default function ArticleCard({
                 : 'group/read p-2 bg-dark-700 border border-dark-600 text-gray-400 rounded-lg transition-all duration-200 hover:bg-green-600 hover:border-green-500 hover:text-white hover:scale-110 hover:shadow-lg hover:shadow-green-500/25'
             }
             title={article.read ? 'Mark as unread' : 'Mark as read'}
+            aria-label={article.read ? 'Mark as unread' : 'Mark as read'}
             onClick={(event) => {
               event.stopPropagation()
               onReadToggle(article)

--- a/app/frontend/components/BookmarkCard.tsx
+++ b/app/frontend/components/BookmarkCard.tsx
@@ -53,6 +53,7 @@ export default function BookmarkCard({
                   : 'group/read p-2 bg-dark-700 border border-dark-600 text-gray-400 rounded-lg transition-all duration-200 hover:bg-green-600 hover:border-green-500 hover:text-white hover:scale-110 hover:shadow-lg hover:shadow-green-500/25'
               }
               title={article.read ? 'Mark as unread' : 'Mark as read'}
+              aria-label={article.read ? 'Mark as unread' : 'Mark as read'}
               onClick={() => onReadToggle(article)}
             >
               <svg
@@ -74,6 +75,7 @@ export default function BookmarkCard({
               type="button"
               className="group/bookmark p-2 bg-gradient-to-r from-red-600 to-red-700 text-white rounded-lg transition-all duration-200 hover:from-red-700 hover:to-red-800 hover:scale-110 hover:shadow-lg hover:shadow-red-500/25"
               title="Remove from reading list"
+              aria-label="Remove from reading list"
               onClick={handleRemove}
             >
               <svg

--- a/app/frontend/components/CategoryFilter.tsx
+++ b/app/frontend/components/CategoryFilter.tsx
@@ -36,6 +36,7 @@ export default function CategoryFilter({
             className={activeFilter === 'all' ? activeClasses : inactiveClasses}
             data-filter-type="all"
             data-filter-value="all"
+            aria-pressed={activeFilter === 'all'}
             onClick={() => onFilterChange('all')}
           >
             <span className="flex items-center">
@@ -53,6 +54,7 @@ export default function CategoryFilter({
                 className={activeFilter === slug ? activeClasses : inactiveClasses}
                 data-filter-type="category"
                 data-filter-value={slug}
+                aria-pressed={activeFilter === slug}
                 onClick={() => onFilterChange(slug)}
               >
                 <span className="flex items-center">

--- a/app/frontend/components/DismissToast.tsx
+++ b/app/frontend/components/DismissToast.tsx
@@ -6,7 +6,12 @@ interface DismissToastProps {
 
 export default function DismissToast({ articleTitle, timeLeft, onUndo }: DismissToastProps) {
   return (
-    <div className="dismiss-toast fixed top-4 right-4 bg-dark-800 border border-primary-500/30 rounded-xl p-4 shadow-2xl z-50 max-w-sm animate-slide-in">
+    <div
+      className="dismiss-toast fixed top-4 right-4 bg-dark-800 border border-primary-500/30 rounded-xl p-4 shadow-2xl z-50 max-w-sm animate-slide-in"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+    >
       <div className="flex items-center justify-between">
         <div className="flex-1 mr-4">
           <div className="text-primary-300 font-medium text-sm mb-1">Article dismissed</div>
@@ -16,6 +21,7 @@ export default function DismissToast({ articleTitle, timeLeft, onUndo }: Dismiss
           <button
             type="button"
             className="undo-btn px-4 py-2 bg-primary-600 hover:bg-primary-700 text-white text-sm font-medium rounded-lg transition-all duration-200 hover:scale-105"
+            aria-label="Undo dismiss"
             onClick={onUndo}
           >
             UNDO
@@ -24,9 +30,11 @@ export default function DismissToast({ articleTitle, timeLeft, onUndo }: Dismiss
       </div>
       <div className="mt-3 text-xs text-gray-500 flex items-center justify-between">
         <span>Ctrl+Z to undo</span>
-        <span className="countdown">{timeLeft}s remaining</span>
+        <span className="countdown" aria-hidden="true">
+          {timeLeft}s remaining
+        </span>
       </div>
-      <div className="mt-2 bg-dark-700 rounded-full h-1 overflow-hidden">
+      <div className="mt-2 bg-dark-700 rounded-full h-1 overflow-hidden" aria-hidden="true">
         <div
           className="countdown-bar bg-primary-500 h-full transition-all duration-1000"
           style={{ width: `${(timeLeft / 15) * 100}%` }}

--- a/app/frontend/components/PageShell.tsx
+++ b/app/frontend/components/PageShell.tsx
@@ -22,7 +22,13 @@ export default function PageShell({
 }: PageShellProps) {
   if (loading) {
     return (
-      <div className="container mx-auto px-4 py-8 max-w-7xl text-center text-gray-400" data-testid={testId}>
+      <div
+        className="container mx-auto px-4 py-8 max-w-7xl text-center text-gray-400"
+        data-testid={testId}
+        role="status"
+        aria-live="polite"
+        aria-busy="true"
+      >
         {loadingMessage}
       </div>
     )

--- a/app/frontend/components/ReadArticleCard.tsx
+++ b/app/frontend/components/ReadArticleCard.tsx
@@ -49,6 +49,7 @@ export default function ReadArticleCard({ article, index, onUnmarkRead }: ReadAr
             type="button"
             className="group/read p-2 bg-gradient-to-r from-orange-600 to-orange-700 text-white rounded-lg transition-all duration-200 hover:from-orange-700 hover:to-orange-800 hover:scale-110 hover:shadow-lg hover:shadow-orange-500/25"
             title="Mark as unread"
+            aria-label="Mark as unread"
             onClick={handleUnmark}
           >
             <svg

--- a/app/frontend/components/ScoreFilter.tsx
+++ b/app/frontend/components/ScoreFilter.tsx
@@ -29,6 +29,7 @@ export default function ScoreFilter({ activeScoreFilter, onScoreFilterChange }: 
             type="button"
             className={activeScoreFilter === option.value ? activeClasses : inactiveClasses}
             data-score-filter={option.value}
+            aria-pressed={activeScoreFilter === option.value}
             onClick={() => onScoreFilterChange(option.value)}
           >
             {option.label}

--- a/app/frontend/components/SourceFilter.tsx
+++ b/app/frontend/components/SourceFilter.tsx
@@ -34,6 +34,7 @@ export default function SourceFilter({
             type="button"
             className={activeSource === 'all' ? activeClasses : inactiveClasses}
             data-source="all"
+            aria-pressed={activeSource === 'all'}
             onClick={() => onSourceChange('all')}
           >
             <span className="flex items-center">
@@ -47,6 +48,7 @@ export default function SourceFilter({
               type="button"
               className={activeSource === source ? activeClasses : inactiveClasses}
               data-source={source}
+              aria-pressed={activeSource === source}
               onClick={() => onSourceChange(source)}
             >
               {humanizeSourceType(source)} ({sourceCounts[source] ?? 0})

--- a/app/frontend/pages/ArticleShowPage.tsx
+++ b/app/frontend/pages/ArticleShowPage.tsx
@@ -91,7 +91,13 @@ export default function ArticleShowPage() {
 
   if (loading) {
     return (
-      <div className="container mx-auto px-4 py-8 max-w-4xl text-center text-gray-400" data-testid="article-show-page">
+      <div
+        className="container mx-auto px-4 py-8 max-w-4xl text-center text-gray-400"
+        data-testid="article-show-page"
+        role="status"
+        aria-live="polite"
+        aria-busy="true"
+      >
         Loading article...
       </div>
     )


### PR DESCRIPTION
Adds aria-label to icon-only card buttons, aria-pressed on filter toggles, live region on DismissToast, and aria-busy on loading states. Closes #172