### PR TITLE
fix(ci): add explicit GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   scan_ruby:
     runs-on: ubuntu-latest
@@ -113,6 +116,9 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     services:
       postgres:
         image: postgres:15
@@ -186,6 +192,9 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     services:
       postgres:
         image: postgres:15
@@ -269,6 +278,7 @@ jobs:
 
   quality_gate:
     runs-on: ubuntu-latest
+    permissions: {}
     needs: [scan_ruby, scan_dependencies, scan_js, lint, frontend_test, test, coverage]
     if: always()
     steps:


### PR DESCRIPTION
## Summary
- Resolves open [code scanning alerts](https://github.com/MarcosLorejan/dev-news-aggregator/security/code-scanning) for `actions/missing-workflow-permissions` in `.github/workflows/ci.yml`
- Sets workflow-level `permissions: contents: read` as the default least-privilege scope
- Grants `actions: write` on `test` and `coverage` so artifact uploads still work
- Sets `permissions: {}` on `quality_gate`, which needs no token access

## Test plan
- [ ] Confirm CI jobs still pass (especially `test` screenshot artifacts and `coverage` report upload)
- [ ] After merge, verify code scanning alerts 4, 5, 296–301 close on the security dashboard