### PR TITLE
feat(frontend): add breadcrumbs and wayfinding (#164)

### DIFF
--- a/app/frontend/components/ArticleShowSkeleton.tsx
+++ b/app/frontend/components/ArticleShowSkeleton.tsx
@@ -1,14 +1,12 @@
 import { Skeleton } from './ui/Skeleton'
 
-export default function ArticleShowSkeleton() {
-  return (
-    <div
-      className="container mx-auto px-4 py-8 max-w-4xl"
-      data-testid="article-show-skeleton"
-      role="status"
-      aria-live="polite"
-      aria-busy="true"
-    >
+interface ArticleShowSkeletonProps {
+  embedded?: boolean
+}
+
+export default function ArticleShowSkeleton({ embedded = false }: ArticleShowSkeletonProps) {
+  const content = (
+    <>
       <span className="sr-only">Loading article</span>
       <article className="surface-panel rounded-2xl p-8 md:p-12">
         <div className="mb-8">
@@ -40,6 +38,26 @@ export default function ArticleShowSkeleton() {
           <Skeleton className="h-11 w-36 rounded-xl" />
         </div>
       </article>
+    </>
+  )
+
+  if (embedded) {
+    return (
+      <div data-testid="article-show-skeleton" role="status" aria-live="polite" aria-busy="true">
+        {content}
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className="container mx-auto px-4 py-8 max-w-4xl"
+      data-testid="article-show-skeleton"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+    >
+      {content}
     </div>
   )
 }

--- a/app/frontend/components/Breadcrumbs.test.tsx
+++ b/app/frontend/components/Breadcrumbs.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+import Breadcrumbs from './Breadcrumbs'
+
+describe('Breadcrumbs', () => {
+  it('renders linked ancestors and plain text for the current page', () => {
+    render(
+      <MemoryRouter>
+        <Breadcrumbs
+          items={[
+            { label: 'Feed', to: '/' },
+            { label: 'Reading List' },
+          ]}
+        />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByRole('navigation', { name: 'Breadcrumb' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Feed' })).toHaveAttribute('href', '/')
+    expect(screen.getByText('Reading List')).toHaveAttribute('aria-current', 'page')
+    expect(screen.queryByRole('link', { name: 'Reading List' })).not.toBeInTheDocument()
+  })
+
+  it('renders a three-level trail for dismissed pages', () => {
+    render(
+      <MemoryRouter>
+        <Breadcrumbs
+          items={[
+            { label: 'Feed', to: '/' },
+            { label: 'Recently Dismissed', to: '/recently_dismissed' },
+            { label: 'All Dismissed' },
+          ]}
+        />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByRole('link', { name: 'Recently Dismissed' })).toHaveAttribute(
+      'href',
+      '/recently_dismissed'
+    )
+    expect(screen.getAllByText('All Dismissed')[0]).toHaveAttribute('aria-current', 'page')
+  })
+
+  it('collapses to back link and current page on mobile for long trails', () => {
+    render(
+      <MemoryRouter>
+        <Breadcrumbs
+          items={[
+            { label: 'Feed', to: '/' },
+            { label: 'Recently Dismissed', to: '/recently_dismissed' },
+            { label: 'All Dismissed' },
+          ]}
+        />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByTestId('breadcrumbs-mobile')).toBeInTheDocument()
+    expect(screen.getByTestId('breadcrumbs-back')).toHaveAttribute('href', '/recently_dismissed')
+    expect(screen.getByTestId('breadcrumbs-back')).toHaveTextContent('← Back')
+  })
+})

--- a/app/frontend/components/Breadcrumbs.tsx
+++ b/app/frontend/components/Breadcrumbs.tsx
@@ -1,0 +1,80 @@
+import { Link } from 'react-router-dom'
+import { cn } from '../utils/cn'
+import { FOCUS_RING } from './ui/buttonStyles'
+
+export interface BreadcrumbItem {
+  label: string
+  to?: string
+}
+
+interface BreadcrumbsProps {
+  items: BreadcrumbItem[]
+  className?: string
+}
+
+const LINK_CLASS = cn('text-gray-400 hover:text-gray-200 transition-colors rounded', FOCUS_RING)
+
+function shouldCollapseMobile(items: BreadcrumbItem[]) {
+  if (items.length > 2) return true
+  return items[items.length - 1].label.length > 36
+}
+
+export default function Breadcrumbs({ items, className }: BreadcrumbsProps) {
+  if (items.length === 0) return null
+
+  const collapse = shouldCollapseMobile(items)
+  const parent = items.length >= 2 ? items[items.length - 2] : null
+  const current = items[items.length - 1]
+
+  return (
+    <nav aria-label="Breadcrumb" className={cn('mb-4', className)} data-testid="breadcrumbs">
+      <ol
+        className={cn(
+          'flex items-center flex-wrap gap-x-2 gap-y-1 text-sm text-gray-500 list-none p-0 m-0',
+          collapse && 'hidden sm:flex'
+        )}
+      >
+        {items.map((item, index) => {
+          const isLast = index === items.length - 1
+          const isLink = Boolean(item.to) && !isLast
+
+          return (
+            <li key={`${item.label}-${index}`} className="inline-flex items-center gap-2 min-w-0 max-w-full">
+              {index > 0 && (
+                <span aria-hidden="true" className="text-gray-600">
+                  /
+                </span>
+              )}
+              {isLink ? (
+                <Link to={item.to!} className={LINK_CLASS}>
+                  {item.label}
+                </Link>
+              ) : (
+                <span
+                  className={cn('truncate', isLast && 'text-gray-300')}
+                  aria-current={isLast ? 'page' : undefined}
+                >
+                  {item.label}
+                </span>
+              )}
+            </li>
+          )
+        })}
+      </ol>
+
+      {collapse && parent?.to && (
+        <div className="flex sm:hidden items-center gap-2 text-sm min-w-0" data-testid="breadcrumbs-mobile">
+          <Link to={parent.to} className={cn(LINK_CLASS, 'shrink-0')} data-testid="breadcrumbs-back">
+            ← Back
+          </Link>
+          <span aria-hidden="true" className="text-gray-600">
+            ·
+          </span>
+          <span className="text-gray-300 truncate" aria-current="page">
+            {current.label}
+          </span>
+        </div>
+      )}
+    </nav>
+  )
+}

--- a/app/frontend/components/breadcrumbTrails.ts
+++ b/app/frontend/components/breadcrumbTrails.ts
@@ -1,0 +1,33 @@
+import type { BreadcrumbItem } from './Breadcrumbs'
+
+export const feedBreadcrumb: BreadcrumbItem = { label: 'Feed', to: '/' }
+
+export const bookmarksBreadcrumbs: BreadcrumbItem[] = [
+  feedBreadcrumb,
+  { label: 'Reading List' },
+]
+
+export const readArticlesBreadcrumbs: BreadcrumbItem[] = [
+  feedBreadcrumb,
+  { label: 'Already Read' },
+]
+
+export const recentlyDismissedBreadcrumbs: BreadcrumbItem[] = [
+  feedBreadcrumb,
+  { label: 'Recently Dismissed' },
+]
+
+export const allDismissedBreadcrumbs: BreadcrumbItem[] = [
+  feedBreadcrumb,
+  { label: 'Recently Dismissed', to: '/recently_dismissed' },
+  { label: 'All Dismissed' },
+]
+
+export const sourcesBreadcrumbs: BreadcrumbItem[] = [
+  feedBreadcrumb,
+  { label: 'News Sources' },
+]
+
+export function articleBreadcrumbs(title: string): BreadcrumbItem[] {
+  return [feedBreadcrumb, { label: title }]
+}

--- a/app/frontend/pages/ArticleShowPage.tsx
+++ b/app/frontend/pages/ArticleShowPage.tsx
@@ -15,6 +15,8 @@ import {
 } from '../utils/format'
 import { useConfirmDialog } from '../hooks/useConfirmDialog'
 import ArticleShowSkeleton from '../components/ArticleShowSkeleton'
+import Breadcrumbs from '../components/Breadcrumbs'
+import { articleBreadcrumbs, feedBreadcrumb } from '../components/breadcrumbTrails'
 import Button from '../components/ui/Button'
 import { buttonClassName } from '../components/ui/Button'
 
@@ -94,8 +96,9 @@ export default function ArticleShowPage() {
 
   if (loading) {
     return (
-      <div data-testid="article-show-page">
-        <ArticleShowSkeleton />
+      <div className="container mx-auto px-4 py-8 max-w-4xl" data-testid="article-show-page">
+        <Breadcrumbs items={articleBreadcrumbs('Article')} />
+        <ArticleShowSkeleton embedded />
       </div>
     )
   }
@@ -103,6 +106,7 @@ export default function ArticleShowPage() {
   if (error || !article) {
     return (
       <div className="container mx-auto px-4 py-8 max-w-4xl text-center" data-testid="article-show-page">
+        <Breadcrumbs items={[feedBreadcrumb, { label: 'Article not found' }]} />
         <p className="text-red-400 mb-4">{error ?? 'Article not found.'}</p>
       </div>
     )
@@ -112,6 +116,7 @@ export default function ArticleShowPage() {
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-4xl" data-testid="article-show-page">
+      <Breadcrumbs items={articleBreadcrumbs(article.title)} />
       <article className="surface-panel rounded-2xl p-8 md:p-12 motion-safe:animate-slide-up motion-sensitive">
         <div className="mb-8">
           <div className="flex flex-wrap items-center gap-4 mb-6">

--- a/app/frontend/pages/BookmarksIndexPage.tsx
+++ b/app/frontend/pages/BookmarksIndexPage.tsx
@@ -7,6 +7,8 @@ import {
 } from '../api/articles'
 import type { BookmarkArticle } from '../types/bookmark'
 import BookmarksList from '../components/BookmarksList'
+import Breadcrumbs from '../components/Breadcrumbs'
+import { bookmarksBreadcrumbs } from '../components/breadcrumbTrails'
 import SourceFilter from '../components/SourceFilter'
 import PageShell from '../components/PageShell'
 import PageHeading from '../components/ui/PageHeading'
@@ -98,6 +100,7 @@ export default function BookmarksIndexPage() {
       showFatalError={articles.length === 0 && totalCount === 0}
       onRetry={reload}
     >
+      <Breadcrumbs items={bookmarksBreadcrumbs} />
       <PageHeading
         title="Reading List"
         subtitle="Your curated collection of bookmarked articles"

--- a/app/frontend/pages/DismissedArticlesIndexPage.tsx
+++ b/app/frontend/pages/DismissedArticlesIndexPage.tsx
@@ -3,6 +3,8 @@ import { fetchDismissedArticles } from '../api/dismissedArticles'
 import type { DismissedArticle } from '../types/dismissedArticle'
 import { NavLink } from 'react-router-dom'
 import DismissedArticlesList from '../components/DismissedArticlesList'
+import Breadcrumbs from '../components/Breadcrumbs'
+import { allDismissedBreadcrumbs } from '../components/breadcrumbTrails'
 import PageShell from '../components/PageShell'
 import { buttonClassName } from '../components/ui/Button'
 import PageHeading from '../components/ui/PageHeading'
@@ -46,6 +48,7 @@ export default function DismissedArticlesIndexPage() {
       showFatalError={articles.length === 0 && totalCount === 0}
       onRetry={reload}
     >
+      <Breadcrumbs items={allDismissedBreadcrumbs} />
       <PageHeading
         title="Dismissed Articles"
         subtitle="Articles you've dismissed from your feed"

--- a/app/frontend/pages/ReadArticlesIndexPage.tsx
+++ b/app/frontend/pages/ReadArticlesIndexPage.tsx
@@ -3,6 +3,8 @@ import { unmarkArticleAsRead } from '../api/articles'
 import { fetchReadArticles } from '../api/readArticles'
 import type { ReadArticle } from '../types/readArticle'
 import ReadArticlesList from '../components/ReadArticlesList'
+import Breadcrumbs from '../components/Breadcrumbs'
+import { readArticlesBreadcrumbs } from '../components/breadcrumbTrails'
 import SourceFilter from '../components/SourceFilter'
 import PageShell from '../components/PageShell'
 import PageHeading from '../components/ui/PageHeading'
@@ -62,6 +64,7 @@ export default function ReadArticlesIndexPage() {
       showFatalError={articles.length === 0 && totalCount === 0}
       onRetry={reload}
     >
+      <Breadcrumbs items={readArticlesBreadcrumbs} />
       <PageHeading
         title="Already Read"
         subtitle="Articles you've finished reading"

--- a/app/frontend/pages/RecentlyDismissedPage.tsx
+++ b/app/frontend/pages/RecentlyDismissedPage.tsx
@@ -3,6 +3,8 @@ import { fetchRecentlyDismissed } from '../api/dismissedArticles'
 import type { DismissedArticle } from '../types/dismissedArticle'
 import { NavLink } from 'react-router-dom'
 import DismissedArticlesList from '../components/DismissedArticlesList'
+import Breadcrumbs from '../components/Breadcrumbs'
+import { recentlyDismissedBreadcrumbs } from '../components/breadcrumbTrails'
 import PageShell from '../components/PageShell'
 import { buttonClassName } from '../components/ui/Button'
 import PageHeading from '../components/ui/PageHeading'
@@ -41,6 +43,7 @@ export default function RecentlyDismissedPage() {
       showFatalError={articles.length === 0}
       onRetry={reload}
     >
+      <Breadcrumbs items={recentlyDismissedBreadcrumbs} />
       <PageHeading
         title="Recently Dismissed"
         subtitle="Articles dismissed in the last 24 hours - easy to restore"

--- a/app/frontend/pages/SourcesIndexPage.tsx
+++ b/app/frontend/pages/SourcesIndexPage.tsx
@@ -10,6 +10,8 @@ import { useConfirmDialog } from '../hooks/useConfirmDialog'
 import Button from '../components/ui/Button'
 import Card from '../components/ui/Card'
 import PageContainer from '../components/ui/PageContainer'
+import Breadcrumbs from '../components/Breadcrumbs'
+import { sourcesBreadcrumbs } from '../components/breadcrumbTrails'
 import SourcesIndexSkeleton from '../components/SourcesIndexSkeleton'
 import PageHeading from '../components/ui/PageHeading'
 
@@ -101,6 +103,7 @@ export default function SourcesIndexPage() {
 
   return (
     <PageContainer width="4xl" testId="sources-page">
+      <Breadcrumbs items={sourcesBreadcrumbs} />
       <PageHeading
         title="News Sources"
         subtitle="Enable or disable sources and manage Reddit subreddits."

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -36,6 +36,8 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
       visit bookmarks_path
     end
     assert_selector "[data-testid='bookmarks-page']", wait: 12
+    assert_selector "[data-testid='breadcrumbs']", wait: 12
+    assert_selector "[data-testid='breadcrumbs']", text: "Reading List", wait: 12
     assert_no_selector "[data-testid='article-list-skeleton']", wait: 12
   end
 
@@ -72,6 +74,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
       visit article_path(article)
     end
     assert_selector "[data-testid='article-show-page']", wait: 12
+    assert_selector "[data-testid='breadcrumbs']", wait: 12
     assert_no_selector "[data-testid='article-show-skeleton']", wait: 12
   end
 end


### PR DESCRIPTION
## Summary
- Add reusable Breadcrumbs component with linked ancestors, plain-text current page, and mobile back collapse for long trails
- Add breadcrumb trails on article show, bookmarks, read, dismissed, recently dismissed, and sources pages
- Extend system test visit helpers to assert breadcrumbs on bookmarks and article show

Closes #164

## Test plan
- [x] npm test (38 tests)
- [x] npm run typecheck
- [x] npm run build:test
- [x] PARALLEL_WORKERS=0 bundle exec rails test:system (49 runs, 0 failures)