### PR TITLE
feat(frontend): add persistent app shell with global navigation (#155)

### DIFF
--- a/app/frontend/components/AppLayout.tsx
+++ b/app/frontend/components/AppLayout.tsx
@@ -1,4 +1,5 @@
 import { Outlet } from 'react-router-dom'
+import AppShell from './AppShell'
 
 export default function AppLayout() {
   return (
@@ -9,9 +10,11 @@ export default function AppLayout() {
       >
         Skip to main content
       </a>
-      <main id="main-content">
-        <Outlet />
-      </main>
+      <AppShell>
+        <main id="main-content" className="flex-1 pb-20 md:pb-0">
+          <Outlet />
+        </main>
+      </AppShell>
     </>
   )
 }

--- a/app/frontend/components/AppShell.test.tsx
+++ b/app/frontend/components/AppShell.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+import AppShell from './AppShell'
+
+function renderShell(initialPath = '/') {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <AppShell>
+        <div>Page content</div>
+      </AppShell>
+    </MemoryRouter>
+  )
+}
+
+describe('AppShell', () => {
+  it('renders desktop nav with all main sections', () => {
+    renderShell()
+    const nav = screen.getByTestId('app-nav')
+    expect(nav).toBeInTheDocument()
+    expect(screen.getByTestId('app-nav-feed')).toHaveTextContent('Feed')
+    expect(screen.getByTestId('app-nav-saved')).toHaveTextContent('Reading List')
+    expect(screen.getByTestId('app-nav-read')).toHaveTextContent('Already Read')
+    expect(screen.getByTestId('app-nav-dismissed')).toHaveTextContent('Recently Dismissed')
+  })
+
+  it('highlights Feed on articles index', () => {
+    renderShell('/articles')
+    expect(screen.getByTestId('app-nav-feed').className).toMatch(/primary/)
+  })
+
+  it('highlights Reading List on bookmarks page', () => {
+    renderShell('/bookmarks')
+    expect(screen.getByTestId('app-nav-saved').className).toMatch(/primary/)
+  })
+
+  it('highlights Dismissed on all dismissed page', () => {
+    renderShell('/dismissed')
+    expect(screen.getByTestId('app-nav-dismissed').className).toMatch(/primary/)
+  })
+
+  it('renders mobile bottom nav', () => {
+    renderShell()
+    expect(screen.getByTestId('app-nav-mobile')).toBeInTheDocument()
+    expect(screen.getByTestId('app-nav-mobile-feed')).toBeInTheDocument()
+  })
+})

--- a/app/frontend/components/AppShell.tsx
+++ b/app/frontend/components/AppShell.tsx
@@ -1,0 +1,143 @@
+import type { ReactNode } from 'react'
+import { NavLink, useLocation } from 'react-router-dom'
+
+interface NavItem {
+  to: string
+  label: string
+  shortLabel: string
+  isActive: (pathname: string) => boolean
+  icon: ReactNode
+}
+
+const navItems: NavItem[] = [
+  {
+    to: '/',
+    label: 'Feed',
+    shortLabel: 'Feed',
+    isActive: (pathname) => pathname === '/' || pathname === '/articles',
+    icon: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9.5a2.5 2.5 0 00-2.5-2.5H15" />
+      </svg>
+    ),
+  },
+  {
+    to: '/bookmarks',
+    label: 'Reading List',
+    shortLabel: 'Saved',
+    isActive: (pathname) => pathname.startsWith('/bookmarks'),
+    icon: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
+      </svg>
+    ),
+  },
+  {
+    to: '/read',
+    label: 'Already Read',
+    shortLabel: 'Read',
+    isActive: (pathname) => pathname.startsWith('/read'),
+    icon: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+    ),
+  },
+  {
+    to: '/recently_dismissed',
+    label: 'Recently Dismissed',
+    shortLabel: 'Dismissed',
+    isActive: (pathname) =>
+      pathname.startsWith('/recently_dismissed') || pathname.startsWith('/dismissed'),
+    icon: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+    ),
+  },
+]
+
+function desktopLinkClassName(isActive: boolean) {
+  return [
+    'px-3 py-2 rounded-lg text-sm font-medium transition-colors duration-200',
+    isActive
+      ? 'bg-primary-600/20 text-primary-300 ring-1 ring-primary-500/40'
+      : 'text-gray-400 hover:text-gray-200 hover:bg-dark-700/60',
+  ].join(' ')
+}
+
+function mobileLinkClassName(isActive: boolean) {
+  return [
+    'flex flex-1 flex-col items-center justify-center gap-1 py-2 text-xs font-medium transition-colors duration-200',
+    isActive ? 'text-primary-400' : 'text-gray-500 hover:text-gray-300',
+  ].join(' ')
+}
+
+interface AppShellProps {
+  children: ReactNode
+}
+
+export default function AppShell({ children }: AppShellProps) {
+  const { pathname } = useLocation()
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <header className="sticky top-0 z-40 glass-effect border-b border-dark-700/50">
+        <div className="container mx-auto px-4 max-w-7xl">
+          <div className="hidden md:flex items-center justify-between h-14">
+            <NavLink
+              to="/"
+              className="text-lg font-bold bg-gradient-to-r from-primary-400 to-primary-600 bg-clip-text text-transparent shrink-0"
+            >
+              Dev News
+            </NavLink>
+            <nav aria-label="Main navigation" data-testid="app-nav" className="flex items-center gap-1">
+              {navItems.map((item) => (
+                <NavLink
+                  key={item.to}
+                  to={item.to}
+                  end={item.to === '/'}
+                  className={() => desktopLinkClassName(item.isActive(pathname))}
+                  data-testid={`app-nav-${item.shortLabel.toLowerCase()}`}
+                >
+                  {item.label}
+                </NavLink>
+              ))}
+            </nav>
+          </div>
+          <div className="flex md:hidden items-center justify-center h-12">
+            <NavLink
+              to="/"
+              className="text-base font-bold bg-gradient-to-r from-primary-400 to-primary-600 bg-clip-text text-transparent"
+            >
+              Dev News
+            </NavLink>
+          </div>
+        </div>
+      </header>
+
+      {children}
+
+      <nav
+        aria-label="Main navigation"
+        data-testid="app-nav-mobile"
+        className="md:hidden fixed bottom-0 inset-x-0 z-40 glass-effect border-t border-dark-700/50 safe-area-pb"
+      >
+        <div className="flex items-stretch h-16">
+          {navItems.map((item) => (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              end={item.to === '/'}
+              className={() => mobileLinkClassName(item.isActive(pathname))}
+              data-testid={`app-nav-mobile-${item.shortLabel.toLowerCase()}`}
+            >
+              {item.icon}
+              <span>{item.shortLabel}</span>
+            </NavLink>
+          ))}
+        </div>
+      </nav>
+    </div>
+  )
+}

--- a/app/frontend/components/PageHeader.tsx
+++ b/app/frontend/components/PageHeader.tsx
@@ -60,39 +60,6 @@ export default function PageHeader({
           >
             Sources
           </NavLink>
-          <NavLink
-            to="/bookmarks"
-            className={navLinkClassName(
-              'group flex items-center px-4 py-2 bg-gradient-to-r from-primary-600 to-primary-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-primary-700 hover:to-primary-800 hover:scale-105 hover:shadow-lg hover:shadow-primary-500/25'
-            )}
-          >
-            <svg className="w-4 h-4 mr-2 transition-transform group-hover:scale-110" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
-            </svg>
-            Reading List
-          </NavLink>
-          <NavLink
-            to="/read"
-            className={navLinkClassName(
-              'group flex items-center px-4 py-2 bg-gradient-to-r from-green-600 to-green-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-green-700 hover:to-green-800 hover:scale-105 hover:shadow-lg hover:shadow-green-500/25'
-            )}
-          >
-            <svg className="w-4 h-4 mr-2 transition-transform group-hover:scale-110" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-            Already Read
-          </NavLink>
-          <NavLink
-            to="/recently_dismissed"
-            className={navLinkClassName(
-              'group flex items-center px-4 py-2 bg-gradient-to-r from-orange-600 to-orange-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-orange-700 hover:to-orange-800 hover:scale-105 hover:shadow-lg hover:shadow-orange-500/25'
-            )}
-          >
-            <svg className="w-4 h-4 mr-2 transition-transform group-hover:scale-110" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-            Recently Dismissed
-          </NavLink>
           {onShowReadChange && (
             <label className="flex items-center gap-2 text-sm text-gray-400 cursor-pointer">
               <input

--- a/app/frontend/components/PageHeading.tsx
+++ b/app/frontend/components/PageHeading.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from 'react'
+
+interface PageHeadingProps {
+  title: string
+  subtitle?: string
+  titleClassName?: string
+  actions?: ReactNode
+  meta?: ReactNode
+}
+
+export default function PageHeading({
+  title,
+  subtitle,
+  titleClassName = 'bg-gradient-to-r from-primary-400 to-primary-600 bg-clip-text text-transparent',
+  actions,
+  meta,
+}: PageHeadingProps) {
+  return (
+    <div className="glass-effect rounded-2xl p-6 md:p-8 mb-8 animate-fade-in">
+      <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 md:gap-6">
+        <div>
+          <h1 className={`text-3xl md:text-4xl font-bold mb-2 ${titleClassName}`}>{title}</h1>
+          {subtitle && <p className="text-gray-400 text-base md:text-lg">{subtitle}</p>}
+        </div>
+        {(actions || meta) && (
+          <div className="flex flex-wrap items-center gap-3 md:gap-4">
+            {actions}
+            {meta}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/frontend/pages/ArticleShowPage.tsx
+++ b/app/frontend/pages/ArticleShowPage.tsx
@@ -107,12 +107,6 @@ export default function ArticleShowPage() {
     return (
       <div className="container mx-auto px-4 py-8 max-w-4xl text-center" data-testid="article-show-page">
         <p className="text-red-400 mb-4">{error ?? 'Article not found.'}</p>
-        <Link
-          to="/articles"
-          className="inline-flex items-center px-4 py-2 bg-primary-600 text-white rounded-lg"
-        >
-          Back to Articles
-        </Link>
       </div>
     )
   }
@@ -121,18 +115,6 @@ export default function ArticleShowPage() {
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-4xl" data-testid="article-show-page">
-      <div className="mb-8 animate-fade-in">
-        <Link
-          to="/articles"
-          className="group inline-flex items-center px-4 py-2 bg-gradient-to-r from-dark-700 to-dark-600 border border-dark-500 text-gray-300 rounded-xl font-medium transition-all duration-200 hover:from-primary-600 hover:to-primary-700 hover:border-primary-500 hover:text-white hover:scale-105 hover:shadow-lg hover:shadow-primary-500/25"
-        >
-          <svg className="w-4 h-4 mr-2 transition-transform group-hover:scale-110" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
-          </svg>
-          Back to Articles
-        </Link>
-      </div>
-
       <article className="glass-effect rounded-2xl p-8 md:p-12 animate-slide-up">
         <div className="mb-8">
           <div className="flex flex-wrap items-center gap-4 mb-6">

--- a/app/frontend/pages/BookmarksIndexPage.tsx
+++ b/app/frontend/pages/BookmarksIndexPage.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from 'react'
-import { Link } from 'react-router-dom'
 import { fetchBookmarks } from '../api/bookmarks'
 import {
   markArticleAsRead,
@@ -10,6 +9,7 @@ import type { BookmarkArticle } from '../types/bookmark'
 import BookmarksList from '../components/BookmarksList'
 import SourceFilter from '../components/SourceFilter'
 import PageShell from '../components/PageShell'
+import PageHeading from '../components/PageHeading'
 import EmptyState from '../components/EmptyState'
 import { useAsyncResource } from '../hooks/useAsyncResource'
 import { useSearchParam } from '../hooks/useSearchParamState'
@@ -98,35 +98,20 @@ export default function BookmarksIndexPage() {
       showFatalError={articles.length === 0 && totalCount === 0}
       onRetry={reload}
     >
-      <div className="glass-effect rounded-2xl p-8 mb-8 animate-fade-in">
-        <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-6">
-          <div>
-            <h1 className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-primary-400 to-primary-600 bg-clip-text text-transparent mb-2">
-              Reading List
-            </h1>
-            <p className="text-gray-400 text-lg">Your curated collection of bookmarked articles</p>
-          </div>
-          <div className="flex items-center space-x-6">
-            <Link
-              to="/articles"
-              className="group flex items-center px-4 py-3 bg-gradient-to-r from-dark-700 to-dark-600 border border-dark-500 text-gray-300 rounded-xl font-medium transition-all duration-200 hover:from-primary-600 hover:to-primary-700 hover:border-primary-500 hover:text-white hover:scale-105 hover:shadow-lg hover:shadow-primary-500/25"
-            >
-              <svg className="w-5 h-5 mr-2 transition-transform group-hover:scale-110" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9.5a2.5 2.5 0 00-2.5-2.5H15" />
-              </svg>
-              Back to All Articles
-            </Link>
-            <div className="text-sm text-gray-400">
-              <div className="flex items-center space-x-2">
-                <span className="w-2 h-2 bg-primary-500 rounded-full animate-pulse" />
-                <span>
-                  Bookmarked: <span className="text-primary-400 font-semibold">{articles.length}</span> articles
-                </span>
-              </div>
+      <PageHeading
+        title="Reading List"
+        subtitle="Your curated collection of bookmarked articles"
+        meta={
+          <div className="text-sm text-gray-400">
+            <div className="flex items-center space-x-2">
+              <span className="w-2 h-2 bg-primary-500 rounded-full animate-pulse" />
+              <span>
+                Bookmarked: <span className="text-primary-400 font-semibold">{articles.length}</span> articles
+              </span>
             </div>
           </div>
-        </div>
-      </div>
+        }
+      />
 
       {error && <div className="mb-4 text-sm text-red-400">{error}</div>}
 

--- a/app/frontend/pages/DismissedArticlesIndexPage.tsx
+++ b/app/frontend/pages/DismissedArticlesIndexPage.tsx
@@ -1,9 +1,10 @@
 import { undismissArticle } from '../api/articles'
 import { fetchDismissedArticles } from '../api/dismissedArticles'
 import type { DismissedArticle } from '../types/dismissedArticle'
-import { Link, NavLink } from 'react-router-dom'
+import { NavLink } from 'react-router-dom'
 import DismissedArticlesList from '../components/DismissedArticlesList'
 import PageShell from '../components/PageShell'
+import PageHeading from '../components/PageHeading'
 import EmptyState from '../components/EmptyState'
 import { useAsyncResource } from '../hooks/useAsyncResource'
 
@@ -44,41 +45,27 @@ export default function DismissedArticlesIndexPage() {
       showFatalError={articles.length === 0 && totalCount === 0}
       onRetry={reload}
     >
-      <div className="glass-effect rounded-2xl p-8 mb-8 animate-fade-in">
-        <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-6">
-          <div>
-            <h1 className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-red-400 to-red-600 bg-clip-text text-transparent mb-2">
-              Dismissed Articles
-            </h1>
-            <p className="text-gray-400 text-lg">Articles you&apos;ve dismissed from your feed</p>
-          </div>
-          <div className="flex items-center space-x-4">
-            <Link
-              to="/articles"
-              className="group flex items-center px-4 py-2 bg-gradient-to-r from-primary-600 to-primary-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-primary-700 hover:to-primary-800 hover:scale-105 hover:shadow-lg hover:shadow-primary-500/25"
-            >
-              <svg className="w-4 h-4 mr-2 transition-transform group-hover:scale-110" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
-              </svg>
-              Back to All Articles
-            </Link>
-            <NavLink
-              to="/recently_dismissed"
-              className={({ isActive }) =>
-                [
-                  'group flex items-center px-4 py-2 bg-gradient-to-r from-orange-600 to-orange-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-orange-700 hover:to-orange-800 hover:scale-105 hover:shadow-lg hover:shadow-orange-500/25',
-                  isActive ? 'ring-2 ring-white/30' : '',
-                ].join(' ')
-              }
-            >
-              <svg className="w-4 h-4 mr-2 transition-transform group-hover:scale-110" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-              Recently Dismissed
-            </NavLink>
-          </div>
-        </div>
-      </div>
+      <PageHeading
+        title="Dismissed Articles"
+        subtitle="Articles you've dismissed from your feed"
+        titleClassName="bg-gradient-to-r from-red-400 to-red-600 bg-clip-text text-transparent"
+        actions={
+          <NavLink
+            to="/recently_dismissed"
+            className={({ isActive }) =>
+              [
+                'group flex items-center px-4 py-2 bg-gradient-to-r from-orange-600 to-orange-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-orange-700 hover:to-orange-800 hover:scale-105 hover:shadow-lg hover:shadow-orange-500/25',
+                isActive ? 'ring-2 ring-white/30' : '',
+              ].join(' ')
+            }
+          >
+            <svg className="w-4 h-4 mr-2 transition-transform group-hover:scale-110" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            Recently Dismissed
+          </NavLink>
+        }
+      />
 
       {error && <div className="mb-4 text-sm text-red-400">{error}</div>}
 

--- a/app/frontend/pages/ReadArticlesIndexPage.tsx
+++ b/app/frontend/pages/ReadArticlesIndexPage.tsx
@@ -1,11 +1,11 @@
 import { useMemo } from 'react'
-import { Link } from 'react-router-dom'
 import { unmarkArticleAsRead } from '../api/articles'
 import { fetchReadArticles } from '../api/readArticles'
 import type { ReadArticle } from '../types/readArticle'
 import ReadArticlesList from '../components/ReadArticlesList'
 import SourceFilter from '../components/SourceFilter'
 import PageShell from '../components/PageShell'
+import PageHeading from '../components/PageHeading'
 import EmptyState from '../components/EmptyState'
 import { useAsyncResource } from '../hooks/useAsyncResource'
 import { useSearchParam } from '../hooks/useSearchParamState'
@@ -62,35 +62,21 @@ export default function ReadArticlesIndexPage() {
       showFatalError={articles.length === 0 && totalCount === 0}
       onRetry={reload}
     >
-      <div className="glass-effect rounded-2xl p-8 mb-8 animate-fade-in">
-        <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-6">
-          <div>
-            <h1 className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-green-400 to-green-600 bg-clip-text text-transparent mb-2">
-              Already Read
-            </h1>
-            <p className="text-gray-400 text-lg">Articles you&apos;ve finished reading</p>
-          </div>
-          <div className="flex items-center space-x-6">
-            <Link
-              to="/articles"
-              className="group flex items-center px-4 py-3 bg-gradient-to-r from-dark-700 to-dark-600 border border-dark-500 text-gray-300 rounded-xl font-medium transition-all duration-200 hover:from-primary-600 hover:to-primary-700 hover:border-primary-500 hover:text-white hover:scale-105 hover:shadow-lg hover:shadow-primary-500/25"
-            >
-              <svg className="w-5 h-5 mr-2 transition-transform group-hover:scale-110" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9.5a2.5 2.5 0 00-2.5-2.5H15" />
-              </svg>
-              Back to All Articles
-            </Link>
-            <div className="text-sm text-gray-400">
-              <div className="flex items-center space-x-2">
-                <span className="w-2 h-2 bg-green-500 rounded-full animate-pulse" />
-                <span>
-                  Read: <span className="text-green-400 font-semibold">{articles.length}</span> articles
-                </span>
-              </div>
+      <PageHeading
+        title="Already Read"
+        subtitle="Articles you've finished reading"
+        titleClassName="bg-gradient-to-r from-green-400 to-green-600 bg-clip-text text-transparent"
+        meta={
+          <div className="text-sm text-gray-400">
+            <div className="flex items-center space-x-2">
+              <span className="w-2 h-2 bg-green-500 rounded-full animate-pulse" />
+              <span>
+                Read: <span className="text-green-400 font-semibold">{articles.length}</span> articles
+              </span>
             </div>
           </div>
-        </div>
-      </div>
+        }
+      />
 
       {error && <div className="mb-4 text-sm text-red-400">{error}</div>}
 

--- a/app/frontend/pages/RecentlyDismissedPage.tsx
+++ b/app/frontend/pages/RecentlyDismissedPage.tsx
@@ -1,9 +1,10 @@
 import { undismissArticle } from '../api/articles'
 import { fetchRecentlyDismissed } from '../api/dismissedArticles'
 import type { DismissedArticle } from '../types/dismissedArticle'
-import { Link, NavLink } from 'react-router-dom'
+import { NavLink } from 'react-router-dom'
 import DismissedArticlesList from '../components/DismissedArticlesList'
 import PageShell from '../components/PageShell'
+import PageHeading from '../components/PageHeading'
 import EmptyState from '../components/EmptyState'
 import { useAsyncResource } from '../hooks/useAsyncResource'
 
@@ -39,41 +40,27 @@ export default function RecentlyDismissedPage() {
       showFatalError={articles.length === 0}
       onRetry={reload}
     >
-      <div className="glass-effect rounded-2xl p-8 mb-8 animate-fade-in">
-        <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-6">
-          <div>
-            <h1 className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-orange-400 to-orange-600 bg-clip-text text-transparent mb-2">
-              Recently Dismissed
-            </h1>
-            <p className="text-gray-400 text-lg">Articles dismissed in the last 24 hours - easy to restore</p>
-          </div>
-          <div className="flex items-center space-x-4">
-            <Link
-              to="/articles"
-              className="group flex items-center px-4 py-2 bg-gradient-to-r from-primary-600 to-primary-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-primary-700 hover:to-primary-800 hover:scale-105 hover:shadow-lg hover:shadow-primary-500/25"
-            >
-              <svg className="w-4 h-4 mr-2 transition-transform group-hover:scale-110" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
-              </svg>
-              Back to All Articles
-            </Link>
-            <NavLink
-              to="/dismissed"
-              className={({ isActive }) =>
-                [
-                  'group flex items-center px-4 py-2 bg-gradient-to-r from-red-600 to-red-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-red-700 hover:to-red-800 hover:scale-105 hover:shadow-lg hover:shadow-red-500/25',
-                  isActive ? 'ring-2 ring-white/30' : '',
-                ].join(' ')
-              }
-            >
-              <svg className="w-4 h-4 mr-2 transition-transform group-hover:scale-110" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
-              </svg>
-              All Dismissed
-            </NavLink>
-          </div>
-        </div>
-      </div>
+      <PageHeading
+        title="Recently Dismissed"
+        subtitle="Articles dismissed in the last 24 hours - easy to restore"
+        titleClassName="bg-gradient-to-r from-orange-400 to-orange-600 bg-clip-text text-transparent"
+        actions={
+          <NavLink
+            to="/dismissed"
+            className={({ isActive }) =>
+              [
+                'group flex items-center px-4 py-2 bg-gradient-to-r from-red-600 to-red-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-red-700 hover:to-red-800 hover:scale-105 hover:shadow-lg hover:shadow-red-500/25',
+                isActive ? 'ring-2 ring-white/30' : '',
+              ].join(' ')
+            }
+          >
+            <svg className="w-4 h-4 mr-2 transition-transform group-hover:scale-110" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+            All Dismissed
+          </NavLink>
+        }
+      />
 
       {error && <div className="mb-4 text-sm text-red-400">{error}</div>}
 

--- a/app/frontend/pages/SourcesIndexPage.tsx
+++ b/app/frontend/pages/SourcesIndexPage.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useState } from 'react'
-import { Link } from 'react-router-dom'
 import {
   addRedditSource,
   fetchSources,
@@ -8,6 +7,7 @@ import {
   type NewsSource,
 } from '../api/sources'
 import { useConfirmDialog } from '../hooks/useConfirmDialog'
+import PageHeading from '../components/PageHeading'
 
 function sourceLabel(source: NewsSource): string {
   if (source.source_type === 'reddit') {
@@ -97,17 +97,11 @@ export default function SourcesIndexPage() {
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-4xl" data-testid="sources-page">
-      <div className="glass-effect rounded-2xl p-8 mb-8">
-        <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
-          <div>
-            <h1 className="text-3xl font-bold text-gray-100 mb-2">News Sources</h1>
-            <p className="text-gray-400">Enable or disable sources and manage Reddit subreddits.</p>
-          </div>
-          <Link to="/articles" className="px-4 py-2 bg-dark-700 border border-dark-600 text-gray-300 rounded-xl hover:bg-dark-600">
-            Back to Articles
-          </Link>
-        </div>
-      </div>
+      <PageHeading
+        title="News Sources"
+        subtitle="Enable or disable sources and manage Reddit subreddits."
+        titleClassName="text-gray-100"
+      />
 
       {error && <div className="mb-4 text-sm text-red-400">{error}</div>}
 

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -26,6 +26,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     end
     assert_selector "[data-testid='articles-page']", wait: 12
     assert_selector "main#main-content", wait: 12
+    assert_selector "[data-testid='app-nav']", wait: 12
     assert_no_text "Loading articles...", wait: 12
   end
 

--- a/test/system/bookmark_functionality_test.rb
+++ b/test/system/bookmark_functionality_test.rb
@@ -150,7 +150,7 @@ class BookmarkFunctionalityTest < ApplicationSystemTestCase
     click_link "Reading List"
     assert_current_path bookmarks_path
 
-    click_link "Back to All Articles"
-    assert_current_path articles_path
+    click_link "Feed", match: :first
+    assert_current_path root_path
   end
 end

--- a/test/system/category_filter_turbo_test.rb
+++ b/test/system/category_filter_turbo_test.rb
@@ -22,8 +22,8 @@ class CategoryFilterTurboTest < ApplicationSystemTestCase
         click_link "Reading List"
         assert_current_path bookmarks_path
 
-        click_link "Back to All Articles"
-        assert_current_path articles_path
+        click_link "Feed", match: :first
+        assert_current_path root_path
 
         fresh_category_btn = first("button.filter-btn[data-filter-type='category']")
         if fresh_category_btn


### PR DESCRIPTION
## Summary
- Add `AppShell` with persistent desktop top nav and mobile bottom tab bar (Feed, Reading List, Already Read, Recently Dismissed)
- Extract `PageHeading` for sub-page titles; remove redundant back links and duplicate nav from `PageHeader`
- Update system tests to use global Feed nav instead of Back to All Articles

## Test plan
- [x] Vitest (13 tests)
- [x] System tests: bookmark, category filter, read articles, dismiss
- [ ] CI green

Closes #155