### PR TITLE
security: make Brakeman warnings fail CI (#182)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           bundler-cache: true
 
       - name: Scan for common Rails security vulnerabilities using static analysis
-        run: bundle exec brakeman --no-pager --no-exit-on-warn
+        run: bundle exec brakeman --no-pager
 
   scan_dependencies:
     runs-on: ubuntu-latest

--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -29,6 +29,13 @@ PreCommit:
     command: ['bundle', 'exec', 'rubocop']
     on_warn: fail
 
+  Brakeman:
+    enabled: true
+    description: 'Scan for Rails security warnings'
+    required: true
+    command: ['bundle', 'exec', 'brakeman', '--no-pager', '--quiet']
+    on_warn: fail
+
   BundleCheck:
     enabled: true
     description: 'Check Gemfile dependencies'

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,9 @@
+{
+  "ignored_warnings": [
+    {
+      "fingerprint": "edf687f759ec9765bd5db185dbc615c80af77d6e7e19386fc42934e7a80307af",
+      "note": "Tracked in #144 (Ruby upgrade from EOL 3.2.3). Keep baselined until that lands."
+    }
+  ],
+  "brakeman_version": "8.0.5"
+}

--- a/docs/PRE_COMMIT_HOOKS.md
+++ b/docs/PRE_COMMIT_HOOKS.md
@@ -6,6 +6,7 @@ This project uses [Overcommit](https://github.com/sds/overcommit) to manage Git 
 
 ### Pre-commit Checks
 - **RuboCop**: Lints Ruby code for style violations
+- **Brakeman**: Fails on new Rails security warnings (see `config/brakeman.ignore` for baselined findings)
 - **Bundle Audit**: Checks for vulnerable gem dependencies
 - **Bundle Check**: Verifies Gemfile dependencies are satisfied
 - **YAML Syntax**: Validates YAML file syntax

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -120,6 +120,7 @@ dev-news-aggregator/
 | `queue.yml` | Solid Queue worker and dispatcher settings |
 | `recurring.yml` | Solid Queue recurring task schedule |
 | `deploy.yml` | Kamal deployment |
+| `brakeman.ignore` | Baselined Brakeman findings (new warnings still fail CI) |
 | `vite.json` | Vite-Rails integration |
 | `environments/` | Per-env Rails settings (development, test, production) |
 | `initializers/` | Boot-time Ruby configuration |


### PR DESCRIPTION
## Summary
- Remove `--no-exit-on-warn` so new Brakeman warnings fail `scan_ruby`
- Baseline the existing EOLRuby warning in `config/brakeman.ignore` (tracked by #144)
- Enable Brakeman in Overcommit and document it

Closes #182

## Test plan
- [x] `bundle exec brakeman --no-pager` exits 0 (1 ignored warning)
- [ ] CI `scan_ruby` passes without `--no-exit-on-warn`