### PR TITLE
chore(dependabot): add npm ecosystem updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,43 @@ updates:
       - dependency-name: "rails"
         update-types: ["version-update:semver-major"]
 
+  # JavaScript dependencies
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: "monday"
+      time: "06:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "feat"
+      prefix-development: "chore"
+      include: "scope"
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "react-router-dom"
+          - "@types/react*"
+      build-tools:
+        patterns:
+          - "vite"
+          - "vite-plugin-ruby"
+          - "@vitejs/*"
+          - "typescript"
+          - "postcss"
+          - "autoprefixer"
+          - "tailwindcss"
+          - "@tailwindcss/*"
+      testing:
+        patterns:
+          - "vitest*"
+          - "@testing-library/*"
+          - "jsdom"
+          - "axe-core"
+
   # GitHub Actions
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
## Summary

- Add an `npm` ecosystem entry to `.github/dependabot.yml` so the React/Vite frontend gets dependency PRs, not just `npm audit` findings in CI.
- Weekly schedule (Monday 06:00 UTC), limit of 5 open PRs, and the same `feat` / `chore` commit-prefix split already used for bundler.
- Grouped into `react`, `build-tools`, and `testing` so a routine bump lands as one PR instead of a dozen.

Closes #183

## Test plan

- [ ] `.github/dependabot.yml` parses and lists all four ecosystems (bundler, npm, github-actions, docker).
- [ ] After merge, check Insights → Dependency graph → Dependabot shows an `npm` entry with a recent check, and that the first npm PRs open as expected.

## Notes

`dependabot-auto-merge.yml` needs no change: it gates on `github.actor == 'dependabot[bot]'` and the `update-type` metadata, not on the ecosystem, so npm patch/minor PRs are auto-merged and majors are flagged for review like the existing bundler ones.

Group patterns cover the current `package.json`; new deps that match none of the groups simply get individual PRs.