### PR TITLE
revert: restore LICENSE and bin/validate from #274 #276

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,19 @@ Guidance for AI coding agents working in this repository. Keep this file concise
 
 ## Verification
 
-Run the checks relevant to your change before opening a pull request:
+Prefer the CI-equivalent local wrapper before opening a pull request:
+
+```bash
+bin/validate
+```
+
+For quick iteration, use fast mode (skips Brakeman and Rails tests):
+
+```bash
+bin/validate --fast
+```
+
+Or run the checks relevant to your change individually:
 
 ```bash
 bin/rails test

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Marcos Lorejan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/bin/validate
+++ b/bin/validate
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -u -o pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: bin/validate [--fast]
+
+Run CI-equivalent local validation checks.
+
+Options:
+  --fast   Skip slower checks that usually need more setup, such as Brakeman
+           and Rails tests.
+  -h, --help  Show this help.
+USAGE
+}
+
+fast=false
+for arg in "$@"; do
+  case "$arg" in
+    --fast)
+      fast=true
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $arg" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+failures=0
+
+run_check() {
+  local name="$1"
+  shift
+
+  printf '\n==> %s\n' "$name"
+  if "$@"; then
+    printf '✓ %s passed\n' "$name"
+  else
+    local status=$?
+    printf '✗ %s failed with exit code %s\n' "$name" "$status" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+skip_check() {
+  local name="$1"
+  printf '\n==> %s\n' "$name"
+  printf '↷ skipped in --fast mode\n'
+}
+
+run_check "RuboCop" bundle exec rubocop -f github
+
+if "$fast"; then
+  skip_check "Brakeman"
+else
+  run_check "Brakeman" bundle exec brakeman --no-pager --no-exit-on-warn
+fi
+
+run_check "TypeScript typecheck" npm run typecheck
+run_check "Frontend tests" npm test
+
+if "$fast"; then
+  skip_check "Rails tests"
+else
+  run_check "Rails tests" env RAILS_ENV=test bin/rails test
+fi
+
+if [ "$failures" -eq 0 ]; then
+  printf '\nAll validation checks passed.\n'
+  exit 0
+fi
+
+printf '\n%s validation check(s) failed.\n' "$failures" >&2
+exit 1

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -2,7 +2,7 @@
 
 Living map of this codebase. **Keep this file in sync with the repo** — see [Maintenance](#maintenance) below.
 
-Last updated: 2026-07-10
+Last updated: 2026-07-13
 
 ## Maintenance
 
@@ -32,7 +32,7 @@ Rails 8 news aggregator with a React (Vite) frontend, PostgreSQL, and scheduled 
 ```
 dev-news-aggregator/
 ├── app/                    # Application code (MVC, services, jobs, frontend)
-├── bin/                    # Executables (rails, dev, jobs, rubocop, brakeman, …)
+├── bin/                    # Executables (rails, validate, dev, jobs, rubocop, brakeman, …)
 ├── config/                 # Rails and app configuration
 ├── db/                     # Migrations, schema, seeds
 ├── docs/                   # Project documentation
@@ -186,6 +186,7 @@ dev-news-aggregator/
 
 | File | Purpose |
 |------|---------|
+| `LICENSE` | MIT license |
 | `README.md` | Project overview and quick start |
 | `CONTRIBUTING.md` | Contributor entry point and PR workflow links |
 | `AGENTS.md` | AI-agent workflow and verification guardrails |


### PR DESCRIPTION
## Summary
- Security-reviewed reverted PRs #274 and #276 (author w3lld1): no malice found
- Restores standard MIT `LICENSE` from #276 and executable `bin/validate` from #274 (reverts #280)
- Keeps #281 `AGENTS.md` structure and documents `bin/validate` / `--fast`; updates `docs/REPO_STRUCTURE.md`

## Security verdict
- **LICENSE**: standard MIT text, copyright Marcos Lorejan 2026
- **bin/validate**: local wrapper for rubocop/brakeman/npm/rails tests only — no network exfil, eval, curl|bash, or privilege escalation
- **AGENTS.md (#274)**: docs only; merged into current #281 guidance

## Test plan
- [ ] Confirm `LICENSE` matches standard MIT
- [ ] Confirm `bin/validate` is executable and runs local checks only
- [ ] Confirm `AGENTS.md` still includes #281 links plus `bin/validate` docs
- [ ] CI green