### PR TITLE
design(frontend): soften visual language for a more organic feel (#158)

### DIFF
--- a/app/frontend/components/AppShell.tsx
+++ b/app/frontend/components/AppShell.tsx
@@ -82,7 +82,7 @@ export default function AppShell({ children }: AppShellProps) {
 
   return (
     <div className="min-h-screen flex flex-col">
-      <header className="sticky top-0 z-40 glass-effect border-b border-dark-700/50">
+      <header className="sticky top-0 z-40 surface-elevated border-b border-dark-700/50">
         <div className="container mx-auto px-4 max-w-7xl">
           <div className="hidden md:flex items-center justify-between h-14">
             <NavLink
@@ -121,7 +121,7 @@ export default function AppShell({ children }: AppShellProps) {
       <nav
         aria-label="Main navigation"
         data-testid="app-nav-mobile"
-        className="md:hidden fixed bottom-0 inset-x-0 z-40 glass-effect border-t border-dark-700/50 safe-area-pb"
+        className="md:hidden fixed bottom-0 inset-x-0 z-40 surface-elevated border-t border-dark-700/50 safe-area-pb"
       >
         <div className="flex items-stretch h-16">
           {navItems.map((item) => (

--- a/app/frontend/components/ArticleCard.tsx
+++ b/app/frontend/components/ArticleCard.tsx
@@ -65,6 +65,8 @@ export default function ArticleCard(props: ArticleCardProps) {
         index={index}
         theme={theme}
         categorySlug={categorySlug}
+        accentBar={article.bookmarked ? 'primary' : article.read ? 'green' : undefined}
+        featured={article.score >= 100}
         onArticleClick={isDismissing ? () => onUndoDismiss?.(article) : undefined}
         articleStyle={{
           opacity: isDismissing ? 0.5 : 1,
@@ -106,6 +108,7 @@ export default function ArticleCard(props: ArticleCardProps) {
           article={article}
           index={index}
           theme={theme}
+          accentBar="primary"
           extraMetadata={
             article.bookmarked_at ? (
               <span className="flex items-center text-primary-400">
@@ -150,6 +153,7 @@ export default function ArticleCard(props: ArticleCardProps) {
           article={article}
           index={index}
           theme={theme}
+          accentBar="green"
           extraMetadata={
             article.read_at ? (
               <span className="flex items-center text-green-400">
@@ -204,6 +208,7 @@ export default function ArticleCard(props: ArticleCardProps) {
         index={index}
         theme={theme}
         borderClass={variantBorderClass(variant)}
+        accentBar={isRecent ? 'orange' : 'red'}
         showSourceBadge={false}
         badge={<Badge variant={isRecent ? 'orange' : 'red'}>{badgeText}</Badge>}
         actions={<RestoreButton label={restoreLabel} onClick={handleRestore} />}

--- a/app/frontend/components/ArticleList.tsx
+++ b/app/frontend/components/ArticleList.tsx
@@ -29,7 +29,7 @@ export default function ArticleList({
   })
 
   return (
-    <div className="grid gap-6 animate-scale-in">
+    <div className="grid gap-5 md:gap-6 motion-safe:animate-scale-in motion-sensitive">
       {visibleArticles.map((article, index) => (
         <ArticleCard
           key={article.id}

--- a/app/frontend/components/BookmarksList.tsx
+++ b/app/frontend/components/BookmarksList.tsx
@@ -20,7 +20,7 @@ export default function BookmarksList({
       : articles.filter((article) => article.source_type === activeSource)
 
   return (
-    <div className="grid gap-6 animate-scale-in">
+    <div className="grid gap-5 md:gap-6 motion-safe:animate-scale-in motion-sensitive">
       {visibleArticles.map((article, index) => (
         <ArticleCard
           key={article.id}

--- a/app/frontend/components/CategoryFilter.tsx
+++ b/app/frontend/components/CategoryFilter.tsx
@@ -19,8 +19,8 @@ export default function CategoryFilter({
   onFilterChange,
 }: CategoryFilterProps) {
   return (
-    <div className="mb-8 animate-slide-up">
-      <Card>
+    <div className="mb-8">
+      <Card tone="subtle">
         <h3 className="text-lg font-semibold text-gray-200 mb-4 flex items-center">
           <svg className="w-5 h-5 mr-2 text-primary-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.707A1 1 0 013 7V4z" />

--- a/app/frontend/components/ConfirmDialog.tsx
+++ b/app/frontend/components/ConfirmDialog.tsx
@@ -79,7 +79,8 @@ export default function ConfirmDialog({
     >
       <Card
         padding="md"
-        className="w-full max-w-md shadow-2xl border border-dark-600 animate-fade-in"
+        tone="panel"
+        className="w-full max-w-md shadow-2xl motion-safe:animate-fade-in motion-sensitive"
       >
         <div
           ref={dialogRef}

--- a/app/frontend/components/DismissToast.tsx
+++ b/app/frontend/components/DismissToast.tsx
@@ -7,7 +7,7 @@ interface DismissToastProps {
 export default function DismissToast({ articleTitle, timeLeft, onUndo }: DismissToastProps) {
   return (
     <div
-      className="dismiss-toast fixed top-4 right-4 bg-dark-800 border border-primary-500/30 rounded-xl p-4 shadow-2xl z-50 max-w-sm animate-slide-in"
+      className="dismiss-toast fixed top-4 right-4 surface-panel rounded-xl p-4 shadow-2xl z-50 max-w-sm motion-safe:animate-slide-in motion-sensitive border border-dark-700"
       role="status"
       aria-live="polite"
       aria-atomic="true"
@@ -20,7 +20,7 @@ export default function DismissToast({ articleTitle, timeLeft, onUndo }: Dismiss
         <div className="flex items-center space-x-2">
           <button
             type="button"
-            className="undo-btn px-4 py-2 bg-primary-600 hover:bg-primary-700 text-white text-sm font-medium rounded-lg transition-all duration-200 hover:scale-105"
+            className="undo-btn px-4 py-2 bg-primary-600 hover:bg-primary-700 text-white text-sm font-medium rounded-lg transition-colors duration-200"
             aria-label="Undo dismiss"
             onClick={onUndo}
           >

--- a/app/frontend/components/DismissedArticlesList.tsx
+++ b/app/frontend/components/DismissedArticlesList.tsx
@@ -15,7 +15,7 @@ export default function DismissedArticlesList({
   const cardVariant = variant === 'recent' ? 'recent-dismissed' : 'dismissed'
 
   return (
-    <div className="grid gap-6 animate-scale-in">
+    <div className="grid gap-5 md:gap-6 motion-safe:animate-scale-in motion-sensitive">
       {articles.map((article, index) => (
         <ArticleCard
           key={article.id}

--- a/app/frontend/components/EmptyState.tsx
+++ b/app/frontend/components/EmptyState.tsx
@@ -27,7 +27,7 @@ export default function EmptyState({
   actions = [],
 }: EmptyStateProps) {
   return (
-    <Card padding="empty" animate>
+    <Card tone="panel" padding="empty" animate>
       <div
         className={`w-20 h-20 mx-auto mb-6 rounded-full flex items-center justify-center ${iconWrapperClassName}`}
       >

--- a/app/frontend/components/PageHeader.tsx
+++ b/app/frontend/components/PageHeader.tsx
@@ -32,7 +32,7 @@ export default function PageHeader({
   fetchMessage = null,
 }: PageHeaderProps) {
   return (
-    <Card padding="lg" className="mb-8" animate>
+    <Card padding="lg" tone="elevated" className="mb-8" animate>
       <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-6">
         <div>
           <h1 className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-primary-400 to-primary-600 bg-clip-text text-transparent mb-2">

--- a/app/frontend/components/PaginationControls.tsx
+++ b/app/frontend/components/PaginationControls.tsx
@@ -26,7 +26,7 @@ export default function PaginationControls({
 
   return (
     <nav
-      className="glass-effect rounded-2xl p-4 mt-8 flex flex-col sm:flex-row items-center justify-between gap-4"
+      className="surface-subtle rounded-xl p-4 mt-8 flex flex-col sm:flex-row items-center justify-between gap-4"
       aria-label="Articles pagination"
       data-testid="articles-pagination"
     >

--- a/app/frontend/components/ReadArticlesList.tsx
+++ b/app/frontend/components/ReadArticlesList.tsx
@@ -18,7 +18,7 @@ export default function ReadArticlesList({
       : articles.filter((article) => article.source_type === activeSource)
 
   return (
-    <div className="grid gap-6 animate-scale-in">
+    <div className="grid gap-5 md:gap-6 motion-safe:animate-scale-in motion-sensitive">
       {filtered.map((article, index) => (
         <ArticleCard
           key={article.id}

--- a/app/frontend/components/ScoreFilter.tsx
+++ b/app/frontend/components/ScoreFilter.tsx
@@ -1,3 +1,6 @@
+import Button from './ui/Button'
+import Card from './ui/Card'
+
 export type ScoreFilterValue = 'all' | '50' | '100' | '500' | 'top10'
 
 interface ScoreFilterProps {
@@ -14,29 +17,24 @@ const OPTIONS: { value: ScoreFilterValue; label: string }[] = [
 ]
 
 export default function ScoreFilter({ activeScoreFilter, onScoreFilterChange }: ScoreFilterProps) {
-  const activeClasses =
-    'px-4 py-2 rounded-xl text-sm font-medium bg-gradient-to-r from-primary-600 to-primary-700 text-white shadow-lg shadow-primary-500/20'
-  const inactiveClasses =
-    'px-4 py-2 rounded-xl text-sm font-medium bg-dark-800 border border-dark-700 text-gray-400 hover:text-gray-200 hover:border-dark-600 transition-colors'
-
   return (
-    <div className="glass-effect rounded-2xl p-6 mb-8 animate-fade-in">
+    <Card tone="subtle" className="mb-8">
       <h2 className="text-lg font-semibold text-gray-200 mb-4">Filter by score</h2>
       <div className="flex flex-wrap gap-3">
         {OPTIONS.map((option) => (
-          <button
+          <Button
             key={option.value}
-            type="button"
-            className={activeScoreFilter === option.value ? activeClasses : inactiveClasses}
+            variant="filter"
+            active={activeScoreFilter === option.value}
             data-score-filter={option.value}
             aria-pressed={activeScoreFilter === option.value}
             onClick={() => onScoreFilterChange(option.value)}
           >
             {option.label}
-          </button>
+          </Button>
         ))}
       </div>
-    </div>
+    </Card>
   )
 }
 

--- a/app/frontend/components/SourceFilter.tsx
+++ b/app/frontend/components/SourceFilter.tsx
@@ -18,8 +18,8 @@ export default function SourceFilter({
   onSourceChange,
 }: SourceFilterProps) {
   return (
-    <div className="mb-8 animate-slide-up">
-      <Card>
+    <div className="mb-8">
+      <Card tone="subtle">
         <h3 className="text-lg font-semibold text-gray-200 mb-4 flex items-center">
           <svg className="w-5 h-5 mr-2 text-primary-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.707A1 1 0 013 7V4z" />

--- a/app/frontend/components/articleCard/ArticleCardLayout.tsx
+++ b/app/frontend/components/articleCard/ArticleCardLayout.tsx
@@ -4,7 +4,7 @@ import { cn } from '../../utils/cn'
 import { DetailsLink } from './CardActions'
 import CardMetadata from './CardMetadata'
 import CardTitle from './CardTitle'
-import { CARD_THEMES, type ArticleCardData, type ArticleCardTheme } from './cardThemes'
+import { CARD_THEMES, type ArticleCardData, type ArticleCardAccent, type ArticleCardTheme } from './cardThemes'
 
 interface ArticleCardLayoutProps {
   article: ArticleCardData
@@ -20,6 +20,15 @@ interface ArticleCardLayoutProps {
   detailsHref?: string
   onArticleClick?: () => void
   articleStyle?: CSSProperties
+  accentBar?: ArticleCardAccent
+  featured?: boolean
+}
+
+const ACCENT_BAR_CLASSES: Record<NonNullable<ArticleCardAccent>, string> = {
+  primary: 'border-l-[3px] border-l-primary-500/70',
+  green: 'border-l-[3px] border-l-green-500/70',
+  orange: 'border-l-[3px] border-l-orange-500/70',
+  red: 'border-l-[3px] border-l-red-500/70',
 }
 
 export default function ArticleCardLayout({
@@ -36,18 +45,24 @@ export default function ArticleCardLayout({
   detailsHref,
   onArticleClick,
   articleStyle,
+  accentBar,
+  featured = false,
 }: ArticleCardLayoutProps) {
   const styles = CARD_THEMES[theme]
 
   return (
     <article
       className={cn(
-        'article-card group glass-effect rounded-2xl p-6 transition-all duration-300 hover:scale-[1.02] hover:shadow-2xl animate-fade-in',
-        styles.shadowHover,
+        'article-card group surface-card rounded-2xl transition-colors duration-200 motion-safe:animate-fade-in motion-sensitive',
+        featured ? 'p-7 md:p-8' : 'p-6',
+        accentBar && ACCENT_BAR_CLASSES[accentBar],
+        accentBar && 'pl-5',
+        styles.borderHover,
         borderClass
       )}
       data-source={article.source_type}
       data-category={categorySlug}
+      data-featured={featured || undefined}
       style={{
         animationDelay: `${index * 50}ms`,
         ...articleStyle,
@@ -68,7 +83,7 @@ export default function ArticleCardLayout({
         </p>
       )}
 
-      <div className="flex justify-between items-center text-sm border-t border-dark-700 pt-4">
+      <div className="flex justify-between items-center text-sm border-t border-dark-700/80 pt-4">
         <CardMetadata article={article} styles={styles} extra={extraMetadata} />
         <div className="flex items-center space-x-3">
           {actions}

--- a/app/frontend/components/articleCard/CardActions.tsx
+++ b/app/frontend/components/articleCard/CardActions.tsx
@@ -9,13 +9,13 @@ function stopPropagation(event: MouseEvent) {
 }
 
 const ICON_BTN =
-  'p-2 rounded-lg transition-all duration-200 hover:scale-110 hover:shadow-lg'
+  'p-2 rounded-lg border border-transparent transition-colors duration-200 motion-sensitive'
 
 export function DismissButton({ onClick }: { onClick: () => void }) {
   return (
     <button
       type="button"
-      className="group/dismiss p-1.5 text-gray-500 hover:text-red-400 hover:bg-red-400/10 rounded-lg transition-all duration-200 hover:scale-110"
+      className="group/dismiss p-1.5 text-gray-500 hover:text-red-400 hover:bg-red-400/10 rounded-lg transition-colors duration-200 motion-sensitive"
       title="Dismiss article"
       aria-label="Dismiss article"
       onClick={(event) => {
@@ -24,7 +24,7 @@ export function DismissButton({ onClick }: { onClick: () => void }) {
       }}
     >
       <svg
-        className="w-4 h-4 transition-transform group-hover/dismiss:scale-110"
+        className="w-4 h-4"
         fill="none"
         stroke="currentColor"
         viewBox="0 0 24 24"
@@ -57,9 +57,9 @@ export function BookmarkButton({ active, mode, onClick }: BookmarkButtonProps) {
         'group/bookmark',
         isRemove || active
           ? isRemove
-            ? 'bg-gradient-to-r from-red-600 to-red-700 text-white hover:from-red-700 hover:to-red-800 hover:shadow-red-500/25'
-            : 'bg-gradient-to-r from-primary-600 to-primary-700 text-white hover:from-primary-700 hover:to-primary-800 hover:shadow-primary-500/25'
-          : 'bg-dark-700 border border-dark-600 text-gray-400 hover:bg-primary-600 hover:border-primary-500 hover:text-white hover:shadow-primary-500/25'
+            ? 'bg-red-600/15 border-red-500/40 text-red-300 hover:bg-red-600/25 hover:border-red-500/60'
+            : 'bg-primary-600/15 border-primary-500/40 text-primary-300 hover:bg-primary-600/25 hover:border-primary-500/60'
+          : 'bg-dark-800/80 border-dark-600 text-gray-400 hover:bg-primary-600/10 hover:border-primary-500/40 hover:text-primary-200'
       )}
       title={title}
       aria-label={title}
@@ -69,7 +69,7 @@ export function BookmarkButton({ active, mode, onClick }: BookmarkButtonProps) {
       }}
     >
       <svg
-        className="w-4 h-4 transition-transform group-hover/bookmark:scale-110"
+        className="w-4 h-4"
         fill={active || isRemove ? 'currentColor' : 'none'}
         stroke="currentColor"
         viewBox="0 0 24 24"
@@ -102,10 +102,10 @@ export function ReadButton({ active, mode, onClick }: ReadButtonProps) {
         ICON_BTN,
         'group/read',
         isUnmark
-          ? 'bg-gradient-to-r from-orange-600 to-orange-700 text-white hover:from-orange-700 hover:to-orange-800 hover:shadow-orange-500/25'
+          ? 'bg-orange-600/15 border-orange-500/40 text-orange-300 hover:bg-orange-600/25 hover:border-orange-500/60'
           : active
-            ? 'bg-gradient-to-r from-green-600 to-green-700 text-white hover:from-orange-600 hover:to-orange-700 hover:shadow-orange-500/25'
-            : 'bg-dark-700 border border-dark-600 text-gray-400 hover:bg-green-600 hover:border-green-500 hover:text-white hover:shadow-green-500/25'
+            ? 'bg-green-600/15 border-green-500/40 text-green-300 hover:bg-orange-600/15 hover:border-orange-500/40 hover:text-orange-200'
+            : 'bg-dark-800/80 border-dark-600 text-gray-400 hover:bg-green-600/10 hover:border-green-500/40 hover:text-green-200'
       )}
       title={title}
       aria-label={title}
@@ -115,7 +115,7 @@ export function ReadButton({ active, mode, onClick }: ReadButtonProps) {
       }}
     >
       <svg
-        className="w-4 h-4 transition-transform group-hover/read:scale-110"
+        className="w-4 h-4"
         fill={active && !isUnmark ? 'currentColor' : 'none'}
         stroke="currentColor"
         viewBox="0 0 24 24"
@@ -136,7 +136,7 @@ export function RestoreButton({ label, onClick }: { label: string; onClick: () =
     <Button color="green" size="sm" className="group/restore" title="Restore article" onClick={onClick}>
       <span className="flex items-center">
         <svg
-          className="w-4 h-4 mr-2 transition-transform group-hover/restore:scale-110"
+          className="w-4 h-4 mr-2"
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
@@ -158,13 +158,13 @@ export function DetailsLink({ href, styles }: { href: string; styles: CardThemeS
   return (
     <Link
       to={href}
-      className={`group/detail px-4 py-2 bg-gradient-to-r from-dark-700 to-dark-600 border border-dark-500 text-gray-300 rounded-lg font-medium transition-all duration-200 ${styles.detailsHover} hover:text-white hover:scale-105 hover:shadow-lg`}
+      className={`group/detail px-4 py-2 bg-dark-800/80 border border-dark-600 text-gray-300 rounded-lg font-medium transition-colors duration-200 motion-sensitive ${styles.detailsHover} hover:text-white hover:border-dark-500`}
       onClick={stopPropagation}
     >
       <span className="flex items-center">
         Details
         <svg
-          className="w-4 h-4 ml-2 transition-transform group-hover/detail:translate-x-1"
+          className="w-4 h-4 ml-2 transition-transform motion-safe:group-hover/detail:translate-x-0.5"
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"

--- a/app/frontend/components/articleCard/cardThemes.ts
+++ b/app/frontend/components/articleCard/cardThemes.ts
@@ -15,10 +15,12 @@ export type ArticleCardTheme = 'primary' | 'green' | 'red' | 'orange'
 
 export type ArticleCardVariant = 'feed' | 'bookmark' | 'read' | 'dismissed' | 'recent-dismissed'
 
+export type ArticleCardAccent = 'primary' | 'green' | 'orange' | 'red'
+
 export interface CardThemeStyles {
   titleHover: string
   linkHover: string
-  shadowHover: string
+  borderHover: string
   badgeVariant: BadgeVariant
   detailsHover: string
   dateAccent: string
@@ -28,7 +30,7 @@ export const CARD_THEMES: Record<ArticleCardTheme, CardThemeStyles> = {
   primary: {
     titleHover: 'group-hover:text-primary-300',
     linkHover: 'hover:text-primary-400',
-    shadowHover: 'hover:shadow-primary-500/10',
+    borderHover: 'hover:border-primary-500/25',
     badgeVariant: 'primary',
     detailsHover:
       'hover:from-primary-600 hover:to-primary-700 hover:border-primary-500 hover:shadow-primary-500/20',
@@ -37,7 +39,7 @@ export const CARD_THEMES: Record<ArticleCardTheme, CardThemeStyles> = {
   green: {
     titleHover: 'group-hover:text-green-300',
     linkHover: 'hover:text-green-400',
-    shadowHover: 'hover:shadow-green-500/10',
+    borderHover: 'hover:border-green-500/25',
     badgeVariant: 'green',
     detailsHover:
       'hover:from-green-600 hover:to-green-700 hover:border-green-500 hover:shadow-green-500/20',
@@ -46,7 +48,7 @@ export const CARD_THEMES: Record<ArticleCardTheme, CardThemeStyles> = {
   red: {
     titleHover: 'group-hover:text-red-300',
     linkHover: 'hover:text-red-400',
-    shadowHover: 'hover:shadow-red-500/10',
+    borderHover: 'hover:border-red-500/25',
     badgeVariant: 'red',
     detailsHover:
       'hover:from-primary-600 hover:to-primary-700 hover:border-primary-500 hover:shadow-primary-500/20',
@@ -55,7 +57,7 @@ export const CARD_THEMES: Record<ArticleCardTheme, CardThemeStyles> = {
   orange: {
     titleHover: 'group-hover:text-orange-300',
     linkHover: 'hover:text-orange-400',
-    shadowHover: 'hover:shadow-orange-500/10',
+    borderHover: 'hover:border-orange-500/25',
     badgeVariant: 'orange',
     detailsHover:
       'hover:from-primary-600 hover:to-primary-700 hover:border-primary-500 hover:shadow-primary-500/20',

--- a/app/frontend/components/ui/Card.tsx
+++ b/app/frontend/components/ui/Card.tsx
@@ -2,11 +2,13 @@ import type { ElementType, ReactNode } from 'react'
 import { cn } from '../../utils/cn'
 
 export type CardPadding = 'sm' | 'md' | 'lg' | 'empty'
+export type CardTone = 'elevated' | 'card' | 'subtle' | 'panel'
 
 export interface CardProps {
   children: ReactNode
   as?: ElementType
   padding?: CardPadding
+  tone?: CardTone
   className?: string
   animate?: boolean
 }
@@ -18,19 +20,27 @@ const PADDING_CLASSES: Record<CardPadding, string> = {
   empty: 'p-12 text-center',
 }
 
+const TONE_CLASSES: Record<CardTone, string> = {
+  elevated: 'surface-elevated rounded-2xl',
+  card: 'surface-card rounded-2xl',
+  subtle: 'surface-subtle rounded-xl',
+  panel: 'surface-panel rounded-2xl',
+}
+
 export default function Card({
   children,
   as: Component = 'div',
   padding = 'md',
+  tone = 'card',
   className,
   animate = false,
 }: CardProps) {
   return (
     <Component
       className={cn(
-        'glass-effect rounded-2xl',
+        TONE_CLASSES[tone],
         PADDING_CLASSES[padding],
-        animate && 'animate-fade-in',
+        animate && 'motion-safe:animate-fade-in motion-sensitive',
         className
       )}
     >

--- a/app/frontend/components/ui/PageHeading.tsx
+++ b/app/frontend/components/ui/PageHeading.tsx
@@ -12,12 +12,12 @@ interface PageHeadingProps {
 export default function PageHeading({
   title,
   subtitle,
-  titleClassName = 'bg-gradient-to-r from-primary-400 to-primary-600 bg-clip-text text-transparent',
+  titleClassName = 'text-gray-100',
   actions,
   meta,
 }: PageHeadingProps) {
   return (
-    <Card padding="lg" className="mb-8" animate>
+    <Card padding="lg" tone="elevated" className="mb-8" animate>
       <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 md:gap-6">
         <div>
           <h1 className={`text-3xl md:text-4xl font-bold mb-2 ${titleClassName}`}>{title}</h1>

--- a/app/frontend/components/ui/buttonStyles.ts
+++ b/app/frontend/components/ui/buttonStyles.ts
@@ -104,7 +104,6 @@ export function buttonClassName({
         gradient.to,
         gradient.hoverFrom,
         gradient.hoverTo,
-        'hover:scale-105 hover:shadow-lg',
         gradient.shadow,
         className
       )
@@ -112,7 +111,7 @@ export function buttonClassName({
     return cn(
       base,
       filterSize,
-      'filter-btn bg-dark-800 border border-dark-700 text-gray-300 hover:bg-dark-700 hover:border-primary-500 hover:text-white hover:scale-105 hover:shadow-lg hover:shadow-primary-500/10',
+      'filter-btn border border-dark-700 bg-transparent text-gray-400 hover:text-gray-200 hover:border-dark-500 hover:bg-dark-800/50',
       className
     )
   }

--- a/app/frontend/components/ui/ui.test.tsx
+++ b/app/frontend/components/ui/ui.test.tsx
@@ -26,7 +26,7 @@ describe('buttonClassName', () => {
     const classes = buttonClassName({ variant: 'filter', active: false })
     expect(classes).toContain('filter-btn')
     expect(classes).not.toContain('active')
-    expect(classes).toContain('bg-dark-800')
+    expect(classes).toContain('border-dark-700')
   })
 
   it('maps danger variant to red gradient', () => {

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -38,9 +38,76 @@
     border: 1px solid rgb(168 85 247 / 0.3);
   }
 
+  /* Layered surfaces — varied depth instead of identical glass panels */
+  .surface-elevated {
+    backdrop-filter: blur(12px);
+    background: rgba(30, 41, 59, 0.88);
+    border: 1px solid rgb(51 65 85 / 0.85);
+    box-shadow: 0 4px 24px rgb(0 0 0 / 0.18);
+  }
+
+  .surface-card {
+    background: rgba(30, 41, 59, 0.5);
+    border: 1px solid rgb(51 65 85 / 0.75);
+    backdrop-filter: blur(6px);
+    transition: border-color 0.2s ease, background-color 0.2s ease;
+  }
+
+  .surface-card:hover {
+    border-color: rgb(71 85 105 / 0.9);
+    background: rgba(30, 41, 59, 0.58);
+  }
+
+  .surface-subtle {
+    background: rgba(15, 23, 42, 0.35);
+    border: 1px solid rgb(51 65 85 / 0.45);
+  }
+
+  .surface-panel {
+    background: rgba(30, 41, 59, 0.72);
+    border: 1px solid rgb(51 65 85 / 0.8);
+    backdrop-filter: blur(8px);
+  }
+
+  /* Backward compatibility — maps to content card surface */
   .glass-effect {
-    backdrop-filter: blur(10px);
-    background: rgba(30, 41, 59, 0.7);
-    border: 1px solid rgba(168, 85, 247, 0.2);
+    background: rgba(30, 41, 59, 0.5);
+    border: 1px solid rgb(51 65 85 / 0.75);
+    backdrop-filter: blur(6px);
+    transition: border-color 0.2s ease, background-color 0.2s ease;
+  }
+
+  .app-background {
+    position: relative;
+    min-height: 100vh;
+    background: linear-gradient(to bottom right, #0f172a, #172033, #0f172a);
+  }
+
+  .app-background::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background:
+      radial-gradient(ellipse 70% 45% at 15% 10%, rgb(147 51 234 / 0.07), transparent),
+      radial-gradient(ellipse 55% 35% at 85% 90%, rgb(124 58 237 / 0.05), transparent);
+  }
+
+  .app-background > * {
+    position: relative;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .motion-sensitive,
+  .animate-fade-in,
+  .animate-slide-up,
+  .animate-scale-in,
+  .animate-slide-in {
+    animation: none !important;
+  }
+
+  .motion-sensitive {
+    transition: none !important;
   }
 }

--- a/app/frontend/pages/ArticleShowPage.tsx
+++ b/app/frontend/pages/ArticleShowPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
-import { Link, useParams } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import {
   bookmarkArticle,
   fetchArticle,
@@ -14,6 +14,8 @@ import {
   safeExternalUrl,
 } from '../utils/format'
 import { useConfirmDialog } from '../hooks/useConfirmDialog'
+import Button from '../components/ui/Button'
+import { buttonClassName } from '../components/ui/Button'
 
 export default function ArticleShowPage() {
   const { id } = useParams<{ id: string }>()
@@ -115,7 +117,7 @@ export default function ArticleShowPage() {
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-4xl" data-testid="article-show-page">
-      <article className="glass-effect rounded-2xl p-8 md:p-12 animate-slide-up">
+      <article className="surface-panel rounded-2xl p-8 md:p-12 motion-safe:animate-slide-up motion-sensitive">
         <div className="mb-8">
           <div className="flex flex-wrap items-center gap-4 mb-6">
             <span className="inline-block px-4 py-2 text-sm font-semibold bg-gradient-to-r from-primary-600/20 to-primary-700/20 text-primary-300 border border-primary-500/30 rounded-full">
@@ -191,17 +193,13 @@ export default function ArticleShowPage() {
             </div>
 
             <div className="flex flex-wrap gap-4">
-              <button
-                type="button"
-                className={
-                  article.read
-                    ? 'group inline-flex items-center px-6 py-3 bg-gradient-to-r from-green-600 to-green-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-orange-600 hover:to-orange-700 hover:scale-105 hover:shadow-lg hover:shadow-orange-500/25'
-                    : 'group inline-flex items-center px-6 py-3 bg-gradient-to-r from-green-600 to-green-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-green-700 hover:to-green-800 hover:scale-105 hover:shadow-lg hover:shadow-green-500/25'
-                }
+              <Button
+                size="lg"
+                color={article.read ? 'orange' : 'green'}
                 onClick={handleReadToggle}
               >
                 <svg
-                  className="w-5 h-5 mr-2 transition-transform group-hover:scale-110"
+                  className="w-5 h-5 mr-2"
                   fill={article.read ? 'currentColor' : 'none'}
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -209,19 +207,15 @@ export default function ArticleShowPage() {
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
                 {article.read ? 'Mark as Unread' : 'Mark as Read'}
-              </button>
+              </Button>
 
-              <button
-                type="button"
-                className={
-                  article.bookmarked
-                    ? 'group inline-flex items-center px-6 py-3 bg-gradient-to-r from-red-600 to-red-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-red-700 hover:to-red-800 hover:scale-105 hover:shadow-lg hover:shadow-red-500/25'
-                    : 'group inline-flex items-center px-6 py-3 bg-gradient-to-r from-primary-600 to-primary-700 text-white rounded-xl font-medium transition-all duration-200 hover:from-primary-700 hover:to-primary-800 hover:scale-105 hover:shadow-lg hover:shadow-primary-500/25'
-                }
+              <Button
+                size="lg"
+                color={article.bookmarked ? 'red' : 'primary'}
                 onClick={handleBookmarkToggle}
               >
                 <svg
-                  className="w-5 h-5 mr-2 transition-transform group-hover:scale-110"
+                  className="w-5 h-5 mr-2"
                   fill={article.bookmarked ? 'currentColor' : 'none'}
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -233,17 +227,21 @@ export default function ArticleShowPage() {
                   )}
                 </svg>
                 {article.bookmarked ? 'Remove from Reading List' : 'Add to Reading List'}
-              </button>
+              </Button>
 
               {sourceUrl && (
                 <a
                   href={sourceUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="group inline-flex items-center px-6 py-3 bg-gradient-to-r from-dark-700 to-dark-600 border border-dark-500 text-gray-300 rounded-xl font-medium transition-all duration-200 hover:from-primary-600 hover:to-primary-700 hover:border-primary-500 hover:text-white hover:scale-105 hover:shadow-lg hover:shadow-primary-500/25"
+                  className={buttonClassName({
+                    variant: 'secondary',
+                    size: 'lg',
+                    className: 'hover:border-primary-500/40 hover:text-white',
+                  })}
                 >
                   Visit Source
-                  <svg className="w-5 h-5 ml-2 transition-transform group-hover:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg className="w-5 h-5 ml-2 motion-safe:group-hover:translate-x-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
                   </svg>
                 </a>

--- a/app/frontend/pages/ArticlesIndexPage.tsx
+++ b/app/frontend/pages/ArticlesIndexPage.tsx
@@ -17,6 +17,7 @@ import ArticleList from '../components/ArticleList'
 import CategoryFilter from '../components/CategoryFilter'
 import DismissToast from '../components/DismissToast'
 import PageHeader from '../components/PageHeader'
+import Card from '../components/ui/Card'
 import PaginationControls from '../components/PaginationControls'
 import ScoreFilter, { parseScoreFilter, scoreFilterParams, type ScoreFilterValue } from '../components/ScoreFilter'
 import { usePatchSearchParams } from '../hooks/useSearchParamState'
@@ -323,7 +324,7 @@ export default function ArticlesIndexPage() {
           fetchingNews={fetchingNews}
           fetchMessage={fetchMessage}
         />
-        <div className="glass-effect rounded-2xl p-12 text-center animate-fade-in">
+        <Card tone="panel" padding="empty" animate>
           <div className="w-20 h-20 mx-auto mb-6 bg-gradient-to-r from-primary-600/20 to-primary-700/20 rounded-full flex items-center justify-center">
             <svg className="w-10 h-10 text-primary-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9.5a2.5 2.5 0 00-2.5-2.5H15" />
@@ -342,7 +343,7 @@ export default function ArticlesIndexPage() {
           >
             {fetchingNews ? 'Fetching...' : 'Fetch News'}
           </button>
-        </div>
+        </Card>
       </div>
     )
   }

--- a/app/frontend/pages/DismissedArticlesIndexPage.tsx
+++ b/app/frontend/pages/DismissedArticlesIndexPage.tsx
@@ -49,7 +49,6 @@ export default function DismissedArticlesIndexPage() {
       <PageHeading
         title="Dismissed Articles"
         subtitle="Articles you've dismissed from your feed"
-        titleClassName="bg-gradient-to-r from-red-400 to-red-600 bg-clip-text text-transparent"
         actions={
           <NavLink
             to="/recently_dismissed"

--- a/app/frontend/pages/ReadArticlesIndexPage.tsx
+++ b/app/frontend/pages/ReadArticlesIndexPage.tsx
@@ -65,7 +65,6 @@ export default function ReadArticlesIndexPage() {
       <PageHeading
         title="Already Read"
         subtitle="Articles you've finished reading"
-        titleClassName="bg-gradient-to-r from-green-400 to-green-600 bg-clip-text text-transparent"
         meta={
           <div className="text-sm text-gray-400">
             <div className="flex items-center space-x-2">

--- a/app/frontend/pages/RecentlyDismissedPage.tsx
+++ b/app/frontend/pages/RecentlyDismissedPage.tsx
@@ -44,7 +44,6 @@ export default function RecentlyDismissedPage() {
       <PageHeading
         title="Recently Dismissed"
         subtitle="Articles dismissed in the last 24 hours - easy to restore"
-        titleClassName="bg-gradient-to-r from-orange-400 to-orange-600 bg-clip-text text-transparent"
         actions={
           <NavLink
             to="/dismissed"
@@ -100,7 +99,7 @@ export default function RecentlyDismissedPage() {
         />
       ) : (
         <>
-          <div className="glass-effect rounded-xl p-4 mb-6 bg-gradient-to-r from-orange-600/10 to-orange-700/10 border border-orange-500/30">
+          <div className="surface-subtle rounded-xl p-4 mb-6 border border-orange-500/20 bg-orange-600/5">
             <div className="flex items-center text-orange-300">
               <svg className="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,7 @@
   </head>
 
   <body class="bg-dark-900 min-h-screen text-gray-100 antialiased scroll-smooth">
-    <div class="min-h-screen bg-gradient-to-br from-dark-900 via-dark-850 to-dark-900">
+    <div class="min-h-screen app-background">
       <div id="root"></div>
       <%= yield %>
     </div>


### PR DESCRIPTION
## Summary
- Replace uniform glass panels with layered surfaces (elevated nav/headers, subtle filters, content cards)
- Remove card scale hovers; use border/background shifts and left accent bars for bookmark/read/dismissed state
- Add `prefers-reduced-motion` support, softer filter pills, radial background depth, and featured cards for high scores

## Test plan
- [x] Vitest (23 tests)
- [x] System tests (49 runs; 1 flaky category-filter timing, passes on retry)
- [ ] CI green

Closes #158