### PR TITLE
ci: re-enable bundler caching in ruby jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: .ruby-version
-          bundler-cache: false
-
-      - name: Clean and install dependencies
-        run: |
-          rm -rf vendor/bundle
-          bundle config set --local path 'vendor/bundle'
-          bundle config set --local deployment false
-          bundle install --jobs 4 --retry 3
+          bundler-cache: true
 
       - name: Scan for common Rails security vulnerabilities using static analysis
         run: bundle exec brakeman --no-pager --no-exit-on-warn
@@ -41,14 +34,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: .ruby-version
-          bundler-cache: false
-
-      - name: Clean and install dependencies
-        run: |
-          rm -rf vendor/bundle
-          bundle config set --local path 'vendor/bundle'
-          bundle config set --local deployment false
-          bundle install --jobs 4 --retry 3
+          bundler-cache: true
 
       - name: Update bundler-audit database
         run: bundle exec bundle-audit update
@@ -84,14 +70,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: .ruby-version
-          bundler-cache: false
-
-      - name: Clean and install dependencies
-        run: |
-          rm -rf vendor/bundle
-          bundle config set --local path 'vendor/bundle'
-          bundle config set --local deployment false
-          bundle install --jobs 4 --retry 3
+          bundler-cache: true
 
       - name: Lint code for consistent style
         run: bundle exec rubocop -f github
@@ -150,14 +129,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: .ruby-version
-          bundler-cache: false
-
-      - name: Clean and install dependencies
-        run: |
-          rm -rf vendor/bundle
-          bundle config set --local path 'vendor/bundle'
-          bundle config set --local deployment false
-          bundle install --jobs 4 --retry 3
+          bundler-cache: true
 
       - name: Build Vite assets for tests
         run: npm run build:test
@@ -226,14 +198,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: .ruby-version
-          bundler-cache: false
-
-      - name: Clean and install dependencies
-        run: |
-          rm -rf vendor/bundle
-          bundle config set --local path 'vendor/bundle'
-          bundle config set --local deployment false
-          bundle install --jobs 4 --retry 3
+          bundler-cache: true
 
       - name: Build Vite assets for tests
         run: npm run build:test


### PR DESCRIPTION
## Summary

- Set `bundler-cache: true` on the five `ruby/setup-ruby` steps (`scan_ruby`, `scan_dependencies`, `lint`, `test`, `coverage`) and drop the manual "Clean and install dependencies" step that wiped `vendor/bundle` and re-ran a full `bundle install` on every job of every run.
- `ruby/setup-ruby` now handles `bundle install` and caches `vendor/bundle`, keyed on the Ruby version and the `Gemfile.lock` hash.

Closes #181

## Why this is safe now

Caching was turned off in 5bc21db ("disable bundler cache completely to avoid native extension corruption"). That corruption came from the hand-rolled `actions/cache` setup that preceded it (8289520, 37e94f3): a `vendor/bundle` cache shared across jobs with loose `restore-keys` fallbacks and an inconsistent `bundle config --without`, so a job could restore gems whose native extensions were built against different settings.

`bundler-cache: true` does not have that failure mode — its key is an exact match on Ruby version + `Gemfile.lock` + platform, with no partial-restore fallback, and each job installs from that one lockfile with no `--without` divergence.

## Test plan

- [x] `Gemfile.lock` lists `x86_64-linux`, so the deployment/frozen mode that `setup-ruby` enables resolves on `ubuntu-latest`.
- [x] Locally reproduced the CI install (`BUNDLE_DEPLOYMENT=true bundle install`): dependency resolution succeeds against the committed lockfile.
- [ ] CI on this PR: the first run is a cache miss and populates the cache; a follow-up push hits it and the Ruby jobs get noticeably shorter.
- [ ] `quality_gate` stays green (no gem resolution regressions).

## Notes

The committed `.bundle/config` already pins `BUNDLE_PATH: vendor/bundle`, which is the same directory `setup-ruby` installs to and caches, so local and CI setups stay consistent.