### PR TITLE
feat(frontend): add skeleton loading states (#162)

### DIFF
--- a/app/frontend/components/ArticleCardSkeleton.tsx
+++ b/app/frontend/components/ArticleCardSkeleton.tsx
@@ -1,0 +1,34 @@
+import { Skeleton } from './ui/Skeleton'
+
+export default function ArticleCardSkeleton() {
+  return (
+    <div className="surface-card rounded-2xl p-6" data-testid="article-card-skeleton" aria-hidden="true">
+      <div className="flex justify-between items-start mb-4 gap-4">
+        <div className="flex-1 space-y-3">
+          <Skeleton className="h-5 w-11/12" />
+          <Skeleton className="h-5 w-8/12" />
+        </div>
+        <Skeleton className="h-6 w-20 rounded-full shrink-0" />
+      </div>
+
+      <div className="space-y-2 mb-6">
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-4/5" />
+      </div>
+
+      <div className="flex justify-between items-center border-t border-dark-700/80 pt-4 gap-4">
+        <div className="flex flex-wrap items-center gap-4">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-4 w-10" />
+          <Skeleton className="h-4 w-10" />
+        </div>
+        <div className="flex items-center gap-3 shrink-0">
+          <Skeleton className="h-8 w-8 rounded-lg" />
+          <Skeleton className="h-8 w-8 rounded-lg" />
+          <Skeleton className="h-9 w-20 rounded-lg" />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/frontend/components/ArticleListSkeleton.tsx
+++ b/app/frontend/components/ArticleListSkeleton.tsx
@@ -1,0 +1,19 @@
+import ArticleCardSkeleton from './ArticleCardSkeleton'
+
+interface ArticleListSkeletonProps {
+  count?: number
+  label?: string
+}
+
+export default function ArticleListSkeleton({ count = 6, label = 'Loading articles' }: ArticleListSkeletonProps) {
+  return (
+    <div data-testid="article-list-skeleton" role="status" aria-live="polite" aria-busy="true">
+      <span className="sr-only">{label}</span>
+      <div className="grid gap-5 md:gap-6">
+        {Array.from({ length: count }, (_, index) => (
+          <ArticleCardSkeleton key={index} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/frontend/components/ArticleShowSkeleton.tsx
+++ b/app/frontend/components/ArticleShowSkeleton.tsx
@@ -1,0 +1,45 @@
+import { Skeleton } from './ui/Skeleton'
+
+export default function ArticleShowSkeleton() {
+  return (
+    <div
+      className="container mx-auto px-4 py-8 max-w-4xl"
+      data-testid="article-show-skeleton"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+    >
+      <span className="sr-only">Loading article</span>
+      <article className="surface-panel rounded-2xl p-8 md:p-12">
+        <div className="mb-8">
+          <div className="flex flex-wrap items-center gap-4 mb-6">
+            <Skeleton className="h-8 w-28 rounded-full" />
+            <Skeleton className="h-7 w-24 rounded-full" />
+          </div>
+
+          <Skeleton className="h-9 w-11/12 max-w-3xl mb-6" />
+
+          <div className="flex flex-wrap items-center gap-6 mb-6">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-4 w-20" />
+            <Skeleton className="h-4 w-24" />
+          </div>
+        </div>
+
+        <div className="space-y-3 mb-8 max-w-prose">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-5/6" />
+          <Skeleton className="h-4 w-4/6" />
+        </div>
+
+        <div className="border-t border-dark-700 pt-8 flex flex-wrap gap-4">
+          <Skeleton className="h-11 w-40 rounded-xl" />
+          <Skeleton className="h-11 w-52 rounded-xl" />
+          <Skeleton className="h-11 w-36 rounded-xl" />
+        </div>
+      </article>
+    </div>
+  )
+}

--- a/app/frontend/components/PageHeaderSkeleton.tsx
+++ b/app/frontend/components/PageHeaderSkeleton.tsx
@@ -1,0 +1,11 @@
+import Card from './ui/Card'
+import { Skeleton } from './ui/Skeleton'
+
+export default function PageHeaderSkeleton() {
+  return (
+    <Card tone="elevated" padding="lg" className="mb-8" aria-hidden="true">
+      <Skeleton className="h-10 w-2/3 max-w-xl mb-3" />
+      <Skeleton className="h-5 w-1/2 max-w-md" />
+    </Card>
+  )
+}

--- a/app/frontend/components/PageShell.tsx
+++ b/app/frontend/components/PageShell.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react'
+import ArticleListSkeleton from './ArticleListSkeleton'
 import PageContainer from './ui/PageContainer'
 import ErrorRetry from './ErrorRetry'
 
@@ -9,6 +10,7 @@ interface PageShellProps {
   error: string | null
   showFatalError: boolean
   onRetry: () => void
+  loadingSkeleton?: ReactNode
   children: ReactNode
 }
 
@@ -19,18 +21,13 @@ export default function PageShell({
   error,
   showFatalError,
   onRetry,
+  loadingSkeleton,
   children,
 }: PageShellProps) {
   if (loading) {
     return (
-      <PageContainer
-        testId={testId}
-        centered
-        role="status"
-        aria-live="polite"
-        aria-busy
-      >
-        {loadingMessage}
+      <PageContainer testId={testId} role="status" aria-live="polite" aria-busy>
+        {loadingSkeleton ?? <ArticleListSkeleton label={loadingMessage} />}
       </PageContainer>
     )
   }

--- a/app/frontend/components/RouteFallback.tsx
+++ b/app/frontend/components/RouteFallback.tsx
@@ -1,9 +1,10 @@
+import ArticleListSkeleton from './ArticleListSkeleton'
 import PageContainer from './ui/PageContainer'
 
 export default function RouteFallback() {
   return (
-    <PageContainer testId="route-loading" centered role="status" aria-live="polite">
-      Loading page...
+    <PageContainer testId="route-loading" role="status" aria-live="polite" aria-busy>
+      <ArticleListSkeleton count={4} label="Loading page" />
     </PageContainer>
   )
 }

--- a/app/frontend/components/SourcesIndexSkeleton.tsx
+++ b/app/frontend/components/SourcesIndexSkeleton.tsx
@@ -1,0 +1,39 @@
+import Card from './ui/Card'
+import { Skeleton } from './ui/Skeleton'
+
+function SourceRowSkeleton() {
+  return (
+    <div className="flex items-center justify-between py-3 border-b border-dark-700 last:border-0" aria-hidden="true">
+      <Skeleton className="h-5 w-40" />
+      <Skeleton className="h-5 w-24" />
+    </div>
+  )
+}
+
+export default function SourcesIndexSkeleton() {
+  return (
+    <div data-testid="sources-list-skeleton" role="status" aria-live="polite" aria-busy="true">
+      <span className="sr-only">Loading sources</span>
+      <Card tone="elevated" padding="lg" className="mb-8" aria-hidden="true">
+        <Skeleton className="h-9 w-48 max-w-full mb-2" />
+        <Skeleton className="h-5 w-96 max-w-full" />
+      </Card>
+
+      <Card as="section" className="mb-8" aria-hidden="true">
+        <Skeleton className="h-7 w-40 mb-4" />
+        <div className="space-y-0">
+          <SourceRowSkeleton />
+          <SourceRowSkeleton />
+          <SourceRowSkeleton />
+        </div>
+      </Card>
+
+      <Card as="section" aria-hidden="true">
+        <Skeleton className="h-7 w-44 mb-4" />
+        <Skeleton className="h-10 w-full mb-4 rounded-lg" />
+        <SourceRowSkeleton />
+        <SourceRowSkeleton />
+      </Card>
+    </div>
+  )
+}

--- a/app/frontend/components/ui/Skeleton.tsx
+++ b/app/frontend/components/ui/Skeleton.tsx
@@ -1,0 +1,14 @@
+import { cn } from '../../utils/cn'
+
+interface SkeletonProps {
+  className?: string
+}
+
+export function Skeleton({ className }: SkeletonProps) {
+  return (
+    <div
+      className={cn('rounded-md bg-dark-700 motion-safe:animate-pulse motion-sensitive', className)}
+      aria-hidden="true"
+    />
+  )
+}

--- a/app/frontend/components/ui/skeleton.test.tsx
+++ b/app/frontend/components/ui/skeleton.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import ArticleListSkeleton from '../ArticleListSkeleton'
+import ArticleShowSkeleton from '../ArticleShowSkeleton'
+import { Skeleton } from './Skeleton'
+
+describe('Skeleton', () => {
+  it('renders a pulse placeholder on dark-700', () => {
+    const { container } = render(<Skeleton className="h-4 w-24" />)
+    const element = container.firstChild as HTMLElement
+    expect(element.className).toContain('bg-dark-700')
+    expect(element.className).toContain('motion-safe:animate-pulse')
+    expect(element).toHaveAttribute('aria-hidden', 'true')
+  })
+})
+
+describe('ArticleListSkeleton', () => {
+  it('renders six card skeletons with an accessible loading label', () => {
+    render(<ArticleListSkeleton />)
+    expect(screen.getByTestId('article-list-skeleton')).toBeInTheDocument()
+    expect(screen.getAllByTestId('article-card-skeleton')).toHaveLength(6)
+    expect(screen.getByText('Loading articles')).toHaveClass('sr-only')
+  })
+
+  it('supports a custom card count', () => {
+    render(<ArticleListSkeleton count={8} label="Loading bookmarks" />)
+    expect(screen.getAllByTestId('article-card-skeleton')).toHaveLength(8)
+    expect(screen.getByText('Loading bookmarks')).toHaveClass('sr-only')
+  })
+})
+
+describe('ArticleShowSkeleton', () => {
+  it('renders article show placeholders with an accessible loading label', () => {
+    render(<ArticleShowSkeleton />)
+    expect(screen.getByTestId('article-show-skeleton')).toBeInTheDocument()
+    expect(screen.getByText('Loading article')).toHaveClass('sr-only')
+  })
+})

--- a/app/frontend/pages/ArticleShowPage.tsx
+++ b/app/frontend/pages/ArticleShowPage.tsx
@@ -14,6 +14,7 @@ import {
   safeExternalUrl,
 } from '../utils/format'
 import { useConfirmDialog } from '../hooks/useConfirmDialog'
+import ArticleShowSkeleton from '../components/ArticleShowSkeleton'
 import Button from '../components/ui/Button'
 import { buttonClassName } from '../components/ui/Button'
 
@@ -93,14 +94,8 @@ export default function ArticleShowPage() {
 
   if (loading) {
     return (
-      <div
-        className="container mx-auto px-4 py-8 max-w-4xl text-center text-gray-400"
-        data-testid="article-show-page"
-        role="status"
-        aria-live="polite"
-        aria-busy="true"
-      >
-        Loading article...
+      <div data-testid="article-show-page">
+        <ArticleShowSkeleton />
       </div>
     )
   }

--- a/app/frontend/pages/ArticlesIndexPage.tsx
+++ b/app/frontend/pages/ArticlesIndexPage.tsx
@@ -14,9 +14,12 @@ import {
 import type { ArticlesIndexResponse } from '../types/article'
 import { parameterize, truncate } from '../utils/format'
 import ArticleList from '../components/ArticleList'
+import ArticleListSkeleton from '../components/ArticleListSkeleton'
 import CategoryFilter from '../components/CategoryFilter'
 import DismissToast from '../components/DismissToast'
 import PageHeader from '../components/PageHeader'
+import PageHeaderSkeleton from '../components/PageHeaderSkeleton'
+import PageContainer from '../components/ui/PageContainer'
 import Card from '../components/ui/Card'
 import PaginationControls from '../components/PaginationControls'
 import ScoreFilter, { parseScoreFilter, scoreFilterParams, type ScoreFilterValue } from '../components/ScoreFilter'
@@ -289,9 +292,10 @@ export default function ArticlesIndexPage() {
 
   if (loading) {
     return (
-      <div className="container mx-auto px-4 py-8 max-w-7xl text-center text-gray-400" data-testid="articles-page">
-        Loading articles...
-      </div>
+      <PageContainer testId="articles-page" role="status" aria-live="polite" aria-busy>
+        <PageHeaderSkeleton />
+        <ArticleListSkeleton count={6} label="Loading articles" />
+      </PageContainer>
     )
   }
 

--- a/app/frontend/pages/SourcesIndexPage.tsx
+++ b/app/frontend/pages/SourcesIndexPage.tsx
@@ -10,6 +10,7 @@ import { useConfirmDialog } from '../hooks/useConfirmDialog'
 import Button from '../components/ui/Button'
 import Card from '../components/ui/Card'
 import PageContainer from '../components/ui/PageContainer'
+import SourcesIndexSkeleton from '../components/SourcesIndexSkeleton'
 import PageHeading from '../components/ui/PageHeading'
 
 function sourceLabel(source: NewsSource): string {
@@ -92,8 +93,8 @@ export default function SourcesIndexPage() {
 
   if (loading) {
     return (
-      <PageContainer width="4xl" testId="sources-page" centered>
-        Loading sources...
+      <PageContainer width="4xl" testId="sources-page" role="status" aria-live="polite" aria-busy>
+        <SourcesIndexSkeleton />
       </PageContainer>
     )
   }

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -27,7 +27,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     assert_selector "[data-testid='articles-page']", wait: 12
     assert_selector "main#main-content", wait: 12
     assert_selector "[data-testid='app-nav']", wait: 12
-    assert_no_text "Loading articles...", wait: 12
+    assert_no_selector "[data-testid='article-list-skeleton']", wait: 12
   end
 
   def visit_bookmarks_index
@@ -36,7 +36,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
       visit bookmarks_path
     end
     assert_selector "[data-testid='bookmarks-page']", wait: 12
-    assert_no_text "Loading reading list...", wait: 12
+    assert_no_selector "[data-testid='article-list-skeleton']", wait: 12
   end
 
   def visit_read_articles_index
@@ -45,7 +45,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
       visit read_articles_path
     end
     assert_selector "[data-testid='read-articles-page']", wait: 12
-    assert_no_text "Loading read articles...", wait: 12
+    assert_no_selector "[data-testid='article-list-skeleton']", wait: 12
   end
 
   def visit_dismissed_articles_index
@@ -54,7 +54,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
       visit dismissed_articles_path
     end
     assert_selector "[data-testid='dismissed-articles-page']", wait: 12
-    assert_no_text "Loading dismissed articles...", wait: 12
+    assert_no_selector "[data-testid='article-list-skeleton']", wait: 12
   end
 
   def visit_recently_dismissed
@@ -63,7 +63,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
       visit recently_dismissed_path
     end
     assert_selector "[data-testid='recently-dismissed-page']", wait: 12
-    assert_no_text "Loading recently dismissed articles...", wait: 12
+    assert_no_selector "[data-testid='article-list-skeleton']", wait: 12
   end
 
   def visit_article_show(article)
@@ -72,6 +72,6 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
       visit article_path(article)
     end
     assert_selector "[data-testid='article-show-page']", wait: 12
-    assert_no_text "Loading article...", wait: 12
+    assert_no_selector "[data-testid='article-show-skeleton']", wait: 12
   end
 end


### PR DESCRIPTION
## Summary
- Add reusable Skeleton primitive with pulse animation on dark-700 shapes and static placeholders when prefers-reduced-motion is set
- Replace bare Loading... text on article list pages, article show, sources, route fallback, and PageShell-backed pages with layout-matched skeletons
- Update system test visit helpers to wait for skeleton test ids to disappear instead of loading copy

Closes #162

## Test plan
- [x] npm test (27 tests)
- [x] npm run typecheck
- [x] npm run build:test
- [x] PARALLEL_WORKERS=0 bundle exec rails test:system (49 runs, 0 failures)