### PR TITLE
feat(frontend): use React Router Link and NavLink for internal navigation (#160)

### DIFF
--- a/app/frontend/components/ArticleCardBase.tsx
+++ b/app/frontend/components/ArticleCardBase.tsx
@@ -1,4 +1,5 @@
 import type { CSSProperties, MouseEvent, ReactNode } from 'react'
+import { Link } from 'react-router-dom'
 import {
   formatPublishedDate,
   humanizeSourceType,
@@ -223,8 +224,8 @@ export default function ArticleCardBase({
         <div className="flex items-center space-x-3">
           {actions}
           {detailsHref && (
-            <a
-              href={detailsHref}
+            <Link
+              to={detailsHref}
               className={`group/detail px-4 py-2 bg-gradient-to-r from-dark-700 to-dark-600 border border-dark-500 text-gray-300 rounded-lg font-medium transition-all duration-200 ${styles.detailsHover} hover:text-white hover:scale-105 hover:shadow-lg`}
               onClick={stopPropagation}
             >
@@ -244,7 +245,7 @@ export default function ArticleCardBase({
                   />
                 </svg>
               </span>
-            </a>
+            </Link>
           )}
         </div>
       </div>

--- a/app/frontend/components/EmptyState.tsx
+++ b/app/frontend/components/EmptyState.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react'
+import { Link } from 'react-router-dom'
 
 interface EmptyStateAction {
   href: string
@@ -40,10 +41,10 @@ export default function EmptyState({
           }
         >
           {actions.map((action) => (
-            <a key={`${action.href}-${action.label}`} href={action.href} className={action.className}>
+            <Link key={`${action.href}-${action.label}`} to={action.href} className={action.className}>
               {action.icon}
               {action.label}
-            </a>
+            </Link>
           ))}
         </div>
       )}

--- a/app/frontend/components/PageHeader.tsx
+++ b/app/frontend/components/PageHeader.tsx
@@ -1,3 +1,4 @@
+import { NavLink } from 'react-router-dom'
 import { formatLastUpdated } from '../utils/format'
 
 interface PageHeaderProps {
@@ -8,6 +9,11 @@ interface PageHeaderProps {
   onFetchNews?: () => void
   fetchingNews?: boolean
   fetchMessage?: string | null
+}
+
+function navLinkClassName(base: string) {
+  return ({ isActive }: { isActive: boolean }) =>
+    isActive ? `${base} ring-2 ring-white/30` : base
 }
 
 export default function PageHeader({
@@ -46,39 +52,47 @@ export default function PageHeader({
               {fetchingNews ? 'Fetching...' : 'Fetch News'}
             </button>
           )}
-          <a
-            href="/sources"
-            className="group flex items-center px-4 py-2 bg-gradient-to-r from-purple-600 to-purple-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-purple-700 hover:to-purple-800 hover:scale-105 hover:shadow-lg hover:shadow-purple-500/25"
+          <NavLink
+            to="/sources"
+            className={navLinkClassName(
+              'group flex items-center px-4 py-2 bg-gradient-to-r from-purple-600 to-purple-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-purple-700 hover:to-purple-800 hover:scale-105 hover:shadow-lg hover:shadow-purple-500/25'
+            )}
           >
             Sources
-          </a>
-          <a
-            href="/bookmarks"
-            className="group flex items-center px-4 py-2 bg-gradient-to-r from-primary-600 to-primary-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-primary-700 hover:to-primary-800 hover:scale-105 hover:shadow-lg hover:shadow-primary-500/25"
+          </NavLink>
+          <NavLink
+            to="/bookmarks"
+            className={navLinkClassName(
+              'group flex items-center px-4 py-2 bg-gradient-to-r from-primary-600 to-primary-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-primary-700 hover:to-primary-800 hover:scale-105 hover:shadow-lg hover:shadow-primary-500/25'
+            )}
           >
             <svg className="w-4 h-4 mr-2 transition-transform group-hover:scale-110" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
             </svg>
             Reading List
-          </a>
-          <a
-            href="/read"
-            className="group flex items-center px-4 py-2 bg-gradient-to-r from-green-600 to-green-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-green-700 hover:to-green-800 hover:scale-105 hover:shadow-lg hover:shadow-green-500/25"
+          </NavLink>
+          <NavLink
+            to="/read"
+            className={navLinkClassName(
+              'group flex items-center px-4 py-2 bg-gradient-to-r from-green-600 to-green-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-green-700 hover:to-green-800 hover:scale-105 hover:shadow-lg hover:shadow-green-500/25'
+            )}
           >
             <svg className="w-4 h-4 mr-2 transition-transform group-hover:scale-110" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
             Already Read
-          </a>
-          <a
-            href="/recently_dismissed"
-            className="group flex items-center px-4 py-2 bg-gradient-to-r from-orange-600 to-orange-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-orange-700 hover:to-orange-800 hover:scale-105 hover:shadow-lg hover:shadow-orange-500/25"
+          </NavLink>
+          <NavLink
+            to="/recently_dismissed"
+            className={navLinkClassName(
+              'group flex items-center px-4 py-2 bg-gradient-to-r from-orange-600 to-orange-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-orange-700 hover:to-orange-800 hover:scale-105 hover:shadow-lg hover:shadow-orange-500/25'
+            )}
           >
             <svg className="w-4 h-4 mr-2 transition-transform group-hover:scale-110" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
             Recently Dismissed
-          </a>
+          </NavLink>
           {onShowReadChange && (
             <label className="flex items-center gap-2 text-sm text-gray-400 cursor-pointer">
               <input

--- a/app/frontend/pages/ArticleShowPage.tsx
+++ b/app/frontend/pages/ArticleShowPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { Link, useParams } from 'react-router-dom'
 import {
   bookmarkArticle,
   fetchArticle,
@@ -107,12 +107,12 @@ export default function ArticleShowPage() {
     return (
       <div className="container mx-auto px-4 py-8 max-w-4xl text-center" data-testid="article-show-page">
         <p className="text-red-400 mb-4">{error ?? 'Article not found.'}</p>
-        <a
-          href="/articles"
+        <Link
+          to="/articles"
           className="inline-flex items-center px-4 py-2 bg-primary-600 text-white rounded-lg"
         >
           Back to Articles
-        </a>
+        </Link>
       </div>
     )
   }
@@ -122,15 +122,15 @@ export default function ArticleShowPage() {
   return (
     <div className="container mx-auto px-4 py-8 max-w-4xl" data-testid="article-show-page">
       <div className="mb-8 animate-fade-in">
-        <a
-          href="/articles"
+        <Link
+          to="/articles"
           className="group inline-flex items-center px-4 py-2 bg-gradient-to-r from-dark-700 to-dark-600 border border-dark-500 text-gray-300 rounded-xl font-medium transition-all duration-200 hover:from-primary-600 hover:to-primary-700 hover:border-primary-500 hover:text-white hover:scale-105 hover:shadow-lg hover:shadow-primary-500/25"
         >
           <svg className="w-4 h-4 mr-2 transition-transform group-hover:scale-110" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
           </svg>
           Back to Articles
-        </a>
+        </Link>
       </div>
 
       <article className="glass-effect rounded-2xl p-8 md:p-12 animate-slide-up">

--- a/app/frontend/pages/BookmarksIndexPage.tsx
+++ b/app/frontend/pages/BookmarksIndexPage.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import { Link } from 'react-router-dom'
 import { fetchBookmarks } from '../api/bookmarks'
 import {
   markArticleAsRead,
@@ -106,15 +107,15 @@ export default function BookmarksIndexPage() {
             <p className="text-gray-400 text-lg">Your curated collection of bookmarked articles</p>
           </div>
           <div className="flex items-center space-x-6">
-            <a
-              href="/articles"
+            <Link
+              to="/articles"
               className="group flex items-center px-4 py-3 bg-gradient-to-r from-dark-700 to-dark-600 border border-dark-500 text-gray-300 rounded-xl font-medium transition-all duration-200 hover:from-primary-600 hover:to-primary-700 hover:border-primary-500 hover:text-white hover:scale-105 hover:shadow-lg hover:shadow-primary-500/25"
             >
               <svg className="w-5 h-5 mr-2 transition-transform group-hover:scale-110" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9.5a2.5 2.5 0 00-2.5-2.5H15" />
               </svg>
               Back to All Articles
-            </a>
+            </Link>
             <div className="text-sm text-gray-400">
               <div className="flex items-center space-x-2">
                 <span className="w-2 h-2 bg-primary-500 rounded-full animate-pulse" />

--- a/app/frontend/pages/DismissedArticlesIndexPage.tsx
+++ b/app/frontend/pages/DismissedArticlesIndexPage.tsx
@@ -1,6 +1,7 @@
 import { undismissArticle } from '../api/articles'
 import { fetchDismissedArticles } from '../api/dismissedArticles'
 import type { DismissedArticle } from '../types/dismissedArticle'
+import { Link, NavLink } from 'react-router-dom'
 import DismissedArticlesList from '../components/DismissedArticlesList'
 import PageShell from '../components/PageShell'
 import EmptyState from '../components/EmptyState'
@@ -52,24 +53,29 @@ export default function DismissedArticlesIndexPage() {
             <p className="text-gray-400 text-lg">Articles you&apos;ve dismissed from your feed</p>
           </div>
           <div className="flex items-center space-x-4">
-            <a
-              href="/articles"
+            <Link
+              to="/articles"
               className="group flex items-center px-4 py-2 bg-gradient-to-r from-primary-600 to-primary-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-primary-700 hover:to-primary-800 hover:scale-105 hover:shadow-lg hover:shadow-primary-500/25"
             >
               <svg className="w-4 h-4 mr-2 transition-transform group-hover:scale-110" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
               </svg>
               Back to All Articles
-            </a>
-            <a
-              href="/recently_dismissed"
-              className="group flex items-center px-4 py-2 bg-gradient-to-r from-orange-600 to-orange-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-orange-700 hover:to-orange-800 hover:scale-105 hover:shadow-lg hover:shadow-orange-500/25"
+            </Link>
+            <NavLink
+              to="/recently_dismissed"
+              className={({ isActive }) =>
+                [
+                  'group flex items-center px-4 py-2 bg-gradient-to-r from-orange-600 to-orange-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-orange-700 hover:to-orange-800 hover:scale-105 hover:shadow-lg hover:shadow-orange-500/25',
+                  isActive ? 'ring-2 ring-white/30' : '',
+                ].join(' ')
+              }
             >
               <svg className="w-4 h-4 mr-2 transition-transform group-hover:scale-110" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
               Recently Dismissed
-            </a>
+            </NavLink>
           </div>
         </div>
       </div>

--- a/app/frontend/pages/ReadArticlesIndexPage.tsx
+++ b/app/frontend/pages/ReadArticlesIndexPage.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import { Link } from 'react-router-dom'
 import { unmarkArticleAsRead } from '../api/articles'
 import { fetchReadArticles } from '../api/readArticles'
 import type { ReadArticle } from '../types/readArticle'
@@ -70,15 +71,15 @@ export default function ReadArticlesIndexPage() {
             <p className="text-gray-400 text-lg">Articles you&apos;ve finished reading</p>
           </div>
           <div className="flex items-center space-x-6">
-            <a
-              href="/articles"
+            <Link
+              to="/articles"
               className="group flex items-center px-4 py-3 bg-gradient-to-r from-dark-700 to-dark-600 border border-dark-500 text-gray-300 rounded-xl font-medium transition-all duration-200 hover:from-primary-600 hover:to-primary-700 hover:border-primary-500 hover:text-white hover:scale-105 hover:shadow-lg hover:shadow-primary-500/25"
             >
               <svg className="w-5 h-5 mr-2 transition-transform group-hover:scale-110" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9.5a2.5 2.5 0 00-2.5-2.5H15" />
               </svg>
               Back to All Articles
-            </a>
+            </Link>
             <div className="text-sm text-gray-400">
               <div className="flex items-center space-x-2">
                 <span className="w-2 h-2 bg-green-500 rounded-full animate-pulse" />

--- a/app/frontend/pages/RecentlyDismissedPage.tsx
+++ b/app/frontend/pages/RecentlyDismissedPage.tsx
@@ -1,6 +1,7 @@
 import { undismissArticle } from '../api/articles'
 import { fetchRecentlyDismissed } from '../api/dismissedArticles'
 import type { DismissedArticle } from '../types/dismissedArticle'
+import { Link, NavLink } from 'react-router-dom'
 import DismissedArticlesList from '../components/DismissedArticlesList'
 import PageShell from '../components/PageShell'
 import EmptyState from '../components/EmptyState'
@@ -47,24 +48,29 @@ export default function RecentlyDismissedPage() {
             <p className="text-gray-400 text-lg">Articles dismissed in the last 24 hours - easy to restore</p>
           </div>
           <div className="flex items-center space-x-4">
-            <a
-              href="/articles"
+            <Link
+              to="/articles"
               className="group flex items-center px-4 py-2 bg-gradient-to-r from-primary-600 to-primary-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-primary-700 hover:to-primary-800 hover:scale-105 hover:shadow-lg hover:shadow-primary-500/25"
             >
               <svg className="w-4 h-4 mr-2 transition-transform group-hover:scale-110" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
               </svg>
               Back to All Articles
-            </a>
-            <a
-              href="/dismissed"
-              className="group flex items-center px-4 py-2 bg-gradient-to-r from-red-600 to-red-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-red-700 hover:to-red-800 hover:scale-105 hover:shadow-lg hover:shadow-red-500/25"
+            </Link>
+            <NavLink
+              to="/dismissed"
+              className={({ isActive }) =>
+                [
+                  'group flex items-center px-4 py-2 bg-gradient-to-r from-red-600 to-red-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-red-700 hover:to-red-800 hover:scale-105 hover:shadow-lg hover:shadow-red-500/25',
+                  isActive ? 'ring-2 ring-white/30' : '',
+                ].join(' ')
+              }
             >
               <svg className="w-4 h-4 mr-2 transition-transform group-hover:scale-110" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
               </svg>
               All Dismissed
-            </a>
+            </NavLink>
           </div>
         </div>
       </div>

--- a/app/frontend/pages/SourcesIndexPage.tsx
+++ b/app/frontend/pages/SourcesIndexPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
 import {
   addRedditSource,
   fetchSources,
@@ -102,9 +103,9 @@ export default function SourcesIndexPage() {
             <h1 className="text-3xl font-bold text-gray-100 mb-2">News Sources</h1>
             <p className="text-gray-400">Enable or disable sources and manage Reddit subreddits.</p>
           </div>
-          <a href="/" className="px-4 py-2 bg-dark-700 border border-dark-600 text-gray-300 rounded-xl hover:bg-dark-600">
+          <Link to="/articles" className="px-4 py-2 bg-dark-700 border border-dark-600 text-gray-300 rounded-xl hover:bg-dark-600">
             Back to Articles
-          </a>
+          </Link>
         </div>
       </div>
 


### PR DESCRIPTION
Replaces internal anchor tags with Link and NavLink for client-side SPA navigation without full page reloads. Closes #160