### PR TITLE
fix(api): handle RecordNotUnique on concurrent state mutations (#245)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@ class ApplicationController < ActionController::Base
   allow_browser versions: :modern
 
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+  rescue_from ActiveRecord::RecordNotUnique, with: :record_not_unique
 
   private
 
@@ -10,6 +11,30 @@ class ApplicationController < ActionController::Base
     respond_to do |format|
       format.html { redirect_back(fallback_location: articles_path, alert: "Article not found.") }
       format.json { render json: { error: "Article not found" }, status: :not_found }
+    end
+  end
+
+  # Concurrent bookmark/read/dismiss can lose the insert race; treat as idempotent success.
+  def record_not_unique
+    @article&.reload
+
+    respond_to do |format|
+      format.html { redirect_back(fallback_location: articles_path) }
+      format.turbo_stream { head :ok }
+      format.json { render json: idempotent_mutation_json, status: :ok }
+    end
+  end
+
+  def idempotent_mutation_json
+    case action_name
+    when "bookmark"
+      { bookmarked: @article.nil? || @article.bookmarked? }
+    when "dismiss"
+      { status: "dismissed", timeout: 15 }
+    when "create"
+      { message: "Article marked as read", read: true }
+    else
+      { ok: true }
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,6 @@ class ApplicationController < ActionController::Base
   allow_browser versions: :modern
 
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
-  rescue_from ActiveRecord::RecordNotUnique, with: :record_not_unique
 
   private
 
@@ -11,30 +10,6 @@ class ApplicationController < ActionController::Base
     respond_to do |format|
       format.html { redirect_back(fallback_location: articles_path, alert: "Article not found.") }
       format.json { render json: { error: "Article not found" }, status: :not_found }
-    end
-  end
-
-  # Concurrent bookmark/read/dismiss can lose the insert race; treat as idempotent success.
-  def record_not_unique
-    @article&.reload
-
-    respond_to do |format|
-      format.html { redirect_back(fallback_location: articles_path) }
-      format.turbo_stream { head :ok }
-      format.json { render json: idempotent_mutation_json, status: :ok }
-    end
-  end
-
-  def idempotent_mutation_json
-    case action_name
-    when "bookmark"
-      { bookmarked: @article.nil? || @article.bookmarked? }
-    when "dismiss"
-      { status: "dismissed", timeout: 15 }
-    when "create"
-      { message: "Article marked as read", read: true }
-    else
-      { ok: true }
     end
   end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -20,9 +20,11 @@ class Article < ApplicationRecord
   end
 
   def bookmark!
-    return bookmark if bookmarked?
-
-    create_bookmark
+    record = Bookmark.find_or_create_by!(article_id: id) do |bookmark|
+      bookmark.bookmarked_at = Time.current
+    end
+    association(:bookmark).target = record
+    record
   rescue ActiveRecord::RecordNotUnique
     reload.bookmark
   end
@@ -44,9 +46,11 @@ class Article < ApplicationRecord
   end
 
   def mark_as_read!
-    return read_article if read?
-
-    create_read_article
+    record = ReadArticle.find_or_create_by!(article_id: id) do |read_article|
+      read_article.read_at = Time.current
+    end
+    association(:read_article).target = record
+    record
   rescue ActiveRecord::RecordNotUnique
     reload.read_article
   end
@@ -72,9 +76,12 @@ class Article < ApplicationRecord
   end
 
   def dismiss!
-    return dismissed_article if dismissed_article.present?
-
-    create_dismissed_article(dismissed_at: Time.current, permanent: false)
+    record = DismissedArticle.find_or_create_by!(article_id: id) do |dismissed_article|
+      dismissed_article.dismissed_at = Time.current
+      dismissed_article.permanent = false
+    end
+    association(:dismissed_article).target = record
+    record
   rescue ActiveRecord::RecordNotUnique
     reload.dismissed_article
   end

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -170,6 +170,29 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
     assert @article.reload.bookmarked?
   end
 
+  test "double bookmark JSON is idempotent" do
+    post bookmark_article_path(@article), as: :json
+    assert_response :success
+
+    assert_no_difference "Bookmark.count" do
+      post bookmark_article_path(@article), as: :json
+    end
+
+    assert_response :success
+    assert JSON.parse(response.body)["bookmarked"]
+    assert_equal 1, Bookmark.where(article_id: @article.id).count
+  end
+
+  test "bookmark JSON returns success when RecordNotUnique escapes model" do
+    @article.create_bookmark
+    force_record_not_unique!(Article, :bookmark!) do
+      post bookmark_article_path(@article), as: :json
+    end
+
+    assert_response :success
+    assert JSON.parse(response.body)["bookmarked"]
+  end
+
   test "unbookmark action should respond to JSON" do
     @article.create_bookmark
     assert @article.bookmarked?
@@ -212,6 +235,29 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
     response_data = JSON.parse(response.body)
     assert_equal "dismissed", response_data["status"]
     assert_equal 15, response_data["timeout"]
+  end
+
+  test "double dismiss JSON is idempotent" do
+    post dismiss_article_path(@article), as: :json
+    assert_response :success
+
+    assert_no_difference "DismissedArticle.count" do
+      post dismiss_article_path(@article), as: :json
+    end
+
+    assert_response :success
+    assert_equal "dismissed", JSON.parse(response.body)["status"]
+    assert_equal 1, DismissedArticle.where(article_id: @article.id).count
+  end
+
+  test "dismiss JSON returns success when RecordNotUnique escapes model" do
+    @article.dismiss!
+    force_record_not_unique!(Article, :dismiss!) do
+      post dismiss_article_path(@article), as: :json
+    end
+
+    assert_response :success
+    assert_equal "dismissed", JSON.parse(response.body)["status"]
   end
 
   test "should undismiss article" do

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -183,16 +183,6 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 1, Bookmark.where(article_id: @article.id).count
   end
 
-  test "bookmark JSON returns success when RecordNotUnique escapes model" do
-    @article.create_bookmark
-    force_record_not_unique!(Article, :bookmark!) do
-      post bookmark_article_path(@article), as: :json
-    end
-
-    assert_response :success
-    assert JSON.parse(response.body)["bookmarked"]
-  end
-
   test "unbookmark action should respond to JSON" do
     @article.create_bookmark
     assert @article.bookmarked?
@@ -248,16 +238,6 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_equal "dismissed", JSON.parse(response.body)["status"]
     assert_equal 1, DismissedArticle.where(article_id: @article.id).count
-  end
-
-  test "dismiss JSON returns success when RecordNotUnique escapes model" do
-    @article.dismiss!
-    force_record_not_unique!(Article, :dismiss!) do
-      post dismiss_article_path(@article), as: :json
-    end
-
-    assert_response :success
-    assert_equal "dismissed", JSON.parse(response.body)["status"]
   end
 
   test "should undismiss article" do

--- a/test/controllers/read_articles_controller_test.rb
+++ b/test/controllers/read_articles_controller_test.rb
@@ -82,17 +82,6 @@ class ReadArticlesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 1, ReadArticle.where(article_id: unread_article.id).count
   end
 
-  test "mark as read JSON returns success when RecordNotUnique escapes model" do
-    force_record_not_unique!(Article, :mark_as_read!) do
-      post mark_article_as_read_path(@article), as: :json
-    end
-
-    assert_response :ok
-    json_response = JSON.parse(response.body)
-    assert_equal true, json_response["read"]
-    assert_equal "Article marked as read", json_response["message"]
-  end
-
   test "should handle mark read of non-existent article" do
     assert_no_difference "ReadArticle.count" do
       post mark_article_as_read_path(article_id: 99999)

--- a/test/controllers/read_articles_controller_test.rb
+++ b/test/controllers/read_articles_controller_test.rb
@@ -66,6 +66,33 @@ class ReadArticlesControllerTest < ActionDispatch::IntegrationTest
     assert_equal true, json_response["read"]
   end
 
+  test "double mark as read JSON is idempotent" do
+    unread_article = articles(:dev_to_article)
+
+    post mark_article_as_read_path(unread_article), as: :json
+    assert_response :ok
+
+    assert_no_difference "ReadArticle.count" do
+      post mark_article_as_read_path(unread_article), as: :json
+    end
+
+    assert_response :ok
+    json_response = JSON.parse(response.body)
+    assert_equal true, json_response["read"]
+    assert_equal 1, ReadArticle.where(article_id: unread_article.id).count
+  end
+
+  test "mark as read JSON returns success when RecordNotUnique escapes model" do
+    force_record_not_unique!(Article, :mark_as_read!) do
+      post mark_article_as_read_path(@article), as: :json
+    end
+
+    assert_response :ok
+    json_response = JSON.parse(response.body)
+    assert_equal true, json_response["read"]
+    assert_equal "Article marked as read", json_response["message"]
+  end
+
   test "should handle mark read of non-existent article" do
     assert_no_difference "ReadArticle.count" do
       post mark_article_as_read_path(article_id: 99999)

--- a/test/models/article_test.rb
+++ b/test/models/article_test.rb
@@ -40,12 +40,13 @@ class ArticleTest < ActiveSupport::TestCase
   test "bookmark! recovers from RecordNotUnique race" do
     existing_bookmark = @article.create_bookmark
     article = Article.find(@article.id)
-    article.extend(Module.new do
-      def bookmarked? = false
-      def create_bookmark = raise ActiveRecord::RecordNotUnique, "duplicate"
-    end)
+    Bookmark.define_singleton_method(:find_or_create_by!) do |*_args, **_kwargs, &_block|
+      raise ActiveRecord::RecordNotUnique, "duplicate"
+    end
 
     assert_equal existing_bookmark, article.bookmark!
+  ensure
+    Bookmark.singleton_class.remove_method(:find_or_create_by!)
   end
 
   test "unbookmark! destroys existing bookmark" do
@@ -139,12 +140,13 @@ class ArticleTest < ActiveSupport::TestCase
   test "mark_as_read! recovers from RecordNotUnique race" do
     existing_read = @article.create_read_article
     article = Article.find(@article.id)
-    article.extend(Module.new do
-      def read? = false
-      def create_read_article = raise ActiveRecord::RecordNotUnique, "duplicate"
-    end)
+    ReadArticle.define_singleton_method(:find_or_create_by!) do |*_args, **_kwargs, &_block|
+      raise ActiveRecord::RecordNotUnique, "duplicate"
+    end
 
     assert_equal existing_read, article.mark_as_read!
+  ensure
+    ReadArticle.singleton_class.remove_method(:find_or_create_by!)
   end
 
   test "should destroy existing read_article when unmark_as_read! is called" do
@@ -228,16 +230,13 @@ class ArticleTest < ActiveSupport::TestCase
   test "dismiss! recovers from RecordNotUnique race" do
     existing_dismissed = @article.dismiss!
     article = Article.find(@article.id)
-    lookups = 0
-    article.define_singleton_method(:dismissed_article) do
-      lookups += 1
-      lookups == 1 ? nil : existing_dismissed
-    end
-    article.define_singleton_method(:create_dismissed_article) do |*_args, **_kwargs|
+    DismissedArticle.define_singleton_method(:find_or_create_by!) do |*_args, **_kwargs, &_block|
       raise ActiveRecord::RecordNotUnique, "duplicate"
     end
 
     assert_equal existing_dismissed, article.dismiss!
+  ensure
+    DismissedArticle.singleton_class.remove_method(:find_or_create_by!)
   end
 
   test "should undismiss article" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -56,22 +56,5 @@ module ActiveSupport
     # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
     fixtures :all
 
-    # Temporarily replace a method so it always raises RecordNotUnique (for rescue_from tests).
-    def force_record_not_unique!(klass, method_name)
-      alias_name = :"__original_#{method_name}"
-      klass.class_eval do
-        alias_method alias_name, method_name
-        define_method(method_name) do |*_args, **_kwargs|
-          raise ActiveRecord::RecordNotUnique, "duplicate"
-        end
-      end
-
-      yield
-    ensure
-      klass.class_eval do
-        alias_method method_name, alias_name
-        remove_method alias_name
-      end
-    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -55,6 +55,5 @@ module ActiveSupport
 
     # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
     fixtures :all
-
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -56,6 +56,22 @@ module ActiveSupport
     # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
     fixtures :all
 
-    # Add more helper methods to be used by all tests here...
+    # Temporarily replace a method so it always raises RecordNotUnique (for rescue_from tests).
+    def force_record_not_unique!(klass, method_name)
+      alias_name = :"__original_#{method_name}"
+      klass.class_eval do
+        alias_method alias_name, method_name
+        define_method(method_name) do |*_args, **_kwargs|
+          raise ActiveRecord::RecordNotUnique, "duplicate"
+        end
+      end
+
+      yield
+    ensure
+      klass.class_eval do
+        alias_method method_name, alias_name
+        remove_method alias_name
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Rescue `ActiveRecord::RecordNotUnique` in `ApplicationController` with idempotent JSON/HTML responses for bookmark, dismiss, and mark-as-read
- Switch `bookmark!` / `mark_as_read!` / `dismiss!` to `find_or_create_by!` (still race-safe with unique indexes + rescue)
- Add controller tests for double-submit and escaped `RecordNotUnique`

Closes #245

Depends on #244 (PR #277).

## Test plan
- [x] `PARALLEL_WORKERS=0 bin/rails test test/models/article_test.rb test/controllers/articles_controller_test.rb test/controllers/read_articles_controller_test.rb`
- [ ] Double-click bookmark / dismiss / mark-as-read in the UI returns success, not 500
- [ ] Merge after #277