### PR TITLE
a11y(frontend): improve accessibility (focus, landmarks, aria) (#163)

### DIFF
--- a/app/frontend/components/AppLayout.test.tsx
+++ b/app/frontend/components/AppLayout.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+import { axe } from 'vitest-axe'
+import AppLayout from './AppLayout'
+
+describe('AppLayout', () => {
+  it('renders skip link and main landmark', () => {
+    render(
+      <MemoryRouter>
+        <AppLayout />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByRole('link', { name: 'Skip to main content' })).toHaveAttribute(
+      'href',
+      '#main-content'
+    )
+    expect(screen.getByRole('main')).toHaveAttribute('id', 'main-content')
+  })
+
+  it('has no critical accessibility violations', async () => {
+    const { container } = render(
+      <MemoryRouter>
+        <AppLayout />
+      </MemoryRouter>
+    )
+
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/app/frontend/components/AppLayout.tsx
+++ b/app/frontend/components/AppLayout.tsx
@@ -1,4 +1,5 @@
 import { Outlet } from 'react-router-dom'
+import { FOCUS_RING } from './ui/buttonStyles'
 import AppShell from './AppShell'
 
 export default function AppLayout() {
@@ -6,7 +7,7 @@ export default function AppLayout() {
     <>
       <a
         href="#main-content"
-        className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-primary-600 focus:text-white focus:rounded-lg"
+        className={`sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-primary-600 focus:text-white focus:rounded-lg ${FOCUS_RING}`}
       >
         Skip to main content
       </a>

--- a/app/frontend/components/AppShell.tsx
+++ b/app/frontend/components/AppShell.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from 'react'
 import { NavLink, useLocation } from 'react-router-dom'
+import { cn } from '../utils/cn'
+import { FOCUS_RING } from './ui/buttonStyles'
 
 interface NavItem {
   to: string
@@ -60,6 +62,7 @@ const navItems: NavItem[] = [
 function desktopLinkClassName(isActive: boolean) {
   return [
     'px-3 py-2 rounded-lg text-sm font-medium transition-colors duration-200',
+    FOCUS_RING,
     isActive
       ? 'bg-primary-600/20 text-primary-300 ring-1 ring-primary-500/40'
       : 'text-gray-400 hover:text-gray-200 hover:bg-dark-700/60',
@@ -69,6 +72,7 @@ function desktopLinkClassName(isActive: boolean) {
 function mobileLinkClassName(isActive: boolean) {
   return [
     'flex flex-1 flex-col items-center justify-center gap-1 py-2 text-xs font-medium transition-colors duration-200',
+    FOCUS_RING,
     isActive ? 'text-primary-400' : 'text-gray-500 hover:text-gray-300',
   ].join(' ')
 }
@@ -87,7 +91,11 @@ export default function AppShell({ children }: AppShellProps) {
           <div className="hidden md:flex items-center justify-between h-14">
             <NavLink
               to="/"
-              className="text-h3 font-bold bg-gradient-to-r from-primary-400 to-primary-600 bg-clip-text text-transparent shrink-0"
+              className={cn(
+                'text-h3 font-bold bg-gradient-to-r from-primary-400 to-primary-600 bg-clip-text text-transparent shrink-0',
+                FOCUS_RING,
+                'rounded-lg'
+              )}
             >
               Dev News
             </NavLink>
@@ -108,7 +116,11 @@ export default function AppShell({ children }: AppShellProps) {
           <div className="flex md:hidden items-center justify-center h-12">
             <NavLink
               to="/"
-              className="text-h3 font-bold bg-gradient-to-r from-primary-400 to-primary-600 bg-clip-text text-transparent"
+              className={cn(
+                'text-h3 font-bold bg-gradient-to-r from-primary-400 to-primary-600 bg-clip-text text-transparent',
+                FOCUS_RING,
+                'rounded-lg'
+              )}
             >
               Dev News
             </NavLink>
@@ -119,7 +131,7 @@ export default function AppShell({ children }: AppShellProps) {
       {children}
 
       <nav
-        aria-label="Main navigation"
+        aria-label="Mobile navigation"
         data-testid="app-nav-mobile"
         className="md:hidden fixed bottom-0 inset-x-0 z-40 surface-elevated border-t border-dark-700/50 safe-area-pb"
       >
@@ -131,6 +143,7 @@ export default function AppShell({ children }: AppShellProps) {
               end={item.to === '/'}
               className={() => mobileLinkClassName(item.isActive(pathname))}
               data-testid={`app-nav-mobile-${item.shortLabel.toLowerCase()}`}
+              aria-label={item.label}
             >
               {item.icon}
               <span>{item.shortLabel}</span>

--- a/app/frontend/components/CategoryFilter.tsx
+++ b/app/frontend/components/CategoryFilter.tsx
@@ -21,12 +21,12 @@ export default function CategoryFilter({
   return (
     <div className="mb-8">
       <Card tone="subtle">
-        <h3 className="text-h3 text-gray-200 mb-4 flex items-center">
-          <svg className="w-5 h-5 mr-2 text-primary-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <h2 className="text-h3 text-gray-200 mb-4 flex items-center">
+          <svg className="w-5 h-5 mr-2 text-primary-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.707A1 1 0 013 7V4z" />
           </svg>
           Filter by Category
-        </h3>
+        </h2>
         <div className="flex flex-wrap gap-3">
           <Button
             variant="filter"

--- a/app/frontend/components/PageHeader.tsx
+++ b/app/frontend/components/PageHeader.tsx
@@ -65,7 +65,7 @@ export default function PageHeader({
             <label className="flex items-center gap-2 text-sm text-gray-400 cursor-pointer">
               <input
                 type="checkbox"
-                className="rounded border-dark-600 bg-dark-800 text-primary-500 focus:ring-primary-500"
+                className="rounded border-dark-600 bg-dark-800 text-primary-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
                 checked={showRead}
                 onChange={(event) => onShowReadChange(event.target.checked)}
                 data-testid="show-read-toggle"

--- a/app/frontend/components/PaginationControls.tsx
+++ b/app/frontend/components/PaginationControls.tsx
@@ -1,3 +1,5 @@
+import { FOCUS_RING } from './ui/buttonStyles'
+
 interface PaginationControlsProps {
   currentPage: number
   totalPages: number
@@ -5,6 +7,8 @@ interface PaginationControlsProps {
   perPage: number
   onPageChange: (page: number) => void
 }
+
+const PAGINATION_BUTTON = `px-4 py-2 rounded-lg border border-dark-500 bg-dark-700 text-gray-300 font-medium transition-all duration-200 hover:bg-dark-600 hover:text-white disabled:opacity-40 disabled:hover:bg-dark-700 disabled:hover:text-gray-300 ${FOCUS_RING}`
 
 export default function PaginationControls({
   currentPage,
@@ -41,7 +45,7 @@ export default function PaginationControls({
       <div className="flex items-center gap-2">
         <button
           type="button"
-          className="px-4 py-2 rounded-lg border border-dark-500 bg-dark-700 text-gray-300 font-medium transition-all duration-200 hover:bg-dark-600 hover:text-white disabled:opacity-40 disabled:hover:bg-dark-700 disabled:hover:text-gray-300"
+          className={PAGINATION_BUTTON}
           onClick={() => goToPage(currentPage - 1)}
           disabled={currentPage <= 1}
           aria-label="Previous page"
@@ -57,7 +61,7 @@ export default function PaginationControls({
 
         <button
           type="button"
-          className="px-4 py-2 rounded-lg border border-dark-500 bg-dark-700 text-gray-300 font-medium transition-all duration-200 hover:bg-dark-600 hover:text-white disabled:opacity-40 disabled:hover:bg-dark-700 disabled:hover:text-gray-300"
+          className={PAGINATION_BUTTON}
           onClick={() => goToPage(currentPage + 1)}
           disabled={currentPage >= totalPages}
           aria-label="Next page"

--- a/app/frontend/components/a11y.test.tsx
+++ b/app/frontend/components/a11y.test.tsx
@@ -1,0 +1,111 @@
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+import { axe } from 'vitest-axe'
+import ArticleCard from './ArticleCard'
+import CategoryFilter from './CategoryFilter'
+import ConfirmDialog from './ConfirmDialog'
+import PageHeading from './ui/PageHeading'
+
+const baseArticle = {
+  id: 1,
+  title: 'Rust 2024 Edition Highlights',
+  url: 'https://example.com/rust',
+  description: 'A summary of Rust changes.',
+  source_type: 'hacker_news',
+  score: 42,
+  comment_count: 7,
+  published_at: '2024-01-15T10:00:00Z',
+  external_id: 'hn-1',
+  created_at: '2024-01-15T10:00:00Z',
+  updated_at: '2024-01-15T10:00:00Z',
+  bookmarked: false,
+  read: false,
+  dismissed: false,
+  pending_dismissal: false,
+}
+
+describe('accessibility audits', () => {
+  it('CategoryFilter has no critical accessibility violations', async () => {
+    const { container } = render(
+      <CategoryFilter
+        categories={[
+          { name: 'Programming Languages', icon: '🔨' },
+          { name: 'Frameworks', icon: '🧱' },
+        ]}
+        categoryCounts={{ 'Programming Languages': 3, Frameworks: 1 }}
+        totalCount={4}
+        activeFilter="all"
+        onFilterChange={vi.fn()}
+      />
+    )
+
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+
+  it('feed ArticleCard has no critical accessibility violations', async () => {
+    const { container } = render(
+      <MemoryRouter>
+        <ArticleCard
+          variant="feed"
+          article={baseArticle}
+          categorySlug="programming-languages"
+          index={0}
+          isDismissing={false}
+          onDismiss={() => {}}
+          onBookmarkToggle={() => {}}
+          onReadToggle={() => {}}
+        />
+      </MemoryRouter>
+    )
+
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+
+  it('PageHeading has no critical accessibility violations', async () => {
+    const { container } = render(
+      <PageHeading title="Reading List" subtitle="Bookmarked articles" />
+    )
+
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+
+  it('ConfirmDialog has no critical accessibility violations when open', async () => {
+    const { container } = render(
+      <ConfirmDialog
+        open
+        title="Remove bookmark"
+        message="Remove this article from your reading list?"
+        confirmLabel="Remove"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />
+    )
+
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})
+
+describe('keyboard focus', () => {
+  it('exposes visible focus styles on primary buttons', async () => {
+    const user = userEvent.setup()
+    const { container } = render(
+      <CategoryFilter
+        categories={[{ name: 'Frameworks', icon: '🧱' }]}
+        categoryCounts={{ Frameworks: 1 }}
+        totalCount={1}
+        activeFilter="all"
+        onFilterChange={vi.fn()}
+      />
+    )
+
+    await user.tab()
+    const focused = container.querySelector(':focus')
+    expect(focused?.className).toMatch(/focus-visible:ring-primary-500|ring-primary-500/)
+  })
+})

--- a/app/frontend/components/articleCard/CardActions.tsx
+++ b/app/frontend/components/articleCard/CardActions.tsx
@@ -1,6 +1,7 @@
 import type { MouseEvent } from 'react'
 import { Link } from 'react-router-dom'
 import Button from '../ui/Button'
+import { FOCUS_RING } from '../ui/buttonStyles'
 import { cn } from '../../utils/cn'
 import type { CardThemeStyles } from './cardThemes'
 
@@ -8,14 +9,19 @@ function stopPropagation(event: MouseEvent) {
   event.stopPropagation()
 }
 
-const ICON_BTN =
-  'p-2 rounded-lg border border-transparent transition-colors duration-200 motion-sensitive'
+const ICON_BTN = cn(
+  'p-2 rounded-lg border border-transparent transition-colors duration-200 motion-sensitive',
+  FOCUS_RING
+)
 
 export function DismissButton({ onClick }: { onClick: () => void }) {
   return (
     <button
       type="button"
-      className="group/dismiss p-1.5 text-gray-500 hover:text-red-400 hover:bg-red-400/10 rounded-lg transition-colors duration-200 motion-sensitive"
+      className={cn(
+        'group/dismiss p-1.5 text-gray-500 hover:text-red-400 hover:bg-red-400/10 rounded-lg transition-colors duration-200 motion-sensitive',
+        FOCUS_RING
+      )}
       title="Dismiss article"
       aria-label="Dismiss article"
       onClick={(event) => {
@@ -28,6 +34,7 @@ export function DismissButton({ onClick }: { onClick: () => void }) {
         fill="none"
         stroke="currentColor"
         viewBox="0 0 24 24"
+        aria-hidden="true"
       >
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
       </svg>
@@ -73,6 +80,7 @@ export function BookmarkButton({ active, mode, onClick }: BookmarkButtonProps) {
         fill={active || isRemove ? 'currentColor' : 'none'}
         stroke="currentColor"
         viewBox="0 0 24 24"
+        aria-hidden="true"
       >
         <path
           strokeLinecap="round"
@@ -119,6 +127,7 @@ export function ReadButton({ active, mode, onClick }: ReadButtonProps) {
         fill={active && !isUnmark ? 'currentColor' : 'none'}
         stroke="currentColor"
         viewBox="0 0 24 24"
+        aria-hidden="true"
       >
         <path
           strokeLinecap="round"
@@ -140,6 +149,7 @@ export function RestoreButton({ label, onClick }: { label: string; onClick: () =
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
+          aria-hidden="true"
         >
           <path
             strokeLinecap="round"
@@ -158,7 +168,12 @@ export function DetailsLink({ href, styles }: { href: string; styles: CardThemeS
   return (
     <Link
       to={href}
-      className={`group/detail px-4 py-2 bg-dark-800/80 border border-dark-600 text-gray-300 rounded-lg font-medium transition-colors duration-200 motion-sensitive ${styles.detailsHover} hover:text-white hover:border-dark-500`}
+      className={cn(
+        'group/detail px-4 py-2 bg-dark-800/80 border border-dark-600 text-gray-300 rounded-lg font-medium transition-colors duration-200 motion-sensitive',
+        FOCUS_RING,
+        styles.detailsHover,
+        'hover:text-white hover:border-dark-500'
+      )}
       onClick={stopPropagation}
     >
       <span className="flex items-center">
@@ -168,6 +183,7 @@ export function DetailsLink({ href, styles }: { href: string; styles: CardThemeS
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
+          aria-hidden="true"
         >
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
         </svg>

--- a/app/frontend/components/articleCard/CardTitle.tsx
+++ b/app/frontend/components/articleCard/CardTitle.tsx
@@ -41,6 +41,7 @@ export default function CardTitle({
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
+              aria-hidden="true"
             >
               <path
                 strokeLinecap="round"

--- a/app/frontend/components/ui/buttonStyles.ts
+++ b/app/frontend/components/ui/buttonStyles.ts
@@ -1,5 +1,8 @@
 import { cn } from '../../utils/cn'
 
+export const FOCUS_RING =
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:ring-offset-dark-950'
+
 export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger' | 'filter'
 export type ButtonSize = 'sm' | 'md' | 'lg'
 export type ButtonColor = 'primary' | 'blue' | 'purple' | 'green' | 'red' | 'orange'
@@ -73,7 +76,10 @@ export function buttonClassName({
   active = false,
   className,
 }: ButtonStyleOptions = {}) {
-  const base = 'inline-flex items-center justify-center font-medium transition-all duration-200'
+  const base = cn(
+    'inline-flex items-center justify-center font-medium transition-all duration-200',
+    FOCUS_RING
+  )
 
   if (variant === 'ghost') {
     return cn(

--- a/app/frontend/components/ui/ui.test.tsx
+++ b/app/frontend/components/ui/ui.test.tsx
@@ -1,8 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { buttonClassName } from './buttonStyles'
+import { buttonClassName, FOCUS_RING } from './buttonStyles'
 import { badgeClassName } from './Badge'
 
 describe('buttonClassName', () => {
+  it('includes keyboard focus ring styles', () => {
+    expect(buttonClassName()).toContain(FOCUS_RING)
+  })
+
   it('returns primary gradient classes by default', () => {
     const classes = buttonClassName()
     expect(classes).toContain('from-primary-600')

--- a/app/frontend/pages/SourcesIndexPage.tsx
+++ b/app/frontend/pages/SourcesIndexPage.tsx
@@ -118,7 +118,7 @@ export default function SourcesIndexPage() {
               <label className="flex items-center gap-2 text-sm text-gray-400 cursor-pointer">
                 <input
                   type="checkbox"
-                  className="rounded border-dark-600 bg-dark-800 text-primary-500 focus:ring-primary-500"
+                  className="rounded border-dark-600 bg-dark-800 text-primary-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
                   checked={source.active}
                   onChange={() => handleToggle(source)}
                   data-testid={`source-toggle-${source.source_type}`}
@@ -139,7 +139,7 @@ export default function SourcesIndexPage() {
             value={subredditInput}
             onChange={(event) => setSubredditInput(event.target.value)}
             placeholder="e.g. programming"
-            className="flex-1 px-4 py-2 bg-dark-800 border border-dark-700 rounded-xl text-gray-200 placeholder-gray-500 focus:outline-none focus:border-primary-500"
+            className="flex-1 px-4 py-2 bg-dark-800 border border-dark-700 rounded-xl text-gray-200 placeholder-gray-500 focus-visible:outline-none focus-visible:border-primary-500 focus-visible:ring-2 focus-visible:ring-primary-500"
             data-testid="subreddit-input"
           />
           <Button type="submit" disabled={adding || !subredditInput.trim()} data-testid="add-subreddit-button">
@@ -159,7 +159,7 @@ export default function SourcesIndexPage() {
                 <label className="flex items-center gap-2 text-sm text-gray-400 cursor-pointer">
                   <input
                     type="checkbox"
-                    className="rounded border-dark-600 bg-dark-800 text-primary-500 focus:ring-primary-500"
+                    className="rounded border-dark-600 bg-dark-800 text-primary-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
                     checked={source.active}
                     onChange={() => handleToggle(source)}
                   />

--- a/app/frontend/test/setup.ts
+++ b/app/frontend/test/setup.ts
@@ -1,6 +1,10 @@
 import '@testing-library/jest-dom/vitest'
+import 'vitest-axe/extend-expect'
+import * as axeMatchers from 'vitest-axe/matchers'
 import { cleanup } from '@testing-library/react'
-import { afterEach } from 'vitest'
+import { afterEach, expect } from 'vitest'
+
+expect.extend(axeMatchers)
 
 afterEach(() => {
   cleanup()

--- a/app/frontend/test/vitest-axe.d.ts
+++ b/app/frontend/test/vitest-axe.d.ts
@@ -1,0 +1,7 @@
+import 'vitest'
+import type { AxeMatchers } from 'vitest-axe/matchers'
+
+declare module 'vitest' {
+  interface Assertion<T = any> extends AxeMatchers {}
+  interface AsymmetricMatchersContaining extends AxeMatchers {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,13 +22,15 @@
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.4",
         "autoprefixer": "^10.5.2",
+        "axe-core": "^4.12.1",
         "jsdom": "^29.1.1",
         "postcss": "^8.5.16",
         "tailwindcss": "^3.4.19",
         "typescript": "^5.7.2",
         "vite": "^7.3.6",
         "vite-plugin-ruby": "^5.2.0",
-        "vitest": "^4.1.10"
+        "vitest": "^4.1.10",
+        "vitest-axe": "^0.1.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -1936,6 +1938,16 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.41",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.41.tgz",
@@ -2059,6 +2071,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/chokidar": {
@@ -2698,6 +2723,13 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "dev": true,
       "license": "MIT"
     },
@@ -3894,6 +3926,7 @@
       "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.10",
         "@vitest/mocker": "4.1.10",
@@ -3976,6 +4009,24 @@
         "vite": {
           "optional": false
         }
+      }
+    },
+    "node_modules/vitest-axe": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/vitest-axe/-/vitest-axe-0.1.0.tgz",
+      "integrity": "sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.0.0",
+        "axe-core": "^4.4.2",
+        "chalk": "^5.0.1",
+        "dom-accessibility-api": "^0.5.14",
+        "lodash-es": "^4.17.21",
+        "redent": "^3.0.0"
+      },
+      "peerDependencies": {
+        "vitest": ">=0.16.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -27,12 +27,14 @@
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "^10.5.2",
+    "axe-core": "^4.12.1",
     "jsdom": "^29.1.1",
     "postcss": "^8.5.16",
     "tailwindcss": "^3.4.19",
     "typescript": "^5.7.2",
     "vite": "^7.3.6",
     "vite-plugin-ruby": "^5.2.0",
-    "vitest": "^4.1.10"
+    "vitest": "^4.1.10",
+    "vitest-axe": "^0.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- Add shared focus-visible ring styles to buttons, nav links, pagination, and card action controls
- Distinguish desktop and mobile navigation landmarks; keep skip link and main content region
- Improve heading hierarchy in category filters and mark decorative SVGs as aria-hidden
- Add vitest-axe audits for AppLayout, CategoryFilter, ArticleCard, PageHeading, and ConfirmDialog

Closes #163

## Test plan
- [x] npm test (35 tests, including axe audits)
- [x] npm run typecheck
- [x] npm run build:test
- [x] PARALLEL_WORKERS=0 bundle exec rails test:system (49 runs, 0 failures)