### PR TITLE
feat(pwa): enable manifest link and register service worker

### DIFF
--- a/app/frontend/entrypoints/application.tsx
+++ b/app/frontend/entrypoints/application.tsx
@@ -2,6 +2,9 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import '@fontsource/inter/latin.css'
 import App from '../components/App'
+import { registerServiceWorker } from '../utils/registerServiceWorker'
+
+registerServiceWorker()
 
 const rootElement = document.getElementById('root')
 

--- a/app/frontend/utils/registerServiceWorker.test.ts
+++ b/app/frontend/utils/registerServiceWorker.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { registerServiceWorker } from './registerServiceWorker'
+
+function stubServiceWorkerContainer(register: ReturnType<typeof vi.fn>) {
+  Object.defineProperty(navigator, 'serviceWorker', {
+    value: { register },
+    configurable: true,
+  })
+}
+
+function stubReadyState(readyState: DocumentReadyState) {
+  Object.defineProperty(document, 'readyState', {
+    value: readyState,
+    configurable: true,
+  })
+}
+
+afterEach(() => {
+  // jsdom exposes neither of these by default, so drop the stubs between tests.
+  Reflect.deleteProperty(navigator, 'serviceWorker')
+  Reflect.deleteProperty(document, 'readyState')
+  vi.restoreAllMocks()
+})
+
+describe('registerServiceWorker', () => {
+  it('registers the service worker at the app scope on an already loaded page', () => {
+    const register = vi.fn().mockResolvedValue({})
+    stubServiceWorkerContainer(register)
+    stubReadyState('complete')
+
+    registerServiceWorker()
+
+    expect(register).toHaveBeenCalledWith('/service-worker', { scope: '/' })
+  })
+
+  it('waits for the load event when the page is still loading', () => {
+    const register = vi.fn().mockResolvedValue({})
+    stubServiceWorkerContainer(register)
+    stubReadyState('loading')
+
+    registerServiceWorker()
+    expect(register).not.toHaveBeenCalled()
+
+    window.dispatchEvent(new Event('load'))
+
+    expect(register).toHaveBeenCalledWith('/service-worker', { scope: '/' })
+  })
+
+  it('does nothing when the browser has no service worker support', () => {
+    stubReadyState('complete')
+
+    expect(() => registerServiceWorker()).not.toThrow()
+  })
+
+  it('reports a failed registration instead of rejecting', async () => {
+    const register = vi.fn().mockRejectedValue(new Error('boom'))
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    stubServiceWorkerContainer(register)
+    stubReadyState('complete')
+
+    registerServiceWorker()
+    await vi.waitFor(() => expect(consoleError).toHaveBeenCalled())
+
+    expect(consoleError.mock.calls[0][0]).toBe('Service worker registration failed')
+  })
+})

--- a/app/frontend/utils/registerServiceWorker.ts
+++ b/app/frontend/utils/registerServiceWorker.ts
@@ -1,0 +1,22 @@
+const SERVICE_WORKER_PATH = '/service-worker'
+
+function register(): void {
+  navigator.serviceWorker.register(SERVICE_WORKER_PATH, { scope: '/' }).catch((error) => {
+    console.error('Service worker registration failed', error)
+  })
+}
+
+export function registerServiceWorker(): void {
+  if (!('serviceWorker' in navigator)) {
+    return
+  }
+
+  // Registering on load keeps the service worker from competing with the
+  // initial render for bandwidth. When the entrypoint itself runs after load
+  // (a lazily imported chunk), that event never fires again, so register now.
+  if (document.readyState === 'complete') {
+    register()
+  } else {
+    window.addEventListener('load', register, { once: true })
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,8 +10,9 @@
 
     <%= yield :head %>
 
-    <%# Enable PWA manifest for installable apps (make sure to enable in config/routes.rb too!) %>
-    <%#= tag.link rel: "manifest", href: pwa_manifest_path(format: :json) %>
+    <%# Enable PWA manifest for installable apps (routes are defined in config/routes.rb) %>
+    <%= tag.link rel: "manifest", href: pwa_manifest_path(format: :json) %>
+    <meta name="theme-color" content="#0f172a">
 
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">

--- a/app/views/pwa/manifest.json.erb
+++ b/app/views/pwa/manifest.json.erb
@@ -1,5 +1,6 @@
 {
-  "name": "DevNewsAggregator",
+  "name": "Dev News Aggregator",
+  "short_name": "Dev News",
   "icons": [
     {
       "src": "/icon.png",
@@ -11,12 +12,17 @@
       "type": "image/png",
       "sizes": "512x512",
       "purpose": "maskable"
+    },
+    {
+      "src": "/icon.svg",
+      "type": "image/svg+xml",
+      "sizes": "any"
     }
   ],
   "start_url": "/",
   "display": "standalone",
   "scope": "/",
-  "description": "DevNewsAggregator.",
-  "theme_color": "red",
-  "background_color": "red"
+  "description": "Developer news from Hacker News, Dev.to, and programming subreddits in a single feed.",
+  "theme_color": "#0f172a",
+  "background_color": "#0f172a"
 }

--- a/app/views/pwa/service-worker.js
+++ b/app/views/pwa/service-worker.js
@@ -1,3 +1,9 @@
+// Browsers only offer the install prompt when the service worker registers a
+// fetch handler, so this listener must exist even though it adds no behavior:
+// requests fall through to the network untouched. Add a caching strategy here
+// if the app ever needs to work offline.
+self.addEventListener("fetch", () => {})
+
 // Add a service worker for processing Web Push notifications:
 //
 // self.addEventListener("push", async (event) => {

--- a/test/integration/pwa_test.rb
+++ b/test/integration/pwa_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+class PwaTest < ActionDispatch::IntegrationTest
+  test "layout links the web app manifest" do
+    get articles_path
+
+    assert_response :success
+    assert_select "link[rel='manifest'][href='/manifest.json']"
+  end
+
+  test "manifest describes an installable app" do
+    get pwa_manifest_path(format: :json)
+
+    assert_response :success
+
+    manifest = JSON.parse(response.body)
+    assert_equal "Dev News Aggregator", manifest["name"]
+    assert_equal "Dev News", manifest["short_name"]
+    assert_equal "/", manifest["start_url"]
+    assert_equal "standalone", manifest["display"]
+    assert manifest["icons"].any? { |icon| icon["sizes"] == "512x512" }
+    assert manifest["icons"].any? { |icon| icon["purpose"] == "maskable" }
+  end
+
+  test "service worker registers a fetch handler so browsers offer the install prompt" do
+    get pwa_service_worker_path
+
+    assert_response :success
+    assert_match(/addEventListener\("fetch"/, response.body)
+  end
+end

--- a/test/integration/pwa_test.rb
+++ b/test/integration/pwa_test.rb
@@ -23,9 +23,12 @@ class PwaTest < ActionDispatch::IntegrationTest
   end
 
   test "service worker registers a fetch handler so browsers offer the install prompt" do
-    get pwa_service_worker_path
+    # The route only has a JavaScript template, so ask for that format explicitly:
+    # a bare GET defaults to HTML and never reaches app/views/pwa/service-worker.js.
+    get pwa_service_worker_path(format: :js)
 
     assert_response :success
+    assert_match(%r{javascript}, response.media_type)
     assert_match(/addEventListener\("fetch"/, response.body)
   end
 end


### PR DESCRIPTION
## Summary

Makes the app installable. Uncommenting the manifest link alone was not enough — browsers only surface the install prompt when a service worker with a `fetch` handler is registered, and the app registered none.

- `app/views/layouts/application.html.erb`: enable the `<link rel="manifest">` tag (the PWA routes already existed) and add a matching `theme-color` meta.
- `app/views/pwa/manifest.json.erb`: replace the Rails scaffold defaults — real `name` / `short_name` / `description`, the app's dark palette (`#0f172a`, i.e. `dark-900`) instead of `red`, and the existing `icon.svg` alongside the 512×512 PNG.
- `app/views/pwa/service-worker.js`: add the `fetch` listener that installability depends on. It deliberately does nothing — requests pass straight through to the network — so this PR adds no caching or offline behavior.
- `app/frontend/utils/registerServiceWorker.ts`: register `/service-worker` at scope `/`, after `load` (or immediately if the entrypoint runs post-load), and log rather than throw on failure.

Closes #257

## Test plan

- [x] `npm test` — 45 passing, including new unit tests for the registration helper (registers at scope, defers to `load` while the page is still loading, no-ops without service worker support, reports failures).
- [x] New `test/integration/pwa_test.rb`: the layout links `/manifest.json`, the manifest describes an installable app (name, `start_url`, `standalone`, 512px + maskable icons), and the service worker ships a `fetch` handler.
- [x] `app/views/pwa/manifest.json.erb` renders as valid JSON.
- [ ] Reviewer check (needs a browser): DevTools → Application → Manifest shows "Dev News Aggregator" with no errors, Service Workers shows `/service-worker` activated, and Chrome offers the install prompt.

## Notes

I could not run `bin/rails test` locally (this machine lacks the Ruby headers needed to build native gem extensions), so the integration test is verified only by CI.

The icons are still the scaffold's red placeholder circle. That is a design asset, out of scope here — worth a follow-up issue if you want a real icon before promoting the install prompt.