### PR TITLE
ci: cancel in-progress runs on new pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   scan_ruby:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add a workflow-level `concurrency` group to `.github/workflows/ci.yml` so a new push to a branch cancels the CI run still in flight for that same branch.
- The group key is `ci-${{ github.workflow }}-${{ github.ref }}`, so each branch (and each of its PR/push refs) queues independently and only the latest commit keeps a running job.

Closes #197

## Test plan

- [ ] YAML parses (`ruby -ryaml -e 'YAML.load_file(".github/workflows/ci.yml")'`).
- [ ] Push two commits back-to-back on this PR: the first CI run shows as cancelled and the second runs to completion.

## Notes

Only `ci.yml` is affected; `dependabot-auto-merge.yml` keeps its current behavior.