### PR TITLE
docs: align database credentials across env files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,24 @@
+# Copy this file to .env before starting the stack:
+#   cp .env.example .env
+
 # Database Configuration
-POSTGRES_USER=devnews
-POSTGRES_PASSWORD=password
+# Read by docker-compose.yml when it creates the PostgreSQL container.
+# These are also the defaults in config/database.yml, so Rails connects to the
+# container without any extra setup.
+POSTGRES_USER=dev_news_user
+POSTGRES_PASSWORD=dev_password
 POSTGRES_DB=dev_news_aggregator_development
 
-# Rails Configuration  
+# Rails database connection (config/database.yml)
+# Rails reads these from the shell environment, not from this file, and falls
+# back to the same values shown above. Export them only to point Rails at a
+# different database, such as a PostgreSQL install outside Docker.
+# DB_HOST=localhost
+# DB_PORT=5432
+# DB_USERNAME=dev_news_user
+# DB_PASSWORD=dev_password
+
+# Rails Configuration
 RAILS_ENV=development
 SECRET_KEY_BASE=your_secret_key_base_here
 
@@ -11,4 +26,3 @@ SECRET_KEY_BASE=your_secret_key_base_here
 # HACKER_NEWS_API_KEY=
 # DEVTO_API_KEY=
 # Reddit uses public Atom feeds (/r/{subreddit}/.rss); no API key required.
-

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ A Rails application that aggregates developer news from Hacker News, Dev.to, and
 # Install dependencies
 bundle install
 
+# Copy the environment template (holds the local database credentials)
+cp .env.example .env
+
 # Start PostgreSQL container
 sudo docker-compose up -d
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,16 +2,16 @@ services:
   db:
     image: postgres:15
     environment:
-      POSTGRES_DB: dev_news_aggregator_development
-      POSTGRES_USER: dev_news_user
-      POSTGRES_PASSWORD: dev_password
+      POSTGRES_DB: ${POSTGRES_DB:-dev_news_aggregator_development}
+      POSTGRES_USER: ${POSTGRES_USER:-dev_news_user}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-dev_password}
     ports:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U dev_news_user -d dev_news_aggregator_development"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-dev_news_user} -d ${POSTGRES_DB:-dev_news_aggregator_development}"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -27,7 +27,7 @@ services:
       db:
         condition: service_healthy
     environment:
-      DATABASE_URL: postgresql://dev_news_user:dev_password@db:5432/dev_news_aggregator_development
+      DATABASE_URL: postgresql://${POSTGRES_USER:-dev_news_user}:${POSTGRES_PASSWORD:-dev_password}@db:5432/${POSTGRES_DB:-dev_news_aggregator_development}
 
 volumes:
   postgres_data:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -223,10 +223,12 @@ Articles table uses generic fields to accommodate all news sources:
 
 ### Environment configuration
 
-Uses Docker Compose for PostgreSQL with environment variables:
-- `POSTGRES_USER`: devnews
-- `POSTGRES_PASSWORD`: password
-- `POSTGRES_DB`: dev_news_aggregator
+Copy `.env.example` to `.env` before starting the stack. Docker Compose reads it to create the PostgreSQL container:
+- `POSTGRES_USER`: dev_news_user
+- `POSTGRES_PASSWORD`: dev_password
+- `POSTGRES_DB`: dev_news_aggregator_development
+
+`config/database.yml` falls back to those same credentials (`DB_USERNAME`, `DB_PASSWORD`, `DB_HOST`, `DB_PORT`), so Rails connects to the container with no extra setup. Rails does not load `.env` itself — export `DB_*` in your shell only when pointing Rails at a different database. Windows setup (`setup-local-env.ps1`) uses the same credentials.
 
 ### Key features
 

--- a/init.sql
+++ b/init.sql
@@ -1,3 +1,5 @@
--- Create test database
+-- Create test database.
+-- The Postgres entrypoint runs this as POSTGRES_USER (see docker-compose.yml),
+-- so that role owns the database and needs no extra grant. Keeping the owner
+-- implicit means changing POSTGRES_USER in .env does not break this script.
 CREATE DATABASE dev_news_aggregator_test;
-GRANT ALL PRIVILEGES ON DATABASE dev_news_aggregator_test TO dev_news_user;


### PR DESCRIPTION
## Summary

Everything now agrees on one credential set — `dev_news_user` / `dev_password` / `dev_news_aggregator_development` — which is what `config/database.yml`, `docker-compose.yml`, `init.sql`, and `setup-local-env.ps1` already used. Only `.env.example` (`devnews` / `password`) and `docs/DEVELOPMENT.md` disagreed.

- `.env.example`: use the canonical values, and explain what actually reads them. `DB_*` are listed (commented) as the escape hatch for pointing Rails at a non-Docker database.
- `docker-compose.yml`: read `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB` from `.env` with the canonical values as defaults, instead of hardcoding them. Compose auto-loads `.env`, so the file now drives the container it claims to configure; `docker-compose up` still works without a `.env`.
- `init.sql`: drop `GRANT ALL PRIVILEGES ... TO dev_news_user`. The entrypoint runs the script as `POSTGRES_USER`, so that role already owns the database it just created — and the hardcoded name was the one thing that broke if you changed the user.
- `README.md`: add the `cp .env.example .env` step to Quick Start.
- `docs/DEVELOPMENT.md`: correct the stale `devnews` / `password` / `dev_news_aggregator` block.

Closes #194

## Test plan

- [x] `docker-compose config` resolves to the canonical credentials with no `.env` present, and to overridden values when `POSTGRES_*` are set.
- [x] Fresh volume + `cp .env.example .env` + `docker-compose up -d db`: container becomes healthy, `dev_news_aggregator_development` and `dev_news_aggregator_test` both exist and are owned by `dev_news_user`, and that role can create/drop tables in the test database without the removed `GRANT`.
- [x] Same boot with `POSTGRES_USER=custom_user`: no errors in the Postgres logs and the test database is created for `custom_user` — the case that previously failed on the hardcoded grant.

## Notes

Rails does not load `.env` (no `dotenv-rails`; `dotenv` is only present transitively via Kamal). The `.env.example` comments now say so, rather than implying the file configures Rails. Since `config/database.yml` defaults to the same credentials, the out-of-the-box flow needs no `DB_*` exports.