### PR TITLE
fix(deps): bump websocket-driver to 0.8.2 for CVEs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -380,7 +380,7 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     websocket (1.2.11)
-    websocket-driver (0.8.0)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)


### PR DESCRIPTION
## Summary
- Bump websocket-driver from 0.8.0 to 0.8.2 to resolve bundler-audit CVEs
- No Gemfile change needed; lockfile-only update

## Test plan
- [ ] bundler-audit CI job passes
- [ ] Confirm Gemfile.lock shows websocket-driver (0.8.2)