### PR TITLE
refactor(frontend): extract shared UI primitives and design tokens (#156)

### DIFF
--- a/app/frontend/components/ArticleCardBase.tsx
+++ b/app/frontend/components/ArticleCardBase.tsx
@@ -5,6 +5,8 @@ import {
   humanizeSourceType,
   truncate,
 } from '../utils/format'
+import Badge, { type BadgeVariant } from './ui/Badge'
+import { cn } from '../utils/cn'
 
 export interface ArticleCardData {
   id: number
@@ -25,7 +27,7 @@ const CARD_THEMES: Record<
     titleHover: string
     linkHover: string
     shadowHover: string
-    badge: string
+    badgeVariant: BadgeVariant
     detailsHover: string
     dateAccent: string
   }
@@ -34,8 +36,7 @@ const CARD_THEMES: Record<
     titleHover: 'group-hover:text-primary-300',
     linkHover: 'hover:text-primary-400',
     shadowHover: 'hover:shadow-primary-500/10',
-    badge:
-      'bg-gradient-to-r from-primary-600/20 to-primary-700/20 text-primary-300 border border-primary-500/30',
+    badgeVariant: 'primary',
     detailsHover:
       'hover:from-primary-600 hover:to-primary-700 hover:border-primary-500 hover:shadow-primary-500/20',
     dateAccent: 'text-primary-400',
@@ -44,8 +45,7 @@ const CARD_THEMES: Record<
     titleHover: 'group-hover:text-green-300',
     linkHover: 'hover:text-green-400',
     shadowHover: 'hover:shadow-green-500/10',
-    badge:
-      'bg-gradient-to-r from-green-600/20 to-green-700/20 text-green-300 border border-green-500/30',
+    badgeVariant: 'green',
     detailsHover:
       'hover:from-green-600 hover:to-green-700 hover:border-green-500 hover:shadow-green-500/20',
     dateAccent: 'text-primary-400',
@@ -54,8 +54,7 @@ const CARD_THEMES: Record<
     titleHover: 'group-hover:text-red-300',
     linkHover: 'hover:text-red-400',
     shadowHover: 'hover:shadow-red-500/10',
-    badge:
-      'bg-gradient-to-r from-red-600/20 to-red-700/20 text-red-300 border border-red-500/30',
+    badgeVariant: 'red',
     detailsHover:
       'hover:from-primary-600 hover:to-primary-700 hover:border-primary-500 hover:shadow-primary-500/20',
     dateAccent: 'text-red-400',
@@ -64,8 +63,7 @@ const CARD_THEMES: Record<
     titleHover: 'group-hover:text-orange-300',
     linkHover: 'hover:text-orange-400',
     shadowHover: 'hover:shadow-orange-500/10',
-    badge:
-      'bg-gradient-to-r from-orange-600/20 to-orange-700/20 text-orange-300 border border-orange-500/30',
+    badgeVariant: 'orange',
     detailsHover:
       'hover:from-primary-600 hover:to-primary-700 hover:border-primary-500 hover:shadow-primary-500/20',
     dateAccent: 'text-orange-400',
@@ -111,7 +109,11 @@ export default function ArticleCardBase({
 
   return (
     <article
-      className={`article-card group glass-effect rounded-2xl p-6 transition-all duration-300 hover:scale-[1.02] hover:shadow-2xl ${styles.shadowHover} animate-fade-in ${borderClass}`}
+      className={cn(
+        'article-card group glass-effect rounded-2xl p-6 transition-all duration-300 hover:scale-[1.02] hover:shadow-2xl animate-fade-in',
+        styles.shadowHover,
+        borderClass
+      )}
       data-source={article.source_type}
       data-category={categorySlug}
       style={{
@@ -152,11 +154,7 @@ export default function ArticleCardBase({
         <div className="ml-4 flex items-center space-x-2">
           {badge}
           {showSourceBadge && !badge && (
-            <span
-              className={`inline-block px-3 py-1.5 text-xs font-semibold rounded-full ${styles.badge}`}
-            >
-              {humanizeSourceType(article.source_type)}
-            </span>
+            <Badge variant={styles.badgeVariant}>{humanizeSourceType(article.source_type)}</Badge>
           )}
           {headerActions}
         </div>

--- a/app/frontend/components/CategoryFilter.tsx
+++ b/app/frontend/components/CategoryFilter.tsx
@@ -1,5 +1,7 @@
 import type { Category } from '../types/article'
 import { parameterize } from '../utils/format'
+import Button from './ui/Button'
+import Card from './ui/Card'
 
 interface CategoryFilterProps {
   categories: Category[]
@@ -16,14 +18,9 @@ export default function CategoryFilter({
   activeFilter,
   onFilterChange,
 }: CategoryFilterProps) {
-  const activeClasses =
-    'filter-btn active px-5 py-2.5 bg-gradient-to-r from-primary-600 to-primary-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-primary-700 hover:to-primary-800 hover:scale-105 hover:shadow-lg hover:shadow-primary-500/25'
-  const inactiveClasses =
-    'filter-btn px-5 py-2.5 bg-dark-800 border border-dark-700 text-gray-300 rounded-xl font-medium transition-all duration-200 hover:bg-dark-700 hover:border-primary-500 hover:text-white hover:scale-105 hover:shadow-lg hover:shadow-primary-500/10'
-
   return (
     <div className="mb-8 animate-slide-up">
-      <div className="glass-effect rounded-2xl p-6">
+      <Card>
         <h3 className="text-lg font-semibold text-gray-200 mb-4 flex items-center">
           <svg className="w-5 h-5 mr-2 text-primary-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.707A1 1 0 013 7V4z" />
@@ -31,9 +28,9 @@ export default function CategoryFilter({
           Filter by Category
         </h3>
         <div className="flex flex-wrap gap-3">
-          <button
-            type="button"
-            className={activeFilter === 'all' ? activeClasses : inactiveClasses}
+          <Button
+            variant="filter"
+            active={activeFilter === 'all'}
             data-filter-type="all"
             data-filter-value="all"
             aria-pressed={activeFilter === 'all'}
@@ -43,15 +40,15 @@ export default function CategoryFilter({
               <span className="w-2 h-2 bg-white rounded-full mr-2" />
               All Articles ({totalCount})
             </span>
-          </button>
+          </Button>
           {categories.map((category) => {
             const slug = parameterize(category.name)
             const count = categoryCounts[category.name] ?? 0
             return (
-              <button
+              <Button
                 key={category.name}
-                type="button"
-                className={activeFilter === slug ? activeClasses : inactiveClasses}
+                variant="filter"
+                active={activeFilter === slug}
                 data-filter-type="category"
                 data-filter-value={slug}
                 aria-pressed={activeFilter === slug}
@@ -61,11 +58,11 @@ export default function CategoryFilter({
                   <span className="text-lg mr-2">{category.icon}</span>
                   {category.name} ({count})
                 </span>
-              </button>
+              </Button>
             )
           })}
         </div>
-      </div>
+      </Card>
     </div>
   )
 }

--- a/app/frontend/components/ConfirmDialog.tsx
+++ b/app/frontend/components/ConfirmDialog.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useRef } from 'react'
+import Button from './ui/Button'
+import Card from './ui/Card'
 
 interface ConfirmDialogProps {
   open: boolean
@@ -68,11 +70,6 @@ export default function ConfirmDialog({
 
   if (!open) return null
 
-  const confirmButtonClass =
-    confirmTone === 'primary'
-      ? 'px-4 py-2 rounded-lg bg-gradient-to-r from-primary-600 to-primary-700 text-white font-medium hover:from-primary-700 hover:to-primary-800 transition-colors'
-      : 'px-4 py-2 rounded-lg bg-gradient-to-r from-red-600 to-red-700 text-white font-medium hover:from-red-700 hover:to-red-800 transition-colors'
-
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center p-4"
@@ -80,42 +77,46 @@ export default function ConfirmDialog({
       data-testid="confirm-dialog-backdrop"
       onClick={onCancel}
     >
-      <div
-        ref={dialogRef}
-        role="alertdialog"
-        aria-modal="true"
-        aria-labelledby="confirm-dialog-title"
-        aria-describedby="confirm-dialog-message"
-        className="glass-effect rounded-2xl p-6 w-full max-w-md shadow-2xl border border-dark-600 animate-fade-in"
-        data-testid="confirm-dialog"
-        onClick={(event) => event.stopPropagation()}
+      <Card
+        padding="md"
+        className="w-full max-w-md shadow-2xl border border-dark-600 animate-fade-in"
       >
-        <h2 id="confirm-dialog-title" className="text-xl font-bold text-gray-100 mb-3">
-          {title}
-        </h2>
-        <p id="confirm-dialog-message" className="text-gray-400 mb-6 leading-relaxed">
-          {message}
-        </p>
-        <div className="flex justify-end gap-3">
-          <button
-            ref={cancelRef}
-            type="button"
-            className="px-4 py-2 rounded-lg border border-dark-500 bg-dark-700 text-gray-300 font-medium hover:bg-dark-600 hover:text-white transition-colors"
-            onClick={onCancel}
-            data-testid="confirm-dialog-cancel"
-          >
-            {cancelLabel}
-          </button>
-          <button
-            type="button"
-            className={confirmButtonClass}
-            onClick={onConfirm}
-            data-testid="confirm-dialog-confirm"
-          >
-            {confirmLabel}
-          </button>
+        <div
+          ref={dialogRef}
+          role="alertdialog"
+          aria-modal="true"
+          aria-labelledby="confirm-dialog-title"
+          aria-describedby="confirm-dialog-message"
+          data-testid="confirm-dialog"
+          onClick={(event) => event.stopPropagation()}
+        >
+          <h2 id="confirm-dialog-title" className="text-xl font-bold text-gray-100 mb-3">
+            {title}
+          </h2>
+          <p id="confirm-dialog-message" className="text-gray-400 mb-6 leading-relaxed">
+            {message}
+          </p>
+          <div className="flex justify-end gap-3">
+            <Button
+              ref={cancelRef}
+              variant="secondary"
+              size="sm"
+              onClick={onCancel}
+              data-testid="confirm-dialog-cancel"
+            >
+              {cancelLabel}
+            </Button>
+            <Button
+              variant={confirmTone === 'primary' ? 'primary' : 'danger'}
+              size="sm"
+              onClick={onConfirm}
+              data-testid="confirm-dialog-confirm"
+            >
+              {confirmLabel}
+            </Button>
+          </div>
         </div>
-      </div>
+      </Card>
     </div>
   )
 }

--- a/app/frontend/components/DismissedArticleCard.tsx
+++ b/app/frontend/components/DismissedArticleCard.tsx
@@ -2,6 +2,8 @@ import type { DismissedArticle } from '../types/dismissedArticle'
 import { formatBookmarkedDate, formatTimeAgo } from '../utils/format'
 import { useConfirmDialog } from '../hooks/useConfirmDialog'
 import ArticleCardBase from './ArticleCardBase'
+import Badge from './ui/Badge'
+import Button from './ui/Button'
 
 interface DismissedArticleCardProps {
   article: DismissedArticle
@@ -42,10 +44,6 @@ export default function DismissedArticleCard({
       ? `Dismissed ${formatBookmarkedDate(article.dismissed_at)}`
       : 'Dismissed'
 
-  const styles = isRecent
-    ? 'bg-gradient-to-r from-orange-600/20 to-orange-700/20 text-orange-300 border border-orange-500/30'
-    : 'bg-gradient-to-r from-red-600/20 to-red-700/20 text-red-300 border border-red-500/30'
-
   return (
     <>
       <ArticleCardBase
@@ -54,18 +52,9 @@ export default function DismissedArticleCard({
         theme={theme}
         borderClass={borderClass}
         showSourceBadge={false}
-        badge={
-          <span className={`inline-block px-3 py-1.5 text-xs font-semibold rounded-full ${styles}`}>
-            {badgeText}
-          </span>
-        }
+        badge={<Badge variant={isRecent ? 'orange' : 'red'}>{badgeText}</Badge>}
         actions={
-          <button
-            type="button"
-            className="group/restore px-4 py-2 bg-gradient-to-r from-green-600 to-green-700 text-white rounded-lg font-medium transition-all duration-200 hover:from-green-700 hover:to-green-800 hover:scale-105 hover:shadow-lg hover:shadow-green-500/25"
-            title="Restore article"
-            onClick={handleRestore}
-          >
+          <Button color="green" size="sm" className="group/restore" title="Restore article" onClick={handleRestore}>
             <span className="flex items-center">
               <svg
                 className="w-4 h-4 mr-2 transition-transform group-hover/restore:scale-110"
@@ -82,7 +71,7 @@ export default function DismissedArticleCard({
               </svg>
               {restoreLabel}
             </span>
-          </button>
+          </Button>
         }
       />
       {dialog}

--- a/app/frontend/components/EmptyState.tsx
+++ b/app/frontend/components/EmptyState.tsx
@@ -1,10 +1,13 @@
 import type { ReactNode } from 'react'
 import { Link } from 'react-router-dom'
+import type { ButtonColor } from './ui/Button'
+import { buttonClassName } from './ui/Button'
+import Card from './ui/Card'
 
 interface EmptyStateAction {
   href: string
   label: string
-  className: string
+  color?: ButtonColor
   icon?: ReactNode
 }
 
@@ -24,7 +27,7 @@ export default function EmptyState({
   actions = [],
 }: EmptyStateProps) {
   return (
-    <div className="glass-effect rounded-2xl p-12 text-center animate-fade-in">
+    <Card padding="empty" animate>
       <div
         className={`w-20 h-20 mx-auto mb-6 rounded-full flex items-center justify-center ${iconWrapperClassName}`}
       >
@@ -41,13 +44,17 @@ export default function EmptyState({
           }
         >
           {actions.map((action) => (
-            <Link key={`${action.href}-${action.label}`} to={action.href} className={action.className}>
+            <Link
+              key={`${action.href}-${action.label}`}
+              to={action.href}
+              className={buttonClassName({ size: 'lg', color: action.color ?? 'primary' })}
+            >
               {action.icon}
               {action.label}
             </Link>
           ))}
         </div>
       )}
-    </div>
+    </Card>
   )
 }

--- a/app/frontend/components/ErrorRetry.tsx
+++ b/app/frontend/components/ErrorRetry.tsx
@@ -1,3 +1,5 @@
+import Button from './ui/Button'
+
 interface ErrorRetryProps {
   message: string
   onRetry: () => void
@@ -7,13 +9,9 @@ export default function ErrorRetry({ message, onRetry }: ErrorRetryProps) {
   return (
     <>
       <p className="text-red-400 mb-4">{message}</p>
-      <button
-        type="button"
-        className="px-4 py-2 bg-primary-600 text-white rounded-lg"
-        onClick={onRetry}
-      >
+      <Button size="sm" onClick={onRetry}>
         Retry
-      </button>
+      </Button>
     </>
   )
 }

--- a/app/frontend/components/PageHeader.tsx
+++ b/app/frontend/components/PageHeader.tsx
@@ -1,5 +1,8 @@
 import { NavLink } from 'react-router-dom'
 import { formatLastUpdated } from '../utils/format'
+import { buttonClassName } from './ui/Button'
+import Card from './ui/Card'
+import Button from './ui/Button'
 
 interface PageHeaderProps {
   totalCount: number
@@ -11,9 +14,12 @@ interface PageHeaderProps {
   fetchMessage?: string | null
 }
 
-function navLinkClassName(base: string) {
+function navLinkClassName(color: 'blue' | 'purple') {
   return ({ isActive }: { isActive: boolean }) =>
-    isActive ? `${base} ring-2 ring-white/30` : base
+    buttonClassName({
+      color,
+      className: isActive ? 'ring-2 ring-white/30' : undefined,
+    })
 }
 
 export default function PageHeader({
@@ -26,7 +32,7 @@ export default function PageHeader({
   fetchMessage = null,
 }: PageHeaderProps) {
   return (
-    <div className="glass-effect rounded-2xl p-8 mb-8 animate-fade-in">
+    <Card padding="lg" className="mb-8" animate>
       <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-6">
         <div>
           <h1 className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-primary-400 to-primary-600 bg-clip-text text-transparent mb-2">
@@ -39,9 +45,9 @@ export default function PageHeader({
         </div>
         <div className="flex flex-wrap items-center gap-3">
           {onFetchNews && (
-            <button
-              type="button"
-              className="group flex items-center px-4 py-2 bg-gradient-to-r from-blue-600 to-blue-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-blue-700 hover:to-blue-800 hover:scale-105 disabled:opacity-60 disabled:hover:scale-100"
+            <Button
+              color="blue"
+              className="group"
               onClick={onFetchNews}
               disabled={fetchingNews}
               data-testid="fetch-news-button"
@@ -50,14 +56,9 @@ export default function PageHeader({
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
               </svg>
               {fetchingNews ? 'Fetching...' : 'Fetch News'}
-            </button>
+            </Button>
           )}
-          <NavLink
-            to="/sources"
-            className={navLinkClassName(
-              'group flex items-center px-4 py-2 bg-gradient-to-r from-purple-600 to-purple-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-purple-700 hover:to-purple-800 hover:scale-105 hover:shadow-lg hover:shadow-purple-500/25'
-            )}
-          >
+          <NavLink to="/sources" className={navLinkClassName('purple')}>
             Sources
           </NavLink>
           {onShowReadChange && (
@@ -87,6 +88,6 @@ export default function PageHeader({
           </div>
         </div>
       </div>
-    </div>
+    </Card>
   )
 }

--- a/app/frontend/components/PageShell.tsx
+++ b/app/frontend/components/PageShell.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react'
+import PageContainer from './ui/PageContainer'
 import ErrorRetry from './ErrorRetry'
 
 interface PageShellProps {
@@ -22,29 +23,25 @@ export default function PageShell({
 }: PageShellProps) {
   if (loading) {
     return (
-      <div
-        className="container mx-auto px-4 py-8 max-w-7xl text-center text-gray-400"
-        data-testid={testId}
+      <PageContainer
+        testId={testId}
+        centered
         role="status"
         aria-live="polite"
-        aria-busy="true"
+        aria-busy
       >
         {loadingMessage}
-      </div>
+      </PageContainer>
     )
   }
 
   if (showFatalError && error) {
     return (
-      <div className="container mx-auto px-4 py-8 max-w-7xl text-center" data-testid={testId}>
+      <PageContainer testId={testId} centered>
         <ErrorRetry message={error} onRetry={onRetry} />
-      </div>
+      </PageContainer>
     )
   }
 
-  return (
-    <div className="container mx-auto px-4 py-8 max-w-7xl" data-testid={testId}>
-      {children}
-    </div>
-  )
+  return <PageContainer testId={testId}>{children}</PageContainer>
 }

--- a/app/frontend/components/RouteFallback.tsx
+++ b/app/frontend/components/RouteFallback.tsx
@@ -1,12 +1,9 @@
+import PageContainer from './ui/PageContainer'
+
 export default function RouteFallback() {
   return (
-    <div
-      className="container mx-auto px-4 py-8 max-w-7xl text-center text-gray-400"
-      data-testid="route-loading"
-      role="status"
-      aria-live="polite"
-    >
+    <PageContainer testId="route-loading" centered role="status" aria-live="polite">
       Loading page...
-    </div>
+    </PageContainer>
   )
 }

--- a/app/frontend/components/SourceFilter.tsx
+++ b/app/frontend/components/SourceFilter.tsx
@@ -1,4 +1,6 @@
 import { humanizeSourceType } from '../utils/format'
+import Button from './ui/Button'
+import Card from './ui/Card'
 
 interface SourceFilterProps {
   sources: string[]
@@ -15,14 +17,9 @@ export default function SourceFilter({
   activeSource,
   onSourceChange,
 }: SourceFilterProps) {
-  const activeClasses =
-    'filter-btn active px-5 py-2.5 bg-gradient-to-r from-primary-600 to-primary-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-primary-700 hover:to-primary-800 hover:scale-105 hover:shadow-lg hover:shadow-primary-500/25'
-  const inactiveClasses =
-    'filter-btn px-5 py-2.5 bg-dark-800 border border-dark-700 text-gray-300 rounded-xl font-medium transition-all duration-200 hover:bg-dark-700 hover:border-primary-500 hover:text-white hover:scale-105 hover:shadow-lg hover:shadow-primary-500/10'
-
   return (
     <div className="mb-8 animate-slide-up">
-      <div className="glass-effect rounded-2xl p-6">
+      <Card>
         <h3 className="text-lg font-semibold text-gray-200 mb-4 flex items-center">
           <svg className="w-5 h-5 mr-2 text-primary-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.707A1 1 0 013 7V4z" />
@@ -30,9 +27,9 @@ export default function SourceFilter({
           Filter by Source
         </h3>
         <div className="flex flex-wrap gap-3">
-          <button
-            type="button"
-            className={activeSource === 'all' ? activeClasses : inactiveClasses}
+          <Button
+            variant="filter"
+            active={activeSource === 'all'}
             data-source="all"
             aria-pressed={activeSource === 'all'}
             onClick={() => onSourceChange('all')}
@@ -41,21 +38,21 @@ export default function SourceFilter({
               <span className="w-2 h-2 bg-white rounded-full mr-2" />
               All Sources ({totalCount})
             </span>
-          </button>
+          </Button>
           {sources.map((source) => (
-            <button
+            <Button
               key={source}
-              type="button"
-              className={activeSource === source ? activeClasses : inactiveClasses}
+              variant="filter"
+              active={activeSource === source}
               data-source={source}
               aria-pressed={activeSource === source}
               onClick={() => onSourceChange(source)}
             >
               {humanizeSourceType(source)} ({sourceCounts[source] ?? 0})
-            </button>
+            </Button>
           ))}
         </div>
-      </div>
+      </Card>
     </div>
   )
 }

--- a/app/frontend/components/ui/Badge.tsx
+++ b/app/frontend/components/ui/Badge.tsx
@@ -1,0 +1,49 @@
+import type { ReactNode } from 'react'
+import { cn } from '../../utils/cn'
+
+export type BadgeVariant = 'primary' | 'green' | 'red' | 'orange'
+export type BadgeSize = 'sm' | 'md'
+
+export interface BadgeProps {
+  children: ReactNode
+  variant?: BadgeVariant
+  size?: BadgeSize
+  className?: string
+}
+
+const VARIANT_CLASSES: Record<BadgeVariant, string> = {
+  primary:
+    'bg-gradient-to-r from-primary-600/20 to-primary-700/20 text-primary-300 border border-primary-500/30',
+  green:
+    'bg-gradient-to-r from-green-600/20 to-green-700/20 text-green-300 border border-green-500/30',
+  red: 'bg-gradient-to-r from-red-600/20 to-red-700/20 text-red-300 border border-red-500/30',
+  orange:
+    'bg-gradient-to-r from-orange-600/20 to-orange-700/20 text-orange-300 border border-orange-500/30',
+}
+
+const SIZE_CLASSES: Record<BadgeSize, string> = {
+  sm: 'px-3 py-1 text-xs',
+  md: 'px-3 py-1.5 text-xs',
+}
+
+export function badgeClassName({
+  variant = 'primary',
+  size = 'md',
+  className,
+}: Pick<BadgeProps, 'variant' | 'size' | 'className'> = {}) {
+  return cn(
+    'inline-block font-semibold rounded-full',
+    SIZE_CLASSES[size],
+    VARIANT_CLASSES[variant],
+    className
+  )
+}
+
+export default function Badge({
+  children,
+  variant = 'primary',
+  size = 'md',
+  className,
+}: BadgeProps) {
+  return <span className={badgeClassName({ variant, size, className })}>{children}</span>
+}

--- a/app/frontend/components/ui/Button.tsx
+++ b/app/frontend/components/ui/Button.tsx
@@ -1,0 +1,37 @@
+import { forwardRef, type ButtonHTMLAttributes, type ReactNode } from 'react'
+import { buttonClassName, type ButtonColor, type ButtonSize, type ButtonVariant } from './buttonStyles'
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant
+  size?: ButtonSize
+  color?: ButtonColor
+  active?: boolean
+  children: ReactNode
+}
+
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  {
+    variant = 'primary',
+    size = 'md',
+    color = 'primary',
+    active = false,
+    className,
+    children,
+    ...props
+  },
+  ref
+) {
+  return (
+    <button
+      ref={ref}
+      type="button"
+      className={buttonClassName({ variant, size, color, active, className })}
+      {...props}
+    >
+      {children}
+    </button>
+  )
+})
+
+export default Button
+export { buttonClassName }

--- a/app/frontend/components/ui/Card.tsx
+++ b/app/frontend/components/ui/Card.tsx
@@ -1,0 +1,40 @@
+import type { ElementType, ReactNode } from 'react'
+import { cn } from '../../utils/cn'
+
+export type CardPadding = 'sm' | 'md' | 'lg' | 'empty'
+
+export interface CardProps {
+  children: ReactNode
+  as?: ElementType
+  padding?: CardPadding
+  className?: string
+  animate?: boolean
+}
+
+const PADDING_CLASSES: Record<CardPadding, string> = {
+  sm: 'p-4',
+  md: 'p-6',
+  lg: 'p-6 md:p-8',
+  empty: 'p-12 text-center',
+}
+
+export default function Card({
+  children,
+  as: Component = 'div',
+  padding = 'md',
+  className,
+  animate = false,
+}: CardProps) {
+  return (
+    <Component
+      className={cn(
+        'glass-effect rounded-2xl',
+        PADDING_CLASSES[padding],
+        animate && 'animate-fade-in',
+        className
+      )}
+    >
+      {children}
+    </Component>
+  )
+}

--- a/app/frontend/components/ui/PageContainer.tsx
+++ b/app/frontend/components/ui/PageContainer.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from 'react'
+import { cn } from '../../utils/cn'
+
+export type PageContainerWidth = '7xl' | '4xl'
+
+export interface PageContainerProps {
+  children: ReactNode
+  width?: PageContainerWidth
+  centered?: boolean
+  className?: string
+  testId?: string
+  role?: string
+  'aria-live'?: 'off' | 'polite' | 'assertive'
+  'aria-busy'?: boolean
+}
+
+export default function PageContainer({
+  children,
+  width = '7xl',
+  centered = false,
+  className,
+  testId,
+  role,
+  'aria-live': ariaLive,
+  'aria-busy': ariaBusy,
+}: PageContainerProps) {
+  return (
+    <div
+      className={cn(
+        'container mx-auto px-4 py-8',
+        width === '7xl' ? 'max-w-7xl' : 'max-w-4xl',
+        centered && 'text-center text-gray-400',
+        className
+      )}
+      data-testid={testId}
+      role={role}
+      aria-live={ariaLive}
+      aria-busy={ariaBusy}
+    >
+      {children}
+    </div>
+  )
+}

--- a/app/frontend/components/ui/PageHeading.tsx
+++ b/app/frontend/components/ui/PageHeading.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react'
+import Card from './Card'
 
 interface PageHeadingProps {
   title: string
@@ -16,7 +17,7 @@ export default function PageHeading({
   meta,
 }: PageHeadingProps) {
   return (
-    <div className="glass-effect rounded-2xl p-6 md:p-8 mb-8 animate-fade-in">
+    <Card padding="lg" className="mb-8" animate>
       <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 md:gap-6">
         <div>
           <h1 className={`text-3xl md:text-4xl font-bold mb-2 ${titleClassName}`}>{title}</h1>
@@ -29,6 +30,6 @@ export default function PageHeading({
           </div>
         )}
       </div>
-    </div>
+    </Card>
   )
 }

--- a/app/frontend/components/ui/buttonStyles.ts
+++ b/app/frontend/components/ui/buttonStyles.ts
@@ -1,0 +1,135 @@
+import { cn } from '../../utils/cn'
+
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger' | 'filter'
+export type ButtonSize = 'sm' | 'md' | 'lg'
+export type ButtonColor = 'primary' | 'blue' | 'purple' | 'green' | 'red' | 'orange'
+
+export interface ButtonStyleOptions {
+  variant?: ButtonVariant
+  size?: ButtonSize
+  color?: ButtonColor
+  active?: boolean
+  className?: string
+}
+
+const GRADIENT_COLORS: Record<
+  ButtonColor,
+  { from: string; to: string; hoverFrom: string; hoverTo: string; shadow: string }
+> = {
+  primary: {
+    from: 'from-primary-600',
+    to: 'to-primary-700',
+    hoverFrom: 'hover:from-primary-700',
+    hoverTo: 'hover:to-primary-800',
+    shadow: 'hover:shadow-primary-500/25',
+  },
+  blue: {
+    from: 'from-blue-600',
+    to: 'to-blue-700',
+    hoverFrom: 'hover:from-blue-700',
+    hoverTo: 'hover:to-blue-800',
+    shadow: 'hover:shadow-blue-500/25',
+  },
+  purple: {
+    from: 'from-purple-600',
+    to: 'to-purple-700',
+    hoverFrom: 'hover:from-purple-700',
+    hoverTo: 'hover:to-purple-800',
+    shadow: 'hover:shadow-purple-500/25',
+  },
+  green: {
+    from: 'from-green-600',
+    to: 'to-green-700',
+    hoverFrom: 'hover:from-green-700',
+    hoverTo: 'hover:to-green-800',
+    shadow: 'hover:shadow-green-500/25',
+  },
+  red: {
+    from: 'from-red-600',
+    to: 'to-red-700',
+    hoverFrom: 'hover:from-red-700',
+    hoverTo: 'hover:to-red-800',
+    shadow: 'hover:shadow-red-500/25',
+  },
+  orange: {
+    from: 'from-orange-600',
+    to: 'to-orange-700',
+    hoverFrom: 'hover:from-orange-700',
+    hoverTo: 'hover:to-orange-800',
+    shadow: 'hover:shadow-orange-500/25',
+  },
+}
+
+const SIZE_CLASSES: Record<ButtonSize, string> = {
+  sm: 'px-4 py-2 text-sm rounded-lg',
+  md: 'px-4 py-2 rounded-xl',
+  lg: 'px-6 py-3 rounded-xl',
+}
+
+export function buttonClassName({
+  variant = 'primary',
+  size = 'md',
+  color = 'primary',
+  active = false,
+  className,
+}: ButtonStyleOptions = {}) {
+  const base = 'inline-flex items-center justify-center font-medium transition-all duration-200'
+
+  if (variant === 'ghost') {
+    return cn(
+      base,
+      'p-1.5 text-gray-500 hover:text-red-400 hover:bg-red-400/10 rounded-lg',
+      className
+    )
+  }
+
+  if (variant === 'secondary') {
+    return cn(
+      base,
+      SIZE_CLASSES[size],
+      'border border-dark-500 bg-dark-700 text-gray-300 hover:bg-dark-600 hover:text-white',
+      className
+    )
+  }
+
+  if (variant === 'filter') {
+    const filterSize = 'px-5 py-2.5 rounded-xl'
+    if (active) {
+      const gradient = GRADIENT_COLORS.primary
+      return cn(
+        base,
+        filterSize,
+        'filter-btn active bg-gradient-to-r text-white',
+        gradient.from,
+        gradient.to,
+        gradient.hoverFrom,
+        gradient.hoverTo,
+        'hover:scale-105 hover:shadow-lg',
+        gradient.shadow,
+        className
+      )
+    }
+    return cn(
+      base,
+      filterSize,
+      'filter-btn bg-dark-800 border border-dark-700 text-gray-300 hover:bg-dark-700 hover:border-primary-500 hover:text-white hover:scale-105 hover:shadow-lg hover:shadow-primary-500/10',
+      className
+    )
+  }
+
+  const gradient = GRADIENT_COLORS[variant === 'danger' ? 'red' : color]
+  return cn(
+    base,
+    SIZE_CLASSES[size],
+    'bg-gradient-to-r text-white',
+    gradient.from,
+    gradient.to,
+    gradient.hoverFrom,
+    gradient.hoverTo,
+    'hover:scale-105',
+    size !== 'sm' && 'hover:shadow-lg',
+    size !== 'sm' && gradient.shadow,
+    'disabled:opacity-60 disabled:hover:scale-100',
+    className
+  )
+}

--- a/app/frontend/components/ui/ui.test.tsx
+++ b/app/frontend/components/ui/ui.test.tsx
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { buttonClassName } from './buttonStyles'
+import { badgeClassName } from './Badge'
+
+describe('buttonClassName', () => {
+  it('returns primary gradient classes by default', () => {
+    const classes = buttonClassName()
+    expect(classes).toContain('from-primary-600')
+    expect(classes).toContain('to-primary-700')
+  })
+
+  it('returns secondary outline classes', () => {
+    const classes = buttonClassName({ variant: 'secondary' })
+    expect(classes).toContain('border-dark-500')
+    expect(classes).toContain('bg-dark-700')
+  })
+
+  it('returns active filter classes', () => {
+    const classes = buttonClassName({ variant: 'filter', active: true })
+    expect(classes).toContain('filter-btn')
+    expect(classes).toContain('active')
+    expect(classes).toContain('from-primary-600')
+  })
+
+  it('returns inactive filter classes', () => {
+    const classes = buttonClassName({ variant: 'filter', active: false })
+    expect(classes).toContain('filter-btn')
+    expect(classes).not.toContain('active')
+    expect(classes).toContain('bg-dark-800')
+  })
+
+  it('maps danger variant to red gradient', () => {
+    const classes = buttonClassName({ variant: 'danger' })
+    expect(classes).toContain('from-red-600')
+  })
+})
+
+describe('badgeClassName', () => {
+  it('returns primary badge classes', () => {
+    const classes = badgeClassName({ variant: 'primary' })
+    expect(classes).toContain('from-primary-600/20')
+    expect(classes).toContain('rounded-full')
+  })
+
+  it('returns orange badge classes', () => {
+    const classes = badgeClassName({ variant: 'orange' })
+    expect(classes).toContain('from-orange-600/20')
+  })
+})

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -11,6 +11,12 @@
   --dark-850: 23 32 51;
   --dark-900: 15 23 42;
   --dark-950: 2 6 23;
+  /* 8px spacing grid: 8, 16, 24, 32, 48 → space-2, space-4, space-6, space-8, space-12 */
+  --space-1: 0.5rem;
+  --space-2: 1rem;
+  --space-3: 1.5rem;
+  --space-4: 2rem;
+  --space-6: 3rem;
 }
 
 @layer utilities {

--- a/app/frontend/pages/BookmarksIndexPage.tsx
+++ b/app/frontend/pages/BookmarksIndexPage.tsx
@@ -9,7 +9,7 @@ import type { BookmarkArticle } from '../types/bookmark'
 import BookmarksList from '../components/BookmarksList'
 import SourceFilter from '../components/SourceFilter'
 import PageShell from '../components/PageShell'
-import PageHeading from '../components/PageHeading'
+import PageHeading from '../components/ui/PageHeading'
 import EmptyState from '../components/EmptyState'
 import { useAsyncResource } from '../hooks/useAsyncResource'
 import { useSearchParam } from '../hooks/useSearchParamState'
@@ -128,8 +128,7 @@ export default function BookmarksIndexPage() {
             {
               href: '/articles',
               label: 'Browse Articles',
-              className:
-                'group inline-flex items-center px-6 py-3 bg-gradient-to-r from-primary-600 to-primary-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-primary-700 hover:to-primary-800 hover:scale-105 hover:shadow-lg hover:shadow-primary-500/25',
+              color: 'primary' as const,
               icon: (
                 <svg className="w-5 h-5 mr-2 transition-transform group-hover:scale-110" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9.5a2.5 2.5 0 00-2.5-2.5H15" />

--- a/app/frontend/pages/DismissedArticlesIndexPage.tsx
+++ b/app/frontend/pages/DismissedArticlesIndexPage.tsx
@@ -4,7 +4,8 @@ import type { DismissedArticle } from '../types/dismissedArticle'
 import { NavLink } from 'react-router-dom'
 import DismissedArticlesList from '../components/DismissedArticlesList'
 import PageShell from '../components/PageShell'
-import PageHeading from '../components/PageHeading'
+import { buttonClassName } from '../components/ui/Button'
+import PageHeading from '../components/ui/PageHeading'
 import EmptyState from '../components/EmptyState'
 import { useAsyncResource } from '../hooks/useAsyncResource'
 
@@ -53,10 +54,10 @@ export default function DismissedArticlesIndexPage() {
           <NavLink
             to="/recently_dismissed"
             className={({ isActive }) =>
-              [
-                'group flex items-center px-4 py-2 bg-gradient-to-r from-orange-600 to-orange-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-orange-700 hover:to-orange-800 hover:scale-105 hover:shadow-lg hover:shadow-orange-500/25',
-                isActive ? 'ring-2 ring-white/30' : '',
-              ].join(' ')
+              buttonClassName({
+                color: 'orange',
+                className: isActive ? 'ring-2 ring-white/30' : undefined,
+              })
             }
           >
             <svg className="w-4 h-4 mr-2 transition-transform group-hover:scale-110" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -83,8 +84,7 @@ export default function DismissedArticlesIndexPage() {
             {
               href: '/articles',
               label: 'Browse Articles',
-              className:
-                'inline-flex items-center px-6 py-3 bg-gradient-to-r from-primary-600 to-primary-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-primary-700 hover:to-primary-800 hover:scale-105',
+              color: 'primary' as const,
               icon: (
                 <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />

--- a/app/frontend/pages/ReadArticlesIndexPage.tsx
+++ b/app/frontend/pages/ReadArticlesIndexPage.tsx
@@ -5,7 +5,7 @@ import type { ReadArticle } from '../types/readArticle'
 import ReadArticlesList from '../components/ReadArticlesList'
 import SourceFilter from '../components/SourceFilter'
 import PageShell from '../components/PageShell'
-import PageHeading from '../components/PageHeading'
+import PageHeading from '../components/ui/PageHeading'
 import EmptyState from '../components/EmptyState'
 import { useAsyncResource } from '../hooks/useAsyncResource'
 import { useSearchParam } from '../hooks/useSearchParamState'
@@ -94,8 +94,7 @@ export default function ReadArticlesIndexPage() {
             {
               href: '/articles',
               label: 'Browse Articles',
-              className:
-                'group inline-flex items-center px-6 py-3 bg-gradient-to-r from-green-600 to-green-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-green-700 hover:to-green-800 hover:scale-105 hover:shadow-lg hover:shadow-green-500/25',
+              color: 'green' as const,
               icon: (
                 <svg className="w-5 h-5 mr-2 transition-transform group-hover:scale-110" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9.5a2.5 2.5 0 00-2.5-2.5H15" />

--- a/app/frontend/pages/RecentlyDismissedPage.tsx
+++ b/app/frontend/pages/RecentlyDismissedPage.tsx
@@ -4,7 +4,8 @@ import type { DismissedArticle } from '../types/dismissedArticle'
 import { NavLink } from 'react-router-dom'
 import DismissedArticlesList from '../components/DismissedArticlesList'
 import PageShell from '../components/PageShell'
-import PageHeading from '../components/PageHeading'
+import { buttonClassName } from '../components/ui/Button'
+import PageHeading from '../components/ui/PageHeading'
 import EmptyState from '../components/EmptyState'
 import { useAsyncResource } from '../hooks/useAsyncResource'
 
@@ -48,10 +49,10 @@ export default function RecentlyDismissedPage() {
           <NavLink
             to="/dismissed"
             className={({ isActive }) =>
-              [
-                'group flex items-center px-4 py-2 bg-gradient-to-r from-red-600 to-red-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-red-700 hover:to-red-800 hover:scale-105 hover:shadow-lg hover:shadow-red-500/25',
-                isActive ? 'ring-2 ring-white/30' : '',
-              ].join(' ')
+              buttonClassName({
+                color: 'red',
+                className: isActive ? 'ring-2 ring-white/30' : undefined,
+              })
             }
           >
             <svg className="w-4 h-4 mr-2 transition-transform group-hover:scale-110" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -78,8 +79,7 @@ export default function RecentlyDismissedPage() {
             {
               href: '/articles',
               label: 'Browse Articles',
-              className:
-                'inline-flex items-center px-6 py-3 bg-gradient-to-r from-primary-600 to-primary-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-primary-700 hover:to-primary-800 hover:scale-105',
+              color: 'primary' as const,
               icon: (
                 <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
@@ -89,8 +89,7 @@ export default function RecentlyDismissedPage() {
             {
               href: '/dismissed',
               label: 'View All Dismissed',
-              className:
-                'inline-flex items-center px-6 py-3 bg-gradient-to-r from-red-600 to-red-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-red-700 hover:to-red-800 hover:scale-105',
+              color: 'red' as const,
               icon: (
                 <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />

--- a/app/frontend/pages/SourcesIndexPage.tsx
+++ b/app/frontend/pages/SourcesIndexPage.tsx
@@ -7,7 +7,10 @@ import {
   type NewsSource,
 } from '../api/sources'
 import { useConfirmDialog } from '../hooks/useConfirmDialog'
-import PageHeading from '../components/PageHeading'
+import Button from '../components/ui/Button'
+import Card from '../components/ui/Card'
+import PageContainer from '../components/ui/PageContainer'
+import PageHeading from '../components/ui/PageHeading'
 
 function sourceLabel(source: NewsSource): string {
   if (source.source_type === 'reddit') {
@@ -89,14 +92,14 @@ export default function SourcesIndexPage() {
 
   if (loading) {
     return (
-      <div className="container mx-auto px-4 py-8 max-w-4xl text-center text-gray-400" data-testid="sources-page">
+      <PageContainer width="4xl" testId="sources-page" centered>
         Loading sources...
-      </div>
+      </PageContainer>
     )
   }
 
   return (
-    <div className="container mx-auto px-4 py-8 max-w-4xl" data-testid="sources-page">
+    <PageContainer width="4xl" testId="sources-page">
       <PageHeading
         title="News Sources"
         subtitle="Enable or disable sources and manage Reddit subreddits."
@@ -105,7 +108,7 @@ export default function SourcesIndexPage() {
 
       {error && <div className="mb-4 text-sm text-red-400">{error}</div>}
 
-      <section className="glass-effect rounded-2xl p-6 mb-8">
+      <Card as="section" className="mb-8">
         <h2 className="text-lg font-semibold text-gray-200 mb-4">Built-in sources</h2>
         <div className="space-y-3">
           {fixedSources.map((source) => (
@@ -124,9 +127,9 @@ export default function SourcesIndexPage() {
             </div>
           ))}
         </div>
-      </section>
+      </Card>
 
-      <section className="glass-effect rounded-2xl p-6">
+      <Card as="section">
         <h2 className="text-lg font-semibold text-gray-200 mb-4">Reddit subreddits</h2>
 
         <form onSubmit={handleAddSubreddit} className="flex flex-col sm:flex-row gap-3 mb-6">
@@ -138,14 +141,9 @@ export default function SourcesIndexPage() {
             className="flex-1 px-4 py-2 bg-dark-800 border border-dark-700 rounded-xl text-gray-200 placeholder-gray-500 focus:outline-none focus:border-primary-500"
             data-testid="subreddit-input"
           />
-          <button
-            type="submit"
-            disabled={adding || !subredditInput.trim()}
-            className="px-4 py-2 bg-primary-600 text-white rounded-xl font-medium hover:bg-primary-700 disabled:opacity-60"
-            data-testid="add-subreddit-button"
-          >
+          <Button type="submit" disabled={adding || !subredditInput.trim()} data-testid="add-subreddit-button">
             {adding ? 'Validating...' : 'Add subreddit'}
-          </button>
+          </Button>
         </form>
 
         {validationError && (
@@ -180,8 +178,8 @@ export default function SourcesIndexPage() {
             <p className="text-gray-500 text-sm">No Reddit subreddits configured.</p>
           )}
         </div>
-      </section>
+      </Card>
       {dialog}
-    </div>
+    </PageContainer>
   )
 }

--- a/app/frontend/utils/cn.ts
+++ b/app/frontend/utils/cn.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(' ')
+}


### PR DESCRIPTION
## Summary
- Add `Button`, `Card`, `Badge`, `PageContainer`, and `PageHeading` under `components/ui/` with typed variant props
- Centralize gradient/outline/filter button styles in `buttonStyles.ts`; add 8px spacing CSS variables
- Migrate PageShell, PageHeader, filters, empty states, confirm dialog, article badges, and sources page

## Test plan
- [x] Vitest (20 tests)
- [x] System tests (49 runs, 0 failures)
- [ ] CI green

Closes #156