### PR TITLE
docs: add contributing guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in this repository. Keep this file concise and defer details to the maintained docs.
+
+## Read First
+
+- `CONTRIBUTING.md`: contributor entry point and pull request workflow.
+- `docs/DEVELOPMENT.md`: setup, architecture, coding standards, test expectations, and git conventions.
+- `docs/REPO_STRUCTURE.md`: repository map. Update it in the same change when structure changes.
+- `docs/PRE_COMMIT_HOOKS.md`: Overcommit setup and local hook checks.
+
+## Work Rules
+
+- Create a branch from `master`; never commit directly to `master`.
+- Keep pull requests focused. Avoid broad roadmap, cleanup, or refactor work unless the issue asks for it.
+- Follow the existing package and Rails boundaries. Prefer service objects for aggregation logic and keep controllers thin.
+- Do not commit credentials, API tokens, database dumps, private customer data, or local machine paths.
+- When adding or moving files, update `docs/REPO_STRUCTURE.md` if the structure map changes.
+
+## Verification
+
+Run the checks relevant to your change before opening a pull request:
+
+```bash
+bin/rails test
+bin/rubocop
+bin/brakeman
+npm test
+npm audit --omit=dev --audit-level=moderate
+```
+
+For hook parity with local contributors, install and run Overcommit as described in `docs/PRE_COMMIT_HOOKS.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing
+
+Thanks for improving Dev News Aggregator. This file is the short entry point; keep detailed project conventions in the existing docs.
+
+## Start Here
+
+- [AGENTS.md](AGENTS.md) for AI-agent workflow, scope, and verification guardrails.
+- [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) for setup, architecture, coding standards, tests, and git conventions.
+- [docs/REPO_STRUCTURE.md](docs/REPO_STRUCTURE.md) for the repository map. Update it when you change project structure.
+- [docs/PRE_COMMIT_HOOKS.md](docs/PRE_COMMIT_HOOKS.md) for Overcommit setup and local hook usage.
+
+## Workflow
+
+1. Create a descriptive branch from `master`; never commit directly to `master`.
+2. Keep changes focused on one issue or behavior.
+3. Follow the conventional commit format documented in `docs/DEVELOPMENT.md`.
+4. Run the relevant tests, lint, and security checks before opening a pull request.
+5. Open a pull request with `gh pr create`, reference the issue, and wait for review before merging.
+
+Use `docs/DEVELOPMENT.md` as the source of truth when this summary and the full guide differ.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ No manual intervention needed for routine security patches and minor updates!
 
 ## Development
 
-See [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) for development guidelines and [docs/REPO_STRUCTURE.md](docs/REPO_STRUCTURE.md) for the repository map (keep it updated when structure changes).
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the contributor entry point, [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) for development guidelines, and [docs/REPO_STRUCTURE.md](docs/REPO_STRUCTURE.md) for the repository map (keep it updated when structure changes).
 
 ### Pre-commit Hooks
 

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -2,7 +2,7 @@
 
 Living map of this codebase. **Keep this file in sync with the repo** — see [Maintenance](#maintenance) below.
 
-Last updated: 2026-07-03
+Last updated: 2026-07-10
 
 ## Maintenance
 
@@ -187,6 +187,8 @@ dev-news-aggregator/
 | File | Purpose |
 |------|---------|
 | `README.md` | Project overview and quick start |
+| `CONTRIBUTING.md` | Contributor entry point and PR workflow links |
+| `AGENTS.md` | AI-agent workflow and verification guardrails |
 | `Gemfile` / `Gemfile.lock` | Ruby gems |
 | `package.json` / `package-lock.json` | Node packages |
 | `docker-compose.yml` | Local PostgreSQL container |


### PR DESCRIPTION
## Summary

- Add a thin root `CONTRIBUTING.md` that links the maintained agent, development, structure, and pre-commit docs.
- Add a concise `AGENTS.md` so AI coding agents have a discoverable workflow and verification entry point.
- Link `CONTRIBUTING.md` from the README and update `docs/REPO_STRUCTURE.md` for the new root files.

Fixes #265

## Testing

- `git diff --check`
- Verified referenced files exist: `AGENTS.md`, `docs/DEVELOPMENT.md`, `docs/REPO_STRUCTURE.md`, and `docs/PRE_COMMIT_HOOKS.md`
- Confirmed `CONTRIBUTING.md` is 20 lines, under the requested 50-line limit

Docs-only change; app tests were not run.
