### PR TITLE
fix(frontend): restore feed UI contrast (#272)

### DIFF
--- a/app/frontend/components/CategoryFilter.tsx
+++ b/app/frontend/components/CategoryFilter.tsx
@@ -21,7 +21,7 @@ export default function CategoryFilter({
   return (
     <div className="mb-8">
       <Card tone="subtle">
-        <h2 className="text-h3 text-gray-200 mb-4 flex items-center">
+        <h2 className="text-h3 text-gray-100 mb-4 flex items-center">
           <svg className="w-5 h-5 mr-2 text-primary-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.707A1 1 0 013 7V4z" />
           </svg>

--- a/app/frontend/components/EmptyState.tsx
+++ b/app/frontend/components/EmptyState.tsx
@@ -34,7 +34,7 @@ export default function EmptyState({
         {icon}
       </div>
       <h2 className="text-h2 text-gray-100 mb-4">{title}</h2>
-      <p className="text-body text-gray-400 mb-8 max-w-prose mx-auto leading-relaxed">{description}</p>
+      <p className="text-body text-gray-300 mb-8 max-w-prose mx-auto leading-relaxed">{description}</p>
       {actions.length > 0 && (
         <div
           className={

--- a/app/frontend/components/PageHeader.tsx
+++ b/app/frontend/components/PageHeader.tsx
@@ -38,7 +38,7 @@ export default function PageHeader({
           <h1 className="text-h1 md:text-display font-bold bg-gradient-to-r from-primary-400 to-primary-600 bg-clip-text text-transparent mb-2">
             Developer News Aggregator
           </h1>
-          <p className="text-body-lg text-gray-400">Stay updated with the latest in tech and development</p>
+          <p className="text-body-lg text-gray-300">Stay updated with the latest in tech and development</p>
           {fetchMessage && (
             <p className="text-sm text-primary-300 mt-2" data-testid="fetch-message">{fetchMessage}</p>
           )}
@@ -62,7 +62,7 @@ export default function PageHeader({
             Sources
           </NavLink>
           {onShowReadChange && (
-            <label className="flex items-center gap-2 text-sm text-gray-400 cursor-pointer">
+            <label className="flex items-center gap-2 text-sm text-gray-300 cursor-pointer">
               <input
                 type="checkbox"
                 className="rounded border-dark-600 bg-dark-800 text-primary-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
@@ -73,15 +73,15 @@ export default function PageHeader({
               Show read articles
             </label>
           )}
-          <div className="text-sm text-gray-400">
+          <div className="text-sm text-gray-300">
             <div className="flex items-center space-x-2">
               <span className="w-2 h-2 bg-primary-500 rounded-full animate-pulse" />
               <span>
-                Total: <span className="text-primary-400 font-semibold">{totalCount}</span> articles
+                Total: <span className="text-primary-300 font-semibold">{totalCount}</span> articles
               </span>
             </div>
             {lastUpdated && (
-              <div className="text-xs text-gray-500 mt-1">
+              <div className="text-xs text-gray-400 mt-1">
                 Updated {formatLastUpdated(lastUpdated)}
               </div>
             )}

--- a/app/frontend/components/ScoreFilter.tsx
+++ b/app/frontend/components/ScoreFilter.tsx
@@ -19,7 +19,7 @@ const OPTIONS: { value: ScoreFilterValue; label: string }[] = [
 export default function ScoreFilter({ activeScoreFilter, onScoreFilterChange }: ScoreFilterProps) {
   return (
     <Card tone="subtle" className="mb-8">
-      <h2 className="text-h3 text-gray-200 mb-4">Filter by score</h2>
+      <h2 className="text-h3 text-gray-100 mb-4">Filter by score</h2>
       <div className="flex flex-wrap gap-3">
         {OPTIONS.map((option) => (
           <Button

--- a/app/frontend/components/SourceFilter.tsx
+++ b/app/frontend/components/SourceFilter.tsx
@@ -20,7 +20,7 @@ export default function SourceFilter({
   return (
     <div className="mb-8">
       <Card tone="subtle">
-        <h3 className="text-h3 text-gray-200 mb-4 flex items-center">
+        <h3 className="text-h3 text-gray-100 mb-4 flex items-center">
           <svg className="w-5 h-5 mr-2 text-primary-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.707A1 1 0 013 7V4z" />
           </svg>

--- a/app/frontend/components/a11y.test.tsx
+++ b/app/frontend/components/a11y.test.tsx
@@ -41,7 +41,11 @@ describe('accessibility audits', () => {
       />
     )
 
-    const results = await axe(container)
+    const results = await axe(container, {
+      rules: {
+        'color-contrast': { enabled: true },
+      },
+    })
     expect(results).toHaveNoViolations()
   })
 

--- a/app/frontend/components/articleCard/ArticleCardLayout.tsx
+++ b/app/frontend/components/articleCard/ArticleCardLayout.tsx
@@ -78,12 +78,12 @@ export default function ArticleCardLayout({
       />
 
       {article.description && (
-        <p className="text-body text-gray-300 mb-6 line-clamp-3 leading-relaxed max-w-prose">
+        <p className="text-body text-gray-200 mb-6 line-clamp-3 leading-relaxed max-w-prose">
           {truncate(article.description, 280)}
         </p>
       )}
 
-      <div className="flex justify-between items-center text-caption text-gray-400 border-t border-dark-700/80 pt-4">
+      <div className="flex justify-between items-center text-caption text-gray-300 border-t border-dark-600 pt-4">
         <CardMetadata article={article} styles={styles} extra={extraMetadata} />
         <div className="flex items-center space-x-3">
           {actions}

--- a/app/frontend/components/articleCard/CardActions.tsx
+++ b/app/frontend/components/articleCard/CardActions.tsx
@@ -19,7 +19,7 @@ export function DismissButton({ onClick }: { onClick: () => void }) {
     <button
       type="button"
       className={cn(
-        'group/dismiss p-1.5 text-gray-500 hover:text-red-400 hover:bg-red-400/10 rounded-lg transition-colors duration-200 motion-sensitive',
+        'group/dismiss p-1.5 text-gray-400 hover:text-red-400 hover:bg-red-400/10 rounded-lg transition-colors duration-200 motion-sensitive',
         FOCUS_RING
       )}
       title="Dismiss article"

--- a/app/frontend/components/articleCard/CardMetadata.tsx
+++ b/app/frontend/components/articleCard/CardMetadata.tsx
@@ -10,7 +10,7 @@ interface CardMetadataProps {
 
 export default function CardMetadata({ article, styles, extra }: CardMetadataProps) {
   return (
-    <div className="flex items-center space-x-6 text-gray-400">
+    <div className="flex items-center space-x-6 text-gray-300">
       <span className="flex items-center">
         <svg
           className={`w-4 h-4 mr-1.5 ${styles.dateAccent}`}

--- a/app/frontend/components/contrast.test.tsx
+++ b/app/frontend/components/contrast.test.tsx
@@ -1,0 +1,58 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { buttonClassName } from './ui/buttonStyles'
+
+/** Relative luminance for sRGB hex (#rgb or #rrggbb). */
+function luminance(hex: string): number {
+  const normalized = hex.replace('#', '')
+  const full =
+    normalized.length === 3
+      ? normalized
+          .split('')
+          .map((c) => c + c)
+          .join('')
+      : normalized
+  const channels = [0, 2, 4].map((i) => {
+    const value = Number.parseInt(full.slice(i, i + 2), 16) / 255
+    return value <= 0.03928 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4
+  })
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2]
+}
+
+function contrastRatio(foreground: string, background: string): number {
+  const lighter = Math.max(luminance(foreground), luminance(background))
+  const darker = Math.min(luminance(foreground), luminance(background))
+  return (lighter + 0.05) / (darker + 0.05)
+}
+
+describe('feed UI contrast tokens', () => {
+  // Colors intentionally match opaque surface panels + lightened captions.
+  const SURFACE = '#1e293b' // surface-card / dark-800
+  const SUBTITLE = '#d1d5db' // gray-300
+  const BODY = '#e5e7eb' // gray-200
+  const METADATA = '#d1d5db' // gray-300
+  const FILTER_INACTIVE = '#e5e7eb' // gray-200 on dark-800
+
+  it('meets WCAG AA for body, caption, and metadata on card surfaces', () => {
+    expect(contrastRatio(BODY, SURFACE)).toBeGreaterThanOrEqual(4.5)
+    expect(contrastRatio(SUBTITLE, SURFACE)).toBeGreaterThanOrEqual(4.5)
+    expect(contrastRatio(METADATA, SURFACE)).toBeGreaterThanOrEqual(4.5)
+  })
+
+  it('uses high-contrast inactive filter button classes', () => {
+    const className = buttonClassName({ variant: 'filter', active: false })
+    expect(className).toContain('text-gray-200')
+    expect(className).toContain('bg-dark-800')
+    expect(className).toContain('border-dark-500')
+    expect(contrastRatio(FILTER_INACTIVE, SURFACE)).toBeGreaterThanOrEqual(4.5)
+  })
+
+  it('defines opaque surface panel backgrounds in application.css', () => {
+    const cssPath = resolve(__dirname, '../entrypoints/application.css')
+    const css = readFileSync(cssPath, 'utf8')
+    expect(css).toMatch(/\.surface-card\s*\{[^}]*background:\s*#1e293b/s)
+    expect(css).toMatch(/\.surface-elevated\s*\{[^}]*background:\s*#1e293b/s)
+    expect(css).not.toMatch(/\.surface-card\s*\{[^}]*background:\s*rgba\(/s)
+  })
+})

--- a/app/frontend/components/ui/PageHeading.tsx
+++ b/app/frontend/components/ui/PageHeading.tsx
@@ -21,7 +21,7 @@ export default function PageHeading({
       <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 md:gap-6">
         <div>
           <h1 className={`text-h1 font-bold mb-2 ${titleClassName}`}>{title}</h1>
-          {subtitle && <p className="text-body-lg text-gray-400">{subtitle}</p>}
+          {subtitle && <p className="text-body-lg text-gray-300">{subtitle}</p>}
         </div>
         {(actions || meta) && (
           <div className="flex flex-wrap items-center gap-3 md:gap-4">

--- a/app/frontend/components/ui/buttonStyles.ts
+++ b/app/frontend/components/ui/buttonStyles.ts
@@ -84,7 +84,7 @@ export function buttonClassName({
   if (variant === 'ghost') {
     return cn(
       base,
-      'p-1.5 text-gray-500 hover:text-red-400 hover:bg-red-400/10 rounded-lg',
+      'p-1.5 text-gray-400 hover:text-red-400 hover:bg-red-400/10 rounded-lg',
       className
     )
   }
@@ -117,7 +117,7 @@ export function buttonClassName({
     return cn(
       base,
       filterSize,
-      'filter-btn border border-dark-700 bg-transparent text-gray-400 hover:text-gray-200 hover:border-dark-500 hover:bg-dark-800/50',
+      'filter-btn border border-dark-500 bg-dark-800 text-gray-200 hover:text-white hover:border-dark-400 hover:bg-dark-700',
       className
     )
   }

--- a/app/frontend/components/ui/ui.test.tsx
+++ b/app/frontend/components/ui/ui.test.tsx
@@ -30,7 +30,9 @@ describe('buttonClassName', () => {
     const classes = buttonClassName({ variant: 'filter', active: false })
     expect(classes).toContain('filter-btn')
     expect(classes).not.toContain('active')
-    expect(classes).toContain('border-dark-700')
+    expect(classes).toContain('border-dark-500')
+    expect(classes).toContain('bg-dark-800')
+    expect(classes).toContain('text-gray-200')
   })
 
   it('maps danger variant to red gradient', () => {

--- a/app/frontend/entrypoints/application.css
+++ b/app/frontend/entrypoints/application.css
@@ -8,7 +8,7 @@
   }
 
   body {
-    @apply text-body text-gray-300;
+    @apply text-body text-gray-200;
   }
 }
 
@@ -48,42 +48,42 @@
     border: 1px solid rgb(168 85 247 / 0.3);
   }
 
-  /* Layered surfaces — varied depth instead of identical glass panels */
+  /*
+   * Layered surfaces — opaque slate panels for WCAG-readable text.
+   * Avoid translucent "glass" fills that wash out to light-on-light when
+   * backdrop sampling fails (e.g. built assets / CSS load order).
+   */
   .surface-elevated {
-    backdrop-filter: blur(12px);
-    background: rgba(30, 41, 59, 0.88);
-    border: 1px solid rgb(51 65 85 / 0.85);
-    box-shadow: 0 4px 24px rgb(0 0 0 / 0.18);
+    background: #1e293b;
+    border: 1px solid #475569;
+    box-shadow: 0 4px 24px rgb(0 0 0 / 0.28);
   }
 
   .surface-card {
-    background: rgba(30, 41, 59, 0.5);
-    border: 1px solid rgb(51 65 85 / 0.75);
-    backdrop-filter: blur(6px);
+    background: #1e293b;
+    border: 1px solid #334155;
     transition: border-color 0.2s ease, background-color 0.2s ease;
   }
 
   .surface-card:hover {
-    border-color: rgb(71 85 105 / 0.9);
-    background: rgba(30, 41, 59, 0.58);
+    border-color: #64748b;
+    background: #243044;
   }
 
   .surface-subtle {
-    background: rgba(15, 23, 42, 0.35);
-    border: 1px solid rgb(51 65 85 / 0.45);
+    background: #172033;
+    border: 1px solid #334155;
   }
 
   .surface-panel {
-    background: rgba(30, 41, 59, 0.72);
-    border: 1px solid rgb(51 65 85 / 0.8);
-    backdrop-filter: blur(8px);
+    background: #1e293b;
+    border: 1px solid #475569;
   }
 
   /* Backward compatibility — maps to content card surface */
   .glass-effect {
-    background: rgba(30, 41, 59, 0.5);
-    border: 1px solid rgb(51 65 85 / 0.75);
-    backdrop-filter: blur(6px);
+    background: #1e293b;
+    border: 1px solid #334155;
     transition: border-color 0.2s ease, background-color 0.2s ease;
   }
 

--- a/app/frontend/entrypoints/application.tsx
+++ b/app/frontend/entrypoints/application.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import '@fontsource/inter/latin.css'
-import './application.css'
 import App from '../components/App'
 
 const rootElement = document.getElementById('root')

--- a/app/frontend/pages/ArticleShowPage.tsx
+++ b/app/frontend/pages/ArticleShowPage.tsx
@@ -143,7 +143,7 @@ export default function ArticleShowPage() {
 
           <h1 className="text-h1 font-bold text-gray-100 mb-6 leading-tight">{article.title}</h1>
 
-          <div className="flex flex-wrap items-center gap-6 text-caption text-gray-400 mb-6">
+          <div className="flex flex-wrap items-center gap-6 text-caption text-gray-300 mb-6">
             <span className="flex items-center">
               <svg className="w-4 h-4 mr-2 text-primary-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />

--- a/app/frontend/pages/ArticlesIndexPage.tsx
+++ b/app/frontend/pages/ArticlesIndexPage.tsx
@@ -335,7 +335,7 @@ export default function ArticlesIndexPage() {
             </svg>
           </div>
           <h2 className="text-h2 text-gray-100 mb-4">No articles found</h2>
-          <p className="text-gray-400 mb-8 max-w-md mx-auto leading-relaxed">
+          <p className="text-gray-300 mb-8 max-w-md mx-auto leading-relaxed">
             Your feed is empty. Click Fetch News to pull the latest articles from your configured sources.
           </p>
           <button

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,8 @@
     <%# Includes all stylesheet files in app/assets/stylesheets %>
     <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
     <%= vite_client_tag %>
+    <%# Link CSS as its own entry so styles load with built assets (no Vite HMR). %>
+    <%= vite_stylesheet_tag 'application.css' %>
     <%= vite_typescript_tag 'application.tsx' %>
   </head>
 

--- a/test/integration/react_shell_test.rb
+++ b/test/integration/react_shell_test.rb
@@ -7,6 +7,7 @@ class ReactShellTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "#root"
     assert_select "script[type='module'][src*='application']"
+    assert_select "link[rel='stylesheet'][href*='application']"
     assert_no_match(/entrypoints\/application\.ts["']/, response.body)
     assert_no_match(/cdn\.tailwindcss\.com/, response.body)
   end
@@ -19,14 +20,13 @@ class ReactShellTest < ActionDispatch::IntegrationTest
     assert manifest.key?("entrypoints/application.tsx")
   end
 
-  test "vite test manifest includes compiled tailwind css" do
+  test "vite test manifest includes compiled tailwind css entrypoint" do
     manifest_path = Rails.root.join("public/vite-test/.vite/manifest.json")
     skip "Run npm run build:test before this test" unless manifest_path.exist?
 
-    entry = JSON.parse(manifest_path.read).fetch("entrypoints/application.tsx")
-    css_assets = Array(entry["css"])
-
-    assert css_assets.any? { |path| path.include?("application") && path.end_with?(".css") }
+    entry = JSON.parse(manifest_path.read).fetch("entrypoints/application.css")
+    assert entry.fetch("file").end_with?(".css")
+    assert_includes entry.fetch("file"), "application"
   end
 
   test "vite test manifest lazy-loads route page chunks" do


### PR DESCRIPTION
## Summary
- Replace translucent glass surfaces with opaque dark slate panels so captions and filters are not light-on-light
- Raise inactive filter and metadata text contrast to meet WCAG AA against card backgrounds
- Link `application.css` via `vite_stylesheet_tag` so styles load with built Vite assets without the HMR client

Closes #272

## Test plan
- [x] `npm test` (includes new `contrast.test.tsx` WCAG ratio checks)
- [ ] Load articles index with built assets only (`bin/vite build` / no Vite dev server) and confirm filters, cards, and header copy are readable
- [ ] Smoke bookmarks and article show pages for the same caption/metadata contrast