### PR TITLE
ci: add TypeScript type-checking to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,24 @@ jobs:
       - name: Lint frontend code
         run: npm run lint
 
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install JavaScript dependencies
+        run: npm ci
+
+      - name: Type-check frontend code
+        run: npm run typecheck
+
   frontend_test:
     runs-on: ubuntu-latest
     steps:
@@ -266,12 +284,12 @@ jobs:
   quality_gate:
     runs-on: ubuntu-latest
     permissions: {}
-    needs: [scan_ruby, scan_dependencies, scan_js, lint, frontend_lint, frontend_test, test, coverage]
+    needs: [scan_ruby, scan_dependencies, scan_js, lint, frontend_lint, typecheck, frontend_test, test, coverage]
     if: always()
     steps:
       - name: Check all jobs status
         run: |
-          if [[ "${{ needs.scan_ruby.result }}" == "failure" || "${{ needs.scan_dependencies.result }}" == "failure" || "${{ needs.scan_js.result }}" == "failure" || "${{ needs.lint.result }}" == "failure" || "${{ needs.frontend_lint.result }}" == "failure" || "${{ needs.frontend_test.result }}" == "failure" || "${{ needs.test.result }}" == "failure" || "${{ needs.coverage.result }}" == "failure" ]]; then
+          if [[ "${{ needs.scan_ruby.result }}" == "failure" || "${{ needs.scan_dependencies.result }}" == "failure" || "${{ needs.scan_js.result }}" == "failure" || "${{ needs.lint.result }}" == "failure" || "${{ needs.frontend_lint.result }}" == "failure" || "${{ needs.typecheck.result }}" == "failure" || "${{ needs.frontend_test.result }}" == "failure" || "${{ needs.test.result }}" == "failure" || "${{ needs.coverage.result }}" == "failure" ]]; then
             echo "One or more jobs failed"
             exit 1
           fi

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -92,7 +92,7 @@ React/Vite frontend checks (also see [AGENTS.md](../AGENTS.md#verification) and 
 |--------|---------|---------|--------|
 | `npm test` | `vitest run` | Frontend unit tests | `frontend_test` |
 | `npm run test:watch` | `vitest` | Frontend tests in watch mode | — (local only) |
-| `npm run typecheck` | `tsc --noEmit` | TypeScript check | — (not in CI yet; run by `bin/validate`) |
+| `npm run typecheck` | `tsc --noEmit` | TypeScript check | `typecheck` |
 | `npm run lint` | `eslint .` | ESLint (TypeScript + React hooks) | `frontend_lint` |
 | `npm run lint:fix` | `eslint . --fix` | Auto-fix lint issues | — (local only) |
 | `npm run format` | `prettier --write ...` | Format frontend sources | — (not enforced in CI) |
@@ -142,7 +142,7 @@ bin/validate --fast   # skips Brakeman and Rails tests
 |-------|----------------|-----------|
 | RuboCop | yes | `lint` |
 | Brakeman | yes (skipped with `--fast`) | `scan_ruby` |
-| `npm run typecheck` | yes | — (local / validate only for now) |
+| `npm run typecheck` | yes | `typecheck` |
 | `npm run lint` | yes | `frontend_lint` |
 | `npm test` | yes | `frontend_test` |
 | `bin/rails test` | yes (skipped with `--fast`) | `test`, `coverage` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
+        "@types/node": "^26.1.1",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^4.3.4",
@@ -1865,6 +1866,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.2.17",
@@ -4888,6 +4899,13 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
+    "@types/node": "^26.1.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^4.3.4",


### PR DESCRIPTION
## Summary

- Add `@types/node` so `tsc --noEmit` actually passes (see below).
- Add a `typecheck` CI job running `npm run typecheck`, wired into `quality_gate`.
- Update the script/validation tables in `docs/DEVELOPMENT.md`, which said typecheck was "not in CI yet".

Closes #184

## The blocker the issue does not mention

`npm run typecheck` already existed (added with `bin/validate`), but it **fails on `master` today** — so simply adding the job would have made CI red:

```
app/frontend/components/contrast.test.tsx(1,30): error TS2307: Cannot find module 'node:fs'
app/frontend/components/contrast.test.tsx(2,25): error TS2307: Cannot find module 'node:path'
app/frontend/components/contrast.test.tsx(52,29): error TS2304: Cannot find name '__dirname'
```

That test reads `application.css` from disk, but `@types/node` was never installed, so the Node built-ins and `__dirname` had no types. Installing it clears all three; no source or test file needed changing, and `tsconfig.json` is untouched (adding an explicit `types` array would have excluded `@types/react` and broken JSX).

## Test plan

- [x] `npm run typecheck` — exits 0 (was: 3 errors on `master`).
- [x] Introduced a deliberate type error (`const x: number = 'nope'`) and confirmed `tsc` exits 2 and CI would fail, then removed it — the acceptance criterion "TypeScript errors fail CI".
- [x] `npm run lint` — 0 errors (8 known warnings, unchanged).
- [x] `npm test` — 41 passing, unchanged.
- [x] `npm audit --omit=dev --audit-level=moderate` — 0 vulnerabilities.
- [x] `.github/workflows/ci.yml` parses; `quality_gate` now depends on `typecheck`.

## Notes

`typecheck` is a separate job rather than a step inside `frontend_lint`, matching how `lint`, `frontend_lint`, `frontend_test`, and `scan_js` are each their own job — it runs in parallel and reports independently. Happy to fold it into `frontend_lint` instead if you would rather save a runner, especially given #180.