### PR TITLE
fix(dev): clarify bin/dev is Rails-only (#262)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,12 @@ Guidance for AI coding agents working in this repository. Keep this file concise
 - Do not commit credentials, API tokens, database dumps, private customer data, or local machine paths.
 - When adding or moving files, update `docs/REPO_STRUCTURE.md` if the structure map changes.
 
+## Local full-stack server
+
+- `bin/dev` starts **Rails only** (`bin/rails server`). It does **not** start Vite.
+- Full stack (Rails + Vite HMR): `npm run dev` in one terminal and `bin/rails server` (or `SOLID_QUEUE_IN_PUMA=1 bin/rails server`) in another; on Windows use `.\dev.ps1`.
+- Details: `docs/DEVELOPMENT.md` and `docs/REACT_SETUP.md`.
+
 ## Verification
 
 Prefer the CI-equivalent local wrapper before opening a pull request:

--- a/README.md
+++ b/README.md
@@ -25,11 +25,18 @@ bin/rails db:seed
 # Fetch initial news
 bin/rails runner "NewsAggregatorService.fetch_all_news"
 
-# Start server
-bin/rails server
+# Full stack: Vite (HMR) + Rails — two terminals
+npm install
+npm run dev          # terminal 1, port 3036
+bin/rails server     # terminal 2, port 3000
+
+# Windows alternative (starts both):
+# .\dev.ps1
 ```
 
-Visit http://localhost:3000
+Visit http://localhost:3000.
+
+`bin/dev` and bare `bin/rails server` start **Rails only** (no Vite). For React hot reload you need `npm run dev` as well, or `.\dev.ps1` on Windows. See [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) and [docs/REACT_SETUP.md](docs/REACT_SETUP.md).
 
 ## Tech Stack
 

--- a/bin/dev
+++ b/bin/dev
@@ -1,2 +1,5 @@
 #!/usr/bin/env ruby
+# Rails-only: runs `bin/rails server`. Does not start Vite.
+# Full stack: `npm run dev` + Rails, or `.\dev.ps1` on Windows.
+# See docs/DEVELOPMENT.md and AGENTS.md.
 exec "./bin/rails", "server", *ARGV

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -25,18 +25,32 @@ bin/rails runner "NewsAggregatorService.fetch_all_news"
 
 ### Running the application
 
+Full-stack development needs **both** Vite (HMR on port 3036) and Rails (port 3000). Prefer this two-process setup (or `.\dev.ps1` on Windows):
+
 ```bash
-# Start Rails server (with Solid Queue supervisor in Puma for background jobs)
+# Terminal 1: Vite
+npm run dev
+
+# Terminal 2: Rails (with Solid Queue supervisor in Puma for background jobs)
 SOLID_QUEUE_IN_PUMA=1 bin/rails server
+```
 
-# Or run job workers in a separate process
-bin/jobs
+```powershell
+# Windows: starts Vite + Rails together
+.\dev.ps1
+```
 
-# Run in development mode
+`bin/dev` is a thin wrapper that runs **`bin/rails server` only** — it does **not** start Vite. Use it when you only need the Rails process (for example jobs already covered elsewhere); for React HMR, always use `npm run dev` + Rails, or `.\dev.ps1`.
+
+```bash
+# Rails-only (no Vite / no HMR)
 bin/dev
 
-# Access application at http://localhost:3000
+# Or run job workers in a separate process instead of SOLID_QUEUE_IN_PUMA
+bin/jobs
 ```
+
+Access the app at http://localhost:3000. See [REACT_SETUP.md](REACT_SETUP.md) for frontend details.
 
 ### News operations
 

--- a/docs/REACT_SETUP.md
+++ b/docs/REACT_SETUP.md
@@ -21,7 +21,7 @@ npm install
 
 ## Development
 
-To run the application in development mode with hot module replacement:
+To run the application in development mode with hot module replacement you need **both** Vite and Rails. `bin/dev` starts Rails only and will not give you HMR.
 
 ```bash
 # Terminal 1: Start Vite dev server (port 3036)
@@ -29,6 +29,7 @@ npm run dev
 
 # Terminal 2: Start Rails server (port 3000)
 bundle exec rails server
+# or: bin/rails server / bin/dev (Rails-only; still need terminal 1 for Vite)
 ```
 
 ### Windows
@@ -40,7 +41,8 @@ On Windows, `bin/rails` does not run directly in CMD/PowerShell. Use one of:
 .\setup-local-env.ps1
 .\dev.ps1
 
-# Or manually:
+# Or manually (two terminals):
+npm run dev
 bundle exec rails server
 # or
 bin\rails.bat server

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -2,7 +2,7 @@
 
 Living map of this codebase. **Keep this file in sync with the repo** — see [Maintenance](#maintenance) below.
 
-Last updated: 2026-07-13
+Last updated: 2026-07-14
 
 ## Maintenance
 
@@ -192,11 +192,15 @@ dev-news-aggregator/
 | `AGENTS.md` | AI-agent workflow and verification guardrails |
 | `Gemfile` / `Gemfile.lock` | Ruby gems |
 | `package.json` / `package-lock.json` | Node packages |
+| `bin/dev` | Rails-only server wrapper (`bin/rails server`); does **not** start Vite |
+| `dev.ps1` | Windows helper that starts Vite + Rails together (full stack) |
 | `docker-compose.yml` | Local PostgreSQL container |
 | `Dockerfile` | Production/container image |
 | `.overcommit.yml` | Git hook configuration |
 | `.rubocop.yml` | Ruby style rules |
 | `tsconfig.json` | TypeScript config for frontend |
+
+**Dev entry points:** `bin/dev` = Rails only. Full stack = `npm run dev` + Rails, or `.\dev.ps1` on Windows. See [DEVELOPMENT.md](DEVELOPMENT.md).
 
 ## Routes (summary)
 


### PR DESCRIPTION
## Summary
- Clarify that in/dev starts Rails only and does not start Vite
- Document full-stack entry points (
pm run dev + Rails, or .\dev.ps1 on Windows) in README, AGENTS.md, DEVELOPMENT.md, REACT_SETUP.md, and REPO_STRUCTURE.md
- Note in/dev vs dev.ps1 in REPO_STRUCTURE.md key root files

## Test plan
- [ ] Confirm README / DEVELOPMENT / AGENTS clearly distinguish Rails-only vs full stack
- [ ] Confirm REPO_STRUCTURE lists both in/dev and dev.ps1 with the Rails-only note
- [ ] Skim bin/dev comment for accuracy

Closes #262