### PR TITLE
fix(db): add unique indexes on user-state tables (#244)

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -21,7 +21,10 @@ class Article < ApplicationRecord
 
   def bookmark!
     return bookmark if bookmarked?
+
     create_bookmark
+  rescue ActiveRecord::RecordNotUnique
+    reload.bookmark
   end
 
   def unbookmark!
@@ -42,7 +45,10 @@ class Article < ApplicationRecord
 
   def mark_as_read!
     return read_article if read?
+
     create_read_article
+  rescue ActiveRecord::RecordNotUnique
+    reload.read_article
   end
 
   def unmark_as_read!
@@ -67,7 +73,10 @@ class Article < ApplicationRecord
 
   def dismiss!
     return dismissed_article if dismissed_article.present?
+
     create_dismissed_article(dismissed_at: Time.current, permanent: false)
+  rescue ActiveRecord::RecordNotUnique
+    reload.dismissed_article
   end
 
   def undismiss!

--- a/db/migrate/20260710180000_add_unique_indexes_on_user_state_tables.rb
+++ b/db/migrate/20260710180000_add_unique_indexes_on_user_state_tables.rb
@@ -1,0 +1,38 @@
+class AddUniqueIndexesOnUserStateTables < ActiveRecord::Migration[8.1]
+  def up
+    deduplicate_user_state_rows
+
+    replace_with_unique_index :bookmarks, :article_id, "index_bookmarks_on_article_id"
+    replace_with_unique_index :read_articles, :article_id, "index_read_articles_on_article_id"
+    replace_with_unique_index :dismissed_articles, :article_id, "index_dismissed_articles_on_article_id"
+  end
+
+  def down
+    replace_with_non_unique_index :bookmarks, :article_id, "index_bookmarks_on_article_id"
+    replace_with_non_unique_index :read_articles, :article_id, "index_read_articles_on_article_id"
+    replace_with_non_unique_index :dismissed_articles, :article_id, "index_dismissed_articles_on_article_id"
+  end
+
+  private
+
+  def deduplicate_user_state_rows
+    %w[bookmarks read_articles dismissed_articles].each do |table|
+      execute <<~SQL.squish
+        DELETE FROM #{table} a
+        USING #{table} b
+        WHERE a.id < b.id
+          AND a.article_id = b.article_id
+      SQL
+    end
+  end
+
+  def replace_with_unique_index(table, column, index_name)
+    remove_index table, name: index_name if index_exists?(table, column, name: index_name)
+    add_index table, column, unique: true, name: index_name
+  end
+
+  def replace_with_non_unique_index(table, column, index_name)
+    remove_index table, name: index_name if index_exists?(table, column, name: index_name)
+    add_index table, column, name: index_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_03_160000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_10_180000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -35,7 +35,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_03_160000) do
     t.datetime "bookmarked_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["article_id"], name: "index_bookmarks_on_article_id"
+    t.index ["article_id"], name: "index_bookmarks_on_article_id", unique: true
   end
 
   create_table "dismissed_articles", force: :cascade do |t|
@@ -44,7 +44,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_03_160000) do
     t.datetime "dismissed_at", null: false
     t.boolean "permanent", default: false
     t.datetime "updated_at", null: false
-    t.index ["article_id"], name: "index_dismissed_articles_on_article_id"
+    t.index ["article_id"], name: "index_dismissed_articles_on_article_id", unique: true
     t.index ["dismissed_at"], name: "index_dismissed_articles_on_dismissed_at"
     t.index ["permanent"], name: "index_dismissed_articles_on_permanent"
   end
@@ -80,7 +80,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_03_160000) do
     t.datetime "created_at", null: false
     t.datetime "read_at"
     t.datetime "updated_at", null: false
-    t.index ["article_id"], name: "index_read_articles_on_article_id"
+    t.index ["article_id"], name: "index_read_articles_on_article_id", unique: true
   end
 
   add_foreign_key "bookmarks", "articles"

--- a/test/models/article_test.rb
+++ b/test/models/article_test.rb
@@ -37,6 +37,17 @@ class ArticleTest < ActiveSupport::TestCase
     assert_equal 1, @article.reload.bookmark ? 1 : 0 # Ensure only one bookmark
   end
 
+  test "bookmark! recovers from RecordNotUnique race" do
+    existing_bookmark = @article.create_bookmark
+    article = Article.find(@article.id)
+    article.extend(Module.new do
+      def bookmarked? = false
+      def create_bookmark = raise ActiveRecord::RecordNotUnique, "duplicate"
+    end)
+
+    assert_equal existing_bookmark, article.bookmark!
+  end
+
   test "unbookmark! destroys existing bookmark" do
     @article.create_bookmark
     assert @article.bookmarked?
@@ -125,6 +136,17 @@ class ArticleTest < ActiveSupport::TestCase
     assert_equal 1, @article.reload.read_article ? 1 : 0 # Ensure only one read_article
   end
 
+  test "mark_as_read! recovers from RecordNotUnique race" do
+    existing_read = @article.create_read_article
+    article = Article.find(@article.id)
+    article.extend(Module.new do
+      def read? = false
+      def create_read_article = raise ActiveRecord::RecordNotUnique, "duplicate"
+    end)
+
+    assert_equal existing_read, article.mark_as_read!
+  end
+
   test "should destroy existing read_article when unmark_as_read! is called" do
     @article.create_read_article
     assert @article.read?
@@ -201,6 +223,21 @@ class ArticleTest < ActiveSupport::TestCase
     first_dismiss = @article.dismiss!
     second_dismiss = @article.dismiss!
     assert_equal first_dismiss, second_dismiss
+  end
+
+  test "dismiss! recovers from RecordNotUnique race" do
+    existing_dismissed = @article.dismiss!
+    article = Article.find(@article.id)
+    lookups = 0
+    article.define_singleton_method(:dismissed_article) do
+      lookups += 1
+      lookups == 1 ? nil : existing_dismissed
+    end
+    article.define_singleton_method(:create_dismissed_article) do |*_args, **_kwargs|
+      raise ActiveRecord::RecordNotUnique, "duplicate"
+    end
+
+    assert_equal existing_dismissed, article.dismiss!
   end
 
   test "should undismiss article" do

--- a/test/models/bookmark_test.rb
+++ b/test/models/bookmark_test.rb
@@ -29,6 +29,20 @@ class BookmarkTest < ActiveSupport::TestCase
     assert_includes duplicate_bookmark.errors[:article_id], "has already been taken"
   end
 
+  test "database enforces unique article_id" do
+    @bookmark.save!
+    now = Time.current
+
+    assert_raises(ActiveRecord::RecordNotUnique) do
+      Bookmark.insert!({
+        article_id: @article.id,
+        bookmarked_at: now,
+        created_at: now,
+        updated_at: now
+      })
+    end
+  end
+
   test "should set bookmarked_at before create" do
     freeze_time = Time.parse("2025-01-01 12:00:00 UTC")
 

--- a/test/models/dismissed_article_test.rb
+++ b/test/models/dismissed_article_test.rb
@@ -27,6 +27,20 @@ class DismissedArticleTest < ActiveSupport::TestCase
     assert_includes duplicate.errors[:article_id], "has already been taken"
   end
 
+  test "database enforces unique article_id" do
+    now = Time.current
+
+    assert_raises(ActiveRecord::RecordNotUnique) do
+      DismissedArticle.insert!({
+        article_id: @article.id,
+        dismissed_at: now,
+        permanent: false,
+        created_at: now,
+        updated_at: now
+      })
+    end
+  end
+
   test "should have default permanent value of false" do
     dismissed = DismissedArticle.create!(
       article: articles(:dev_to_article),

--- a/test/models/read_article_test.rb
+++ b/test/models/read_article_test.rb
@@ -28,6 +28,20 @@ class ReadArticleTest < ActiveSupport::TestCase
     assert_includes duplicate.errors[:article_id], "has already been taken"
   end
 
+  test "database enforces unique article_id" do
+    @read_article.save!
+    now = Time.current
+
+    assert_raises(ActiveRecord::RecordNotUnique) do
+      ReadArticle.insert!({
+        article_id: @article.id,
+        read_at: now,
+        created_at: now,
+        updated_at: now
+      })
+    end
+  end
+
   test "should set read_at before create" do
     @read_article.save!
     assert @read_article.read_at.present?


### PR DESCRIPTION
## Summary
- Add unique indexes on `article_id` for bookmarks, read_articles, and dismissed_articles (with dedupe migration)
- Rescue `ActiveRecord::RecordNotUnique` in `bookmark!` / `mark_as_read!` / `dismiss!` so concurrent mutations stay idempotent
- Cover DB uniqueness and race recovery in model tests

Closes #244

## Test plan
- [x] `PARALLEL_WORKERS=0 bin/rails test test/models/article_test.rb test/models/bookmark_test.rb test/models/read_article_test.rb test/models/dismissed_article_test.rb`
- [ ] Verify migration is reversible (`bin/rails db:rollback` then `db:migrate`)
- [ ] Double-click bookmark/dismiss/read in UI does not 500