### PR TITLE
fix(fetching): ingest Reddit via Atom feeds (#273)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,5 +9,6 @@ SECRET_KEY_BASE=your_secret_key_base_here
 
 # Optional: API Keys (if needed in future)
 # HACKER_NEWS_API_KEY=
-# REDDIT_API_KEY=
 # DEVTO_API_KEY=
+# Reddit uses public Atom feeds (/r/{subreddit}/.rss); no API key required.
+

--- a/app/services/news_fetchers/base_fetcher.rb
+++ b/app/services/news_fetchers/base_fetcher.rb
@@ -1,6 +1,8 @@
 class NewsFetchers::BaseFetcher
   include HTTParty
 
+  class FetchError < StandardError; end
+
   RETRYABLE_ERRORS = [
     Net::OpenTimeout,
     Net::ReadTimeout,
@@ -32,9 +34,15 @@ class NewsFetchers::BaseFetcher
     def parse_http_response(response)
       return response unless response.is_a?(HTTParty::Response)
 
+      unless response.success?
+        body_preview = response.body.to_s.gsub(/\s+/, " ").strip[0, 200]
+        raise FetchError,
+              "HTTP #{response.code} for #{response.request&.uri}: #{body_preview.presence || '(empty body)'}"
+      end
+
       response.parsed_response
-    rescue JSON::ParserError
-      nil
+    rescue JSON::ParserError => e
+      raise FetchError, "Invalid JSON response: #{e.message}"
     end
   end
 

--- a/app/services/news_fetchers/reddit_fetcher.rb
+++ b/app/services/news_fetchers/reddit_fetcher.rb
@@ -1,7 +1,33 @@
 class NewsFetchers::RedditFetcher < NewsFetchers::BaseFetcher
+  USER_AGENT = "web:dev-news-aggregator:v1.0 (by /u/devnewsaggregator)"
+  LINK_HREF_PATTERN = %r{<a\s+href="([^"]+)"\s*>\s*\[link\]\s*</a>}i
+
   base_uri "https://www.reddit.com"
-  format :json
-  headers "User-Agent" => "DevNewsAggregator/1.0"
+  headers "User-Agent" => USER_AGENT
+
+  class << self
+    attr_writer :min_request_interval_seconds
+
+    def min_request_interval_seconds
+      @min_request_interval_seconds || 1.2
+    end
+
+    def reset_throttle!
+      @last_request_at = nil
+    end
+
+    def throttle!
+      @throttle_mutex ||= Mutex.new
+      @throttle_mutex.synchronize do
+        now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        if @last_request_at
+          wait = min_request_interval_seconds - (now - @last_request_at)
+          sleep(wait) if wait.positive?
+        end
+        @last_request_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+    end
+  end
 
   def initialize(subreddit: "programming")
     super()
@@ -13,53 +39,99 @@ class NewsFetchers::RedditFetcher < NewsFetchers::BaseFetcher
   end
 
   def fetch_articles
-    Rails.logger.info "Fetching articles from Reddit r/#{@subreddit}..."
+    Rails.logger.info "Fetching articles from Reddit r/#{@subreddit} (Atom feed)..."
 
-    # Get hot posts from subreddit
-    response = self.class.get(
-      "/r/#{@subreddit}.json",
-      query: { limit: NewsAggregatorConfig.max_articles_per_source }
-    )
-    return [] unless response.is_a?(Hash) && response["data"]
+    feed_body = fetch_feed_body
+    entries = parse_atom_entries(feed_body)
+    raise FetchError, "Reddit r/#{@subreddit} feed contained no entries" if entries.empty?
 
-    posts_data = response.dig("data", "children")
-    return [] unless posts_data.is_a?(Array)
-
-    posts_data.each do |post|
-      create_article_from_post(post["data"])
+    entries.first(NewsAggregatorConfig.max_articles_per_source).each do |entry|
+      create_article_from_entry(entry)
     end
 
     Rails.logger.info "Fetched #{@articles.length} articles from Reddit r/#{@subreddit}"
     @articles
-  rescue JSON::ParserError, StandardError => e
-    Rails.logger.error "Error fetching Reddit r/#{@subreddit}: #{e.message}"
-    []
   end
 
   private
 
-  def create_article_from_post(post_data)
-    # Skip self posts without URLs
-    return if post_data["is_self"] && post_data["url_overridden_by_dest"].nil?
+  def fetch_feed_body
+    self.class.throttle!
 
-    # Use external URL if available, otherwise Reddit permalink
-    article_url = post_data["url_overridden_by_dest"] ||
-                  "https://reddit.com#{post_data['permalink']}"
+    response = self.class.get(
+      "/r/#{@subreddit}/.rss",
+      format: :plain,
+      headers: { "User-Agent" => USER_AGENT }
+    )
+
+    body = response.to_s
+    raise FetchError, "Empty Reddit r/#{@subreddit} Atom feed" if body.blank?
+
+    body
+  end
+
+  def parse_atom_entries(feed_body)
+    document = Nokogiri::XML(feed_body)
+    document.remove_namespaces!
+
+    document.xpath("//entry").filter_map do |entry|
+      title = entry.at_xpath("./title")&.text&.strip
+      external_id = entry.at_xpath("./id")&.text&.strip
+      permalink = entry.at_xpath("./link/@href")&.value&.strip
+      published = entry.at_xpath("./published")&.text.presence ||
+                  entry.at_xpath("./updated")&.text
+      content_html = entry.at_xpath("./content")&.text.to_s
+
+      next if title.blank? || external_id.blank? || permalink.blank?
+
+      {
+        title: title,
+        external_id: external_id.delete_prefix("t3_"),
+        permalink: permalink,
+        published_at: published,
+        content_html: content_html,
+        article_url: extract_article_url(content_html, permalink)
+      }
+    end
+  end
+
+  def extract_article_url(content_html, permalink)
+    unescaped = CGI.unescapeHTML(content_html.to_s)
+    match = unescaped.match(LINK_HREF_PATTERN)
+    link_url = match&.captures&.first
+
+    if link_url.present? && !reddit_host?(link_url)
+      link_url
+    else
+      permalink
+    end
+  end
+
+  def reddit_host?(url)
+    host = URI.parse(url).host
+    host&.end_with?("reddit.com")
+  rescue URI::InvalidURIError
+    false
+  end
+
+  def create_article_from_entry(entry)
+    published_at = Time.iso8601(entry[:published_at])
+    description = Nokogiri::HTML.fragment(CGI.unescapeHTML(entry[:content_html])).text.squish
 
     article_attributes = {
-      title: post_data["title"],
-      url: article_url,
-      published_at: Time.at(post_data["created_utc"]),
-      description: post_data["selftext"] || "",
-      external_id: post_data["id"],
+      title: entry[:title],
+      url: entry[:article_url],
+      published_at: published_at,
+      description: description,
+      external_id: entry[:external_id],
       source_type: "reddit_#{@subreddit}",
-      score: post_data["score"] || 0,
-      comment_count: post_data["num_comments"] || 0
+      score: 0,
+      comment_count: 0
     }
 
     article = create_or_update_article(article_attributes)
     @articles << article if article.persisted?
   rescue StandardError => e
-    Rails.logger.error "Error creating Reddit article #{post_data['id']}: #{e.message}"
+    Rails.logger.error "Error creating Reddit article #{entry[:external_id]}: #{e.message}"
   end
 end

--- a/app/services/news_fetchers/reddit_fetcher.rb
+++ b/app/services/news_fetchers/reddit_fetcher.rb
@@ -108,8 +108,10 @@ class NewsFetchers::RedditFetcher < NewsFetchers::BaseFetcher
   end
 
   def reddit_host?(url)
-    host = URI.parse(url).host
-    host&.end_with?("reddit.com")
+    host = URI.parse(url).host&.downcase
+    return false if host.blank?
+
+    host == "reddit.com" || host.end_with?(".reddit.com")
   rescue URI::InvalidURIError
     false
   end
@@ -117,6 +119,7 @@ class NewsFetchers::RedditFetcher < NewsFetchers::BaseFetcher
   def create_article_from_entry(entry)
     published_at = Time.iso8601(entry[:published_at])
     description = Nokogiri::HTML.fragment(CGI.unescapeHTML(entry[:content_html])).text.squish
+    source_type = "reddit_#{@subreddit}"
 
     article_attributes = {
       title: entry[:title],
@@ -124,10 +127,14 @@ class NewsFetchers::RedditFetcher < NewsFetchers::BaseFetcher
       published_at: published_at,
       description: description,
       external_id: entry[:external_id],
-      source_type: "reddit_#{@subreddit}",
-      score: 0,
-      comment_count: 0
+      source_type: source_type
     }
+
+    # Atom feeds do not include score/comments — only seed defaults on create.
+    unless Article.exists?(external_id: entry[:external_id], source_type: source_type)
+      article_attributes[:score] = 0
+      article_attributes[:comment_count] = 0
+    end
 
     article = create_or_update_article(article_attributes)
     @articles << article if article.persisted?

--- a/app/services/reddit_subreddit_validator.rb
+++ b/app/services/reddit_subreddit_validator.rb
@@ -1,5 +1,5 @@
 class RedditSubredditValidator
-  USER_AGENT = "DevNewsAggregator/1.0"
+  USER_AGENT = NewsFetchers::RedditFetcher::USER_AGENT
 
   def self.valid?(subreddit)
     normalized = normalize(subreddit)
@@ -9,15 +9,15 @@ class RedditSubredditValidator
     cached = Rails.cache.read(cache_key)
     return cached unless cached.nil?
 
+    NewsFetchers::RedditFetcher.throttle!
+
     response = HTTParty.get(
-      "https://www.reddit.com/r/#{normalized}/about.json",
+      "https://www.reddit.com/r/#{normalized}/.rss",
       headers: { "User-Agent" => USER_AGENT },
       timeout: 5
     )
 
-    valid = response.code == 200 &&
-            response.parsed_response.is_a?(Hash) &&
-            response.dig("data", "subreddit_type") != "banned"
+    valid = response.code == 200 && response.body.to_s.include?("<feed")
 
     Rails.cache.write(cache_key, valid, expires_in: 1.hour)
     valid

--- a/config/news_aggregator.yml
+++ b/config/news_aggregator.yml
@@ -30,8 +30,9 @@ development: &default
       articles_endpoint: "/articles"
       
     reddit:
+      # Public JSON listings return 403; fetchers use Atom RSS (.rss) instead.
       base_url: "https://www.reddit.com/r"
-      format: ".json"
+      format: ".rss"
       subreddits:
         - programming
         - webdev

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -153,7 +153,7 @@ config/schedule.rb                      # Cron job definitions
 
 **Dev.to**: Uses REST API (`dev.to/api/articles`) with query params for pagination and filtering by top posts from last 7 days.
 
-**Reddit**: Multiple instances for different subreddits. Each subreddit is treated as a separate source type in the database.
+**Reddit**: Multiple instances for different subreddits. Each subreddit is treated as a separate source type in the database. Fetchers read the public Atom feed (`/r/{subreddit}/.rss`) because unauthenticated `.json` listings return HTTP 403. Requests are throttled to reduce rate-limit errors; HTTP failures are recorded on `FetchRun` instead of silent zero-article success.
 
 ### Database schema
 

--- a/test/services/news_fetchers/base_fetcher_test.rb
+++ b/test/services/news_fetchers/base_fetcher_test.rb
@@ -71,19 +71,40 @@ class NewsFetchers::BaseFetcherTest < ActiveSupport::TestCase
   test "parse_http_response unwraps HTTParty responses" do
     fake_response = Object.new
     fake_response.define_singleton_method(:parsed_response) { %w[a b] }
+    fake_response.define_singleton_method(:success?) { true }
     fake_response.define_singleton_method(:is_a?) { |klass| klass == HTTParty::Response }
 
     result = NewsFetchers::BaseFetcher.send(:parse_http_response, fake_response)
     assert_equal %w[a b], result
   end
 
-  test "parse_http_response returns nil for invalid JSON bodies" do
+  test "parse_http_response raises FetchError for invalid JSON bodies" do
     fake_response = Object.new
     fake_response.define_singleton_method(:parsed_response) { raise JSON::ParserError, "unexpected character" }
+    fake_response.define_singleton_method(:success?) { true }
     fake_response.define_singleton_method(:is_a?) { |klass| klass == HTTParty::Response }
 
-    result = NewsFetchers::BaseFetcher.send(:parse_http_response, fake_response)
-    assert_nil result
+    error = assert_raises(NewsFetchers::BaseFetcher::FetchError) do
+      NewsFetchers::BaseFetcher.send(:parse_http_response, fake_response)
+    end
+    assert_match(/Invalid JSON response/, error.message)
+  end
+
+  test "parse_http_response raises FetchError for non-success HTTP responses" do
+    request = Object.new
+    request.define_singleton_method(:uri) { "https://example.com/api" }
+
+    fake_response = Object.new
+    fake_response.define_singleton_method(:success?) { false }
+    fake_response.define_singleton_method(:code) { 403 }
+    fake_response.define_singleton_method(:body) { "Blocked" }
+    fake_response.define_singleton_method(:request) { request }
+    fake_response.define_singleton_method(:is_a?) { |klass| klass == HTTParty::Response }
+
+    error = assert_raises(NewsFetchers::BaseFetcher::FetchError) do
+      NewsFetchers::BaseFetcher.send(:parse_http_response, fake_response)
+    end
+    assert_match(/HTTP 403/, error.message)
   end
 
   test "get retries transient network errors with backoff before succeeding" do

--- a/test/services/news_fetchers/hacker_news_fetcher_test.rb
+++ b/test/services/news_fetchers/hacker_news_fetcher_test.rb
@@ -52,12 +52,15 @@ class NewsFetchers::HackerNewsFetcherTest < ActiveSupport::TestCase
     end
   end
 
-  test "fetch_articles returns empty array when top stories request fails" do
+  test "fetch_articles raises when top stories request fails" do
     stub_request(:get, "https://hacker-news.firebaseio.com/v0/topstories.json")
       .to_return(status: 500, body: "error")
 
     assert_no_difference "Article.count" do
-      assert_empty @fetcher.fetch_articles
+      error = assert_raises(NewsFetchers::BaseFetcher::FetchError) do
+        @fetcher.fetch_articles
+      end
+      assert_match(/HTTP 500/, error.message)
     end
   end
 

--- a/test/services/news_fetchers/reddit_fetcher_test.rb
+++ b/test/services/news_fetchers/reddit_fetcher_test.rb
@@ -76,6 +76,48 @@ class NewsFetchers::RedditFetcherTest < ActiveSupport::TestCase
     end
   end
 
+  test "fetch_articles preserves existing score and comment_count on update" do
+    Article.create!(
+      title: "Old Title",
+      url: "https://example.com/old",
+      published_at: 1.day.ago,
+      description: "old",
+      external_id: "abc123",
+      source_type: "reddit_programming",
+      score: 42,
+      comment_count: 7
+    )
+
+    stub_reddit_feed(<<~ATOM)
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <entry>
+          <id>t3_abc123</id>
+          <title>Updated Title</title>
+          <link href="https://www.reddit.com/r/programming/comments/abc123/reddit_link/" />
+          <published>2023-11-14T22:13:20+00:00</published>
+          <content type="html">&lt;a href="https://example.com/article"&gt;[link]&lt;/a&gt;</content>
+        </entry>
+      </feed>
+    ATOM
+
+    assert_no_difference "Article.count" do
+      article = @fetcher.fetch_articles.first
+      assert_equal "Updated Title", article.title
+      assert_equal "https://example.com/article", article.url
+      assert_equal 42, article.score
+      assert_equal 7, article.comment_count
+    end
+  end
+
+  test "extract_article_url keeps external hosts that contain reddit.com as a substring" do
+    url = @fetcher.send(
+      :extract_article_url,
+      %(<a href="https://notreddit.com/post">[link]</a>),
+      "https://www.reddit.com/r/programming/comments/x/title/"
+    )
+    assert_equal "https://notreddit.com/post", url
+  end
+
   private
 
   def stub_reddit_feed(body)

--- a/test/services/news_fetchers/reddit_fetcher_test.rb
+++ b/test/services/news_fetchers/reddit_fetcher_test.rb
@@ -3,111 +3,83 @@ require "test_helper"
 class NewsFetchers::RedditFetcherTest < ActiveSupport::TestCase
   def setup
     @fetcher = NewsFetchers::RedditFetcher.new(subreddit: "programming")
+    NewsFetchers::RedditFetcher.min_request_interval_seconds = 0
+    NewsFetchers::RedditFetcher.reset_throttle!
   end
 
-  test "fetch_articles creates articles from link posts" do
-    stub_request(:get, "https://www.reddit.com/r/programming.json")
-      .with(query: { limit: NewsAggregatorConfig.max_articles_per_source })
-      .to_return(
-        status: 200,
-        body: {
-          data: {
-            children: [
-              {
-                data: {
-                  id: "abc123",
-                  title: "Reddit Link",
-                  url_overridden_by_dest: "https://example.com/article",
-                  created_utc: 1_700_000_000,
-                  selftext: "",
-                  is_self: false,
-                  score: 50,
-                  num_comments: 8
-                }
-              }
-            ]
-          }
-        }.to_json,
-        headers: { "Content-Type" => "application/json" }
-      )
+  def teardown
+    NewsFetchers::RedditFetcher.min_request_interval_seconds = nil
+    NewsFetchers::RedditFetcher.reset_throttle!
+  end
+
+  test "fetch_articles creates articles from Atom link posts" do
+    stub_reddit_feed(<<~ATOM)
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <entry>
+          <id>t3_abc123</id>
+          <title>Reddit Link</title>
+          <link href="https://www.reddit.com/r/programming/comments/abc123/reddit_link/" />
+          <published>2023-11-14T22:13:20+00:00</published>
+          <content type="html">submitted by /u/someone &lt;a href="https://example.com/article"&gt;[link]&lt;/a&gt; &lt;a href="https://www.reddit.com/r/programming/comments/abc123/reddit_link/"&gt;[comments]&lt;/a&gt;</content>
+        </entry>
+      </feed>
+    ATOM
 
     assert_difference "Article.count", 1 do
       articles = @fetcher.fetch_articles
       assert_equal 1, articles.length
       assert_equal "Reddit Link", articles.first.title
+      assert_equal "https://example.com/article", articles.first.url
       assert_equal "reddit_programming", articles.first.source_type
+      assert_equal "abc123", articles.first.external_id
     end
   end
 
-  test "fetch_articles skips self posts without external URL" do
-    stub_request(:get, "https://www.reddit.com/r/programming.json")
-      .with(query: { limit: NewsAggregatorConfig.max_articles_per_source })
-      .to_return(
-        status: 200,
-        body: {
-          data: {
-            children: [
-              {
-                data: {
-                  id: "self1",
-                  title: "Self post",
-                  is_self: true,
-                  permalink: "/r/programming/comments/self1/title/",
-                  created_utc: 1_700_000_000,
-                  score: 1,
-                  num_comments: 0
-                }
-              }
-            ]
-          }
-        }.to_json,
-        headers: { "Content-Type" => "application/json" }
-      )
-
-    assert_no_difference "Article.count" do
-      assert_empty @fetcher.fetch_articles
-    end
-  end
-
-  test "fetch_articles uses overridden URL for self posts with external link" do
-    stub_request(:get, "https://www.reddit.com/r/programming.json")
-      .with(query: { limit: NewsAggregatorConfig.max_articles_per_source })
-      .to_return(
-        status: 200,
-        body: {
-          data: {
-            children: [
-              {
-                data: {
-                  id: "self2",
-                  title: "Self with link",
-                  is_self: true,
-                  url_overridden_by_dest: "https://example.com/linked",
-                  permalink: "/r/programming/comments/self2/title/",
-                  created_utc: 1_700_000_000,
-                  score: 2,
-                  num_comments: 1
-                }
-              }
-            ]
-          }
-        }.to_json,
-        headers: { "Content-Type" => "application/json" }
-      )
+  test "fetch_articles uses permalink when link points at Reddit" do
+    stub_reddit_feed(<<~ATOM)
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <entry>
+          <id>t3_self1</id>
+          <title>Self post</title>
+          <link href="https://www.reddit.com/r/programming/comments/self1/title/" />
+          <published>2023-11-14T22:13:20+00:00</published>
+          <content type="html">&lt;a href="https://www.reddit.com/r/programming/comments/self1/title/"&gt;[link]&lt;/a&gt;</content>
+        </entry>
+      </feed>
+    ATOM
 
     assert_difference "Article.count", 1 do
       article = @fetcher.fetch_articles.first
-      assert_equal "https://example.com/linked", article.url
+      assert_equal "https://www.reddit.com/r/programming/comments/self1/title/", article.url
     end
   end
 
-  test "fetch_articles returns empty array when API response is invalid" do
-    stub_request(:get, "https://www.reddit.com/r/programming.json")
-      .with(query: { limit: NewsAggregatorConfig.max_articles_per_source })
-      .to_return(status: 200, body: {}.to_json, headers: { "Content-Type" => "application/json" })
+  test "fetch_articles raises when Reddit returns HTTP errors" do
+    stub_request(:get, "https://www.reddit.com/r/programming/.rss")
+      .to_return(status: 403, body: "<html>Blocked</html>", headers: { "Content-Type" => "text/html" })
 
-    assert_no_difference "Article.count" do
-      assert_empty @fetcher.fetch_articles
+    error = assert_raises(NewsFetchers::BaseFetcher::FetchError) do
+      @fetcher.fetch_articles
     end
+    assert_match(/HTTP 403/, error.message)
+  end
+
+  test "fetch_articles raises when feed has no entries" do
+    stub_reddit_feed(<<~ATOM)
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <title>programming</title>
+      </feed>
+    ATOM
+
+    assert_raises(NewsFetchers::BaseFetcher::FetchError) do
+      @fetcher.fetch_articles
+    end
+  end
+
+  private
+
+  def stub_reddit_feed(body)
+    stub_request(:get, "https://www.reddit.com/r/programming/.rss")
+      .to_return(status: 200, body: body, headers: { "Content-Type" => "application/atom+xml" })
   end
 end


### PR DESCRIPTION
## Summary
- Switch Reddit fetchers from blocked unauthenticated `.json` listings to public Atom RSS (`/r/{subreddit}/.rss`)
- Raise on non-2xx HTTP responses in `BaseFetcher` so `FetchRun` records failures instead of silent zero-article success
- Throttle Reddit requests and extract external article URLs from Atom `[link]` hrefs

Closes #273

## Test plan
- [x] `bundle exec ruby -Itest test/services/news_fetchers/reddit_fetcher_test.rb`
- [x] `bundle exec ruby -Itest test/services/news_fetchers/base_fetcher_test.rb`
- [x] `bundle exec ruby -Itest test/services/news_aggregator_service_test.rb`
- [x] Live smoke: `RedditFetcher` ingested 25 `reddit_programming` articles with external URLs
- [ ] `bin/rails news:fetch` then `bin/rails news:fetch_status` shows Reddit sources with articles_count > 0 (or failure details on rate limit)