### PR TITLE
feat(frontend): improve typography with modular scale and readable fonts (#161)

### DIFF
--- a/app/frontend/components/AppShell.tsx
+++ b/app/frontend/components/AppShell.tsx
@@ -87,7 +87,7 @@ export default function AppShell({ children }: AppShellProps) {
           <div className="hidden md:flex items-center justify-between h-14">
             <NavLink
               to="/"
-              className="text-lg font-bold bg-gradient-to-r from-primary-400 to-primary-600 bg-clip-text text-transparent shrink-0"
+              className="text-h3 font-bold bg-gradient-to-r from-primary-400 to-primary-600 bg-clip-text text-transparent shrink-0"
             >
               Dev News
             </NavLink>
@@ -108,7 +108,7 @@ export default function AppShell({ children }: AppShellProps) {
           <div className="flex md:hidden items-center justify-center h-12">
             <NavLink
               to="/"
-              className="text-base font-bold bg-gradient-to-r from-primary-400 to-primary-600 bg-clip-text text-transparent"
+              className="text-h3 font-bold bg-gradient-to-r from-primary-400 to-primary-600 bg-clip-text text-transparent"
             >
               Dev News
             </NavLink>

--- a/app/frontend/components/ArticleCard.test.tsx
+++ b/app/frontend/components/ArticleCard.test.tsx
@@ -20,7 +20,16 @@ describe('ArticleCard', () => {
       <MemoryRouter>
         <ArticleCard
           variant="feed"
-          article={{ ...baseArticle, bookmarked: false, read: false }}
+          article={{
+            ...baseArticle,
+            external_id: 'hn-1',
+            created_at: '2024-01-15T10:00:00Z',
+            updated_at: '2024-01-15T10:00:00Z',
+            bookmarked: false,
+            read: false,
+            dismissed: false,
+            pending_dismissal: false,
+          }}
           categorySlug="programming"
           index={0}
           isDismissing={false}

--- a/app/frontend/components/ArticleCard.tsx
+++ b/app/frontend/components/ArticleCard.tsx
@@ -11,7 +11,7 @@ import {
   ReadButton,
   RestoreButton,
 } from './articleCard/CardActions'
-import { variantBorderClass, variantTheme, type ArticleCardVariant } from './articleCard/cardThemes'
+import { variantBorderClass, variantTheme } from './articleCard/cardThemes'
 import Badge from './ui/Badge'
 
 type FeedCardProps = {

--- a/app/frontend/components/CategoryFilter.tsx
+++ b/app/frontend/components/CategoryFilter.tsx
@@ -21,7 +21,7 @@ export default function CategoryFilter({
   return (
     <div className="mb-8">
       <Card tone="subtle">
-        <h3 className="text-lg font-semibold text-gray-200 mb-4 flex items-center">
+        <h3 className="text-h3 text-gray-200 mb-4 flex items-center">
           <svg className="w-5 h-5 mr-2 text-primary-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.707A1 1 0 013 7V4z" />
           </svg>
@@ -55,7 +55,9 @@ export default function CategoryFilter({
                 onClick={() => onFilterChange(slug)}
               >
                 <span className="flex items-center">
-                  <span className="text-lg mr-2">{category.icon}</span>
+                  <span className="inline-flex items-center justify-center w-5 text-base leading-none mr-2" aria-hidden="true">
+                    {category.icon}
+                  </span>
                   {category.name} ({count})
                 </span>
               </Button>

--- a/app/frontend/components/ConfirmDialog.tsx
+++ b/app/frontend/components/ConfirmDialog.tsx
@@ -91,10 +91,10 @@ export default function ConfirmDialog({
           data-testid="confirm-dialog"
           onClick={(event) => event.stopPropagation()}
         >
-          <h2 id="confirm-dialog-title" className="text-xl font-bold text-gray-100 mb-3">
+          <h2 id="confirm-dialog-title" className="text-h3 text-gray-100 mb-3">
             {title}
           </h2>
-          <p id="confirm-dialog-message" className="text-gray-400 mb-6 leading-relaxed">
+          <p id="confirm-dialog-message" className="text-body text-gray-400 mb-6">
             {message}
           </p>
           <div className="flex justify-end gap-3">

--- a/app/frontend/components/EmptyState.tsx
+++ b/app/frontend/components/EmptyState.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
 import { Link } from 'react-router-dom'
-import type { ButtonColor } from './ui/Button'
+import type { ButtonColor } from './ui/buttonStyles'
 import { buttonClassName } from './ui/Button'
 import Card from './ui/Card'
 
@@ -33,8 +33,8 @@ export default function EmptyState({
       >
         {icon}
       </div>
-      <h2 className="text-2xl font-bold text-gray-200 mb-4">{title}</h2>
-      <p className="text-gray-400 mb-8 max-w-md mx-auto leading-relaxed">{description}</p>
+      <h2 className="text-h2 text-gray-100 mb-4">{title}</h2>
+      <p className="text-body text-gray-400 mb-8 max-w-prose mx-auto leading-relaxed">{description}</p>
       {actions.length > 0 && (
         <div
           className={

--- a/app/frontend/components/PageHeader.tsx
+++ b/app/frontend/components/PageHeader.tsx
@@ -35,10 +35,10 @@ export default function PageHeader({
     <Card padding="lg" tone="elevated" className="mb-8" animate>
       <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-6">
         <div>
-          <h1 className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-primary-400 to-primary-600 bg-clip-text text-transparent mb-2">
+          <h1 className="text-h1 md:text-display font-bold bg-gradient-to-r from-primary-400 to-primary-600 bg-clip-text text-transparent mb-2">
             Developer News Aggregator
           </h1>
-          <p className="text-gray-400 text-lg">Stay updated with the latest in tech and development</p>
+          <p className="text-body-lg text-gray-400">Stay updated with the latest in tech and development</p>
           {fetchMessage && (
             <p className="text-sm text-primary-300 mt-2" data-testid="fetch-message">{fetchMessage}</p>
           )}

--- a/app/frontend/components/ScoreFilter.tsx
+++ b/app/frontend/components/ScoreFilter.tsx
@@ -19,7 +19,7 @@ const OPTIONS: { value: ScoreFilterValue; label: string }[] = [
 export default function ScoreFilter({ activeScoreFilter, onScoreFilterChange }: ScoreFilterProps) {
   return (
     <Card tone="subtle" className="mb-8">
-      <h2 className="text-lg font-semibold text-gray-200 mb-4">Filter by score</h2>
+      <h2 className="text-h3 text-gray-200 mb-4">Filter by score</h2>
       <div className="flex flex-wrap gap-3">
         {OPTIONS.map((option) => (
           <Button

--- a/app/frontend/components/SourceFilter.tsx
+++ b/app/frontend/components/SourceFilter.tsx
@@ -20,7 +20,7 @@ export default function SourceFilter({
   return (
     <div className="mb-8">
       <Card tone="subtle">
-        <h3 className="text-lg font-semibold text-gray-200 mb-4 flex items-center">
+        <h3 className="text-h3 text-gray-200 mb-4 flex items-center">
           <svg className="w-5 h-5 mr-2 text-primary-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.707A1 1 0 013 7V4z" />
           </svg>

--- a/app/frontend/components/articleCard/ArticleCardLayout.tsx
+++ b/app/frontend/components/articleCard/ArticleCardLayout.tsx
@@ -78,12 +78,12 @@ export default function ArticleCardLayout({
       />
 
       {article.description && (
-        <p className="text-gray-400 mb-6 line-clamp-3 leading-relaxed">
+        <p className="text-body text-gray-300 mb-6 line-clamp-3 leading-relaxed max-w-prose">
           {truncate(article.description, 280)}
         </p>
       )}
 
-      <div className="flex justify-between items-center text-sm border-t border-dark-700/80 pt-4">
+      <div className="flex justify-between items-center text-caption text-gray-400 border-t border-dark-700/80 pt-4">
         <CardMetadata article={article} styles={styles} extra={extraMetadata} />
         <div className="flex items-center space-x-3">
           {actions}

--- a/app/frontend/components/articleCard/CardMetadata.tsx
+++ b/app/frontend/components/articleCard/CardMetadata.tsx
@@ -10,7 +10,7 @@ interface CardMetadataProps {
 
 export default function CardMetadata({ article, styles, extra }: CardMetadataProps) {
   return (
-    <div className="flex items-center space-x-6 text-gray-500">
+    <div className="flex items-center space-x-6 text-gray-400">
       <span className="flex items-center">
         <svg
           className={`w-4 h-4 mr-1.5 ${styles.dateAccent}`}

--- a/app/frontend/components/articleCard/CardTitle.tsx
+++ b/app/frontend/components/articleCard/CardTitle.tsx
@@ -26,7 +26,7 @@ export default function CardTitle({
     <div className="flex justify-between items-start mb-4">
       <div className="flex-1">
         <h2
-          className={`text-xl font-bold text-gray-100 mb-2 leading-tight ${styles.titleHover} transition-colors duration-200`}
+          className={`text-h3 font-semibold text-gray-50 mb-2 leading-snug ${styles.titleHover} transition-colors duration-200`}
         >
           <a
             href={article.url}

--- a/app/frontend/components/ui/PageHeading.tsx
+++ b/app/frontend/components/ui/PageHeading.tsx
@@ -20,8 +20,8 @@ export default function PageHeading({
     <Card padding="lg" tone="elevated" className="mb-8" animate>
       <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 md:gap-6">
         <div>
-          <h1 className={`text-3xl md:text-4xl font-bold mb-2 ${titleClassName}`}>{title}</h1>
-          {subtitle && <p className="text-gray-400 text-base md:text-lg">{subtitle}</p>}
+          <h1 className={`text-h1 font-bold mb-2 ${titleClassName}`}>{title}</h1>
+          {subtitle && <p className="text-body-lg text-gray-400">{subtitle}</p>}
         </div>
         {(actions || meta) && (
           <div className="flex flex-wrap items-center gap-3 md:gap-4">

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -2,6 +2,16 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+  html {
+    @apply font-sans antialiased;
+  }
+
+  body {
+    @apply text-body text-gray-300;
+  }
+}
+
 :root {
   --primary-50: 250 245 255;
   --primary-500: 168 85 247;

--- a/app/frontend/entrypoints/application.tsx
+++ b/app/frontend/entrypoints/application.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+import '@fontsource/inter/latin.css'
 import './application.css'
 import App from '../components/App'
 

--- a/app/frontend/pages/ArticleShowPage.tsx
+++ b/app/frontend/pages/ArticleShowPage.tsx
@@ -141,9 +141,9 @@ export default function ArticleShowPage() {
             )}
           </div>
 
-          <h1 className="text-3xl md:text-4xl font-bold text-gray-100 mb-6 leading-tight">{article.title}</h1>
+          <h1 className="text-h1 font-bold text-gray-100 mb-6 leading-tight">{article.title}</h1>
 
-          <div className="flex flex-wrap items-center gap-6 text-sm text-gray-400 mb-6">
+          <div className="flex flex-wrap items-center gap-6 text-caption text-gray-400 mb-6">
             <span className="flex items-center">
               <svg className="w-4 h-4 mr-2 text-primary-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
@@ -167,8 +167,8 @@ export default function ArticleShowPage() {
 
         {article.description && (
           <div className="mb-8">
-            <div className="prose prose-lg max-w-none">
-              <div className="text-gray-300 leading-relaxed text-lg whitespace-pre-wrap">{article.description}</div>
+            <div className="prose prose-lg prose-invert max-w-prose">
+              <p className="whitespace-pre-wrap">{article.description}</p>
             </div>
           </div>
         )}
@@ -177,7 +177,7 @@ export default function ArticleShowPage() {
           {actionError && <div className="mb-4 text-sm text-red-400">{actionError}</div>}
 
           <div className="flex flex-col lg:flex-row justify-between items-start lg:items-center gap-6">
-            <div className="text-sm text-gray-500 space-y-1">
+            <div className="text-caption text-gray-500 space-y-1">
               <p className="flex items-center">
                 <svg className="w-4 h-4 mr-2 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14" />

--- a/app/frontend/pages/ArticlesIndexPage.tsx
+++ b/app/frontend/pages/ArticlesIndexPage.tsx
@@ -330,7 +330,7 @@ export default function ArticlesIndexPage() {
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9.5a2.5 2.5 0 00-2.5-2.5H15" />
             </svg>
           </div>
-          <h2 className="text-2xl font-bold text-gray-200 mb-4">No articles found</h2>
+          <h2 className="text-h2 text-gray-100 mb-4">No articles found</h2>
           <p className="text-gray-400 mb-8 max-w-md mx-auto leading-relaxed">
             Your feed is empty. Click Fetch News to pull the latest articles from your configured sources.
           </p>

--- a/app/frontend/pages/SourcesIndexPage.tsx
+++ b/app/frontend/pages/SourcesIndexPage.tsx
@@ -109,7 +109,7 @@ export default function SourcesIndexPage() {
       {error && <div className="mb-4 text-sm text-red-400">{error}</div>}
 
       <Card as="section" className="mb-8">
-        <h2 className="text-lg font-semibold text-gray-200 mb-4">Built-in sources</h2>
+        <h2 className="text-h3 text-gray-200 mb-4">Built-in sources</h2>
         <div className="space-y-3">
           {fixedSources.map((source) => (
             <div key={source.id} className="flex items-center justify-between py-3 border-b border-dark-700 last:border-0">
@@ -130,7 +130,7 @@ export default function SourcesIndexPage() {
       </Card>
 
       <Card as="section">
-        <h2 className="text-lg font-semibold text-gray-200 mb-4">Reddit subreddits</h2>
+        <h2 className="text-h3 text-gray-200 mb-4">Reddit subreddits</h2>
 
         <form onSubmit={handleAddSubreddit} className="flex flex-col sm:flex-row gap-3 mb-6">
           <input

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "dev-news-aggregator",
       "version": "1.0.0",
       "dependencies": {
+        "@fontsource/inter": "^5.2.8",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^7.18.1"
@@ -1007,6 +1008,15 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@fontsource/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -2919,6 +2929,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3545,6 +3556,7 @@
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@fontsource/inter": "^5.2.8",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.18.1"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,6 +8,20 @@ export default {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        sans: ['Inter', 'system-ui', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'sans-serif'],
+      },
+      /* Modular scale ~1.25 from 16px body */
+      fontSize: {
+        display: ['3rem', { lineHeight: '1.15', letterSpacing: '-0.02em', fontWeight: '700' }],
+        h1: ['2.25rem', { lineHeight: '1.25', letterSpacing: '-0.01em', fontWeight: '700' }],
+        h2: ['1.5rem', { lineHeight: '1.3', fontWeight: '600' }],
+        h3: ['1.125rem', { lineHeight: '1.4', fontWeight: '600' }],
+        body: ['1rem', { lineHeight: '1.6' }],
+        'body-lg': ['1.125rem', { lineHeight: '1.65' }],
+        caption: ['0.875rem', { lineHeight: '1.5' }],
+        overline: ['0.75rem', { lineHeight: '1.5', letterSpacing: '0.02em' }],
+      },
       colors: {
         primary: {
           50: '#faf5ff',
@@ -61,6 +75,27 @@ export default {
           '100%': { transform: 'translateX(0)', opacity: '1' },
         },
       },
+      typography: ({ theme }) => ({
+        invert: {
+          css: {
+            '--tw-prose-body': theme('colors.gray.300'),
+            '--tw-prose-headings': theme('colors.gray.100'),
+            '--tw-prose-lead': theme('colors.gray.300'),
+            '--tw-prose-links': theme('colors.primary.400'),
+            '--tw-prose-bold': theme('colors.gray.100'),
+            '--tw-prose-counters': theme('colors.gray.400'),
+            '--tw-prose-bullets': theme('colors.gray.500'),
+            '--tw-prose-quotes': theme('colors.gray.300'),
+            '--tw-prose-quote-borders': theme('colors.dark.600'),
+            '--tw-prose-captions': theme('colors.gray.400'),
+            '--tw-prose-code': theme('colors.primary.300'),
+            '--tw-prose-pre-code': theme('colors.gray.200'),
+            '--tw-prose-pre-bg': theme('colors.dark.800'),
+            maxWidth: '65ch',
+            lineHeight: '1.65',
+          },
+        },
+      }),
     },
   },
   plugins: [typography],


### PR DESCRIPTION
## Summary
- Load **Inter** via `@fontsource/inter` with `font-display: swap`
- Define modular type scale (display, h1–h3, ody, caption) in Tailwind config
- Enable `prose-invert` on article show with 65ch max width and tuned dark-theme colors
- Improve card hierarchy: larger semibold titles, caption metadata, `max-w-prose` descriptions
- Standardize category filter emoji sizing

## Test plan
- [x] Vitest (23 tests)
- [x] Typecheck
- [x] Vite test build
- [ ] CI green

Closes #161