### PR TITLE
chore(github): add PR and general issue templates (#270)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Report unexpected behavior or a regression
+title: "bug: "
+labels: ["bug"]
+assignees: ""
+---
+
+## Description
+
+<!-- What went wrong? -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+## Actual behavior
+
+## Environment
+
+- OS:
+- Ruby / Rails (if known):
+- Node (if frontend-related):
+- Browser (if UI-related):
+
+## Additional context
+
+<!-- Logs, screenshots, related PRs/issues -->

--- a/.github/ISSUE_TEMPLATE/cicd-enhancements.md
+++ b/.github/ISSUE_TEMPLATE/cicd-enhancements.md
@@ -1,85 +1,26 @@
 ---
-name: CI/CD Enhancements
-about: Track remaining CI/CD improvements and automation features
-title: 'Enhance CI/CD pipeline with deployment automation and pre-commit hooks'
-labels: ['enhancement', 'ci/cd', 'automation']
-assignees: ''
+name: CI/CD enhancement
+about: Improve GitHub Actions, Dependabot, deploy automation, or local validation hooks
+title: "ci: "
+labels: ["enhancement"]
+assignees: ""
 ---
 
-## Summary
-Complete the CI/CD pipeline by adding automated deployment and local development tooling.
+## Problem
 
-## Current Status ✅
-- [x] Fixed bundler caching issues in GitHub Actions
-- [x] Added comprehensive test coverage reporting with SimpleCov
-- [x] Fixed security vulnerabilities (Brakeman warnings)
-- [x] Enhanced Dependabot configuration with grouping and Docker monitoring
-- [x] Improved CI workflow with job dependencies and quality gates
+<!-- What is slow, missing, or brittle in CI/CD or local validation? -->
 
-## Remaining Tasks
+## Proposed change
 
-### 🚀 Deployment Automation
-- [ ] Set up Kamal-based CD workflow for automated deployments
-- [ ] Configure container registry (Docker Hub, GHCR, etc.)
-- [ ] Set up staging and production environments
-- [ ] Add deployment secrets management
-- [ ] Configure zero-downtime deployments
+## Acceptance criteria
 
-### 🔧 Pre-commit Hooks  
-- [ ] Install and configure pre-commit hooks
-- [ ] Add RuboCop linting check before commits
-- [ ] Add test execution before commits (optional, for speed)
-- [ ] Add commit message validation
-- [ ] Document setup process for team members
+- [ ]
+- [ ]
 
-### 📊 Additional Quality Gates
-- [ ] Add performance testing integration
-- [ ] Set up automated security scanning (bundle audit)
-- [ ] Add code complexity analysis
-- [ ] Configure notification systems for deployment status
+## Related files
 
-## Implementation Details
+<!-- e.g. .github/workflows/ci.yml, bin/validate, .overcommit.yml, docs/PRE_COMMIT_HOOKS.md -->
 
-### Deployment Setup Requirements
-When ready to implement, we'll need:
+-
 
-1. **Container Registry Configuration**
-   - Registry choice (ghcr.io, Docker Hub, etc.)
-   - Image naming convention
-   - Authentication tokens as GitHub secrets
-
-2. **Server Configuration**
-   - Target domain/host(s) for deployment
-   - SSH access configuration
-   - Environment-specific secrets (RAILS_MASTER_KEY, etc.)
-
-3. **Workflow Triggers**
-   - Auto-deploy on main branch
-   - Optional staging environment for feature branches
-   - Manual deployment triggers
-
-### Pre-commit Hooks Setup
-- Use Overcommit or native Git hooks
-- Fast feedback loop for developers
-- Configurable severity levels
-- Team onboarding documentation
-
-## Acceptance Criteria
-- [ ] Deployment workflow successfully deploys to staging/production
-- [ ] Pre-commit hooks prevent bad commits from being pushed
-- [ ] Documentation updated for team setup
-- [ ] All secrets properly configured and secured
-- [ ] Rollback procedures documented and tested
-
-## Priority
-- **Deployment Automation**: Medium (can be done when ready to deploy)
-- **Pre-commit Hooks**: Low (nice-to-have for developer experience)
-
-## Related Files
-- `.github/workflows/ci.yml` (current CI configuration)
-- `config/deploy.yml` (Kamal configuration)
-- `Gemfile` (dependency management)
-
----
-
-**Note**: This issue tracks future enhancements. The current CI/CD pipeline is fully functional and addresses the immediate bundler caching issues that were causing build failures.
+## Additional context

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Development guide
+    url: https://github.com/MarcosLorejan/dev-news-aggregator/blob/master/docs/DEVELOPMENT.md
+    about: Setup, commands, and project conventions
+  - name: Agent guidelines
+    url: https://github.com/MarcosLorejan/dev-news-aggregator/blob/master/AGENTS.md
+    about: How coding agents should work in this repo

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,19 @@
+---
+name: Documentation
+about: Fix or improve docs (README, AGENTS.md, DEVELOPMENT, REPO_STRUCTURE, etc.)
+title: "docs: "
+labels: ["documentation"]
+assignees: ""
+---
+
+## What is wrong or missing?
+
+## Where should it live?
+
+<!-- e.g. README.md, docs/DEVELOPMENT.md, AGENTS.md, docs/REPO_STRUCTURE.md -->
+
+## Proposed change
+
+## Acceptance criteria
+
+- [ ]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Propose a new capability or improvement
+title: "feat: "
+labels: ["enhancement"]
+assignees: ""
+---
+
+## Problem
+
+<!-- What user or agent pain does this address? -->
+
+## Proposed solution
+
+## Alternatives considered
+
+## Acceptance criteria
+
+- [ ]
+- [ ]
+
+## Additional context

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Summary
+
+<!-- What changed and why? Link related issues with Closes #N when applicable. -->
+
+-
+
+## Test plan
+
+<!-- How can reviewers verify this? Prefer bin/validate or the checks relevant to your change. -->
+
+- [ ]
+- [ ]
+
+## Notes
+
+<!-- Optional: screenshots, migration notes, follow-ups, or agent context. -->

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -180,7 +180,8 @@ dev-news-aggregator/
 | `workflows/ci.yml` | CI pipeline (tests, lint, security) |
 | `workflows/dependabot-auto-merge.yml` | Auto-merge for patch/minor Dependabot PRs |
 | `dependabot.yml` | Dependency update schedule |
-| `ISSUE_TEMPLATE/` | GitHub issue templates |
+| `pull_request_template.md` | Default PR body checklist |
+| `ISSUE_TEMPLATE/` | Issue chooser templates (bug, feature, docs, CI/CD) |
 
 ## Key root files
 


### PR DESCRIPTION
## Summary
- Add `.github/pull_request_template.md` for a consistent PR checklist
- Add issue chooser templates: bug, feature, documentation, plus refreshed CI/CD template
- Add `ISSUE_TEMPLATE/config.yml` with links to DEVELOPMENT.md and AGENTS.md
- Update REPO_STRUCTURE.md `.github/` map

## Test plan
- [ ] Open "New issue" on GitHub and confirm chooser shows Bug / Feature / Documentation / CI/CD
- [ ] Open a draft PR and confirm the PR template body pre-fills
- [ ] Confirm stale filled-in CI/CD tracker content is gone from the template

Closes #270
