### PR TITLE
fix(frontend): cancel stale API requests with AbortController (#247)

### DIFF
--- a/app/frontend/api/articles.ts
+++ b/app/frontend/api/articles.ts
@@ -7,6 +7,7 @@ export function fetchArticles(params?: {
   show_read?: boolean
   min_score?: number
   top_percent?: number
+  signal?: AbortSignal
 }) {
   const search = new URLSearchParams()
   if (params?.page) search.set('page', String(params.page))
@@ -16,7 +17,9 @@ export function fetchArticles(params?: {
   if (params?.top_percent) search.set('top_percent', String(params.top_percent))
 
   const query = search.toString()
-  return apiRequest<ArticlesIndexResponse>(`/articles.json${query ? `?${query}` : ''}`)
+  return apiRequest<ArticlesIndexResponse>(`/articles.json${query ? `?${query}` : ''}`, {
+    signal: params?.signal,
+  })
 }
 
 export interface FetchNewsResponse {

--- a/app/frontend/api/bookmarks.ts
+++ b/app/frontend/api/bookmarks.ts
@@ -1,11 +1,17 @@
 import { apiRequest } from './client'
 import type { BookmarksIndexResponse } from '../types/bookmark'
 
-export function fetchBookmarks(params?: { page?: number; per_page?: number }) {
+export function fetchBookmarks(params?: {
+  page?: number
+  per_page?: number
+  signal?: AbortSignal
+}) {
   const search = new URLSearchParams()
   if (params?.page) search.set('page', String(params.page))
   if (params?.per_page) search.set('per_page', String(params.per_page))
 
   const query = search.toString()
-  return apiRequest<BookmarksIndexResponse>(`/bookmarks.json${query ? `?${query}` : ''}`)
+  return apiRequest<BookmarksIndexResponse>(`/bookmarks.json${query ? `?${query}` : ''}`, {
+    signal: params?.signal,
+  })
 }

--- a/app/frontend/api/client.test.ts
+++ b/app/frontend/api/client.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { apiRequest, isAbortError } from './client'
+
+describe('apiRequest', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('passes AbortSignal through to fetch', async () => {
+    const controller = new AbortController()
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await apiRequest('/articles.json', { signal: controller.signal })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0][1].signal).toBe(controller.signal)
+  })
+
+  it('isAbortError detects AbortError', () => {
+    expect(isAbortError(new DOMException('Aborted', 'AbortError'))).toBe(true)
+    expect(isAbortError(Object.assign(new Error('Aborted'), { name: 'AbortError' }))).toBe(true)
+    expect(isAbortError(new Error('other'))).toBe(false)
+  })
+})

--- a/app/frontend/api/client.ts
+++ b/app/frontend/api/client.ts
@@ -2,6 +2,13 @@ function csrfToken(): string {
   return document.querySelector<HTMLMetaElement>('meta[name="csrf-token"]')?.content ?? ''
 }
 
+export function isAbortError(error: unknown): boolean {
+  return (
+    (typeof DOMException !== 'undefined' && error instanceof DOMException && error.name === 'AbortError') ||
+    (error instanceof Error && error.name === 'AbortError')
+  )
+}
+
 export async function apiRequest<T>(
   path: string,
   options: RequestInit = {}

--- a/app/frontend/api/dismissedArticles.ts
+++ b/app/frontend/api/dismissedArticles.ts
@@ -4,15 +4,23 @@ import type {
   RecentlyDismissedResponse,
 } from '../types/dismissedArticle'
 
-export function fetchDismissedArticles(params?: { page?: number; per_page?: number }) {
+export function fetchDismissedArticles(params?: {
+  page?: number
+  per_page?: number
+  signal?: AbortSignal
+}) {
   const search = new URLSearchParams()
   if (params?.page) search.set('page', String(params.page))
   if (params?.per_page) search.set('per_page', String(params.per_page))
 
   const query = search.toString()
-  return apiRequest<DismissedArticlesIndexResponse>(`/dismissed.json${query ? `?${query}` : ''}`)
+  return apiRequest<DismissedArticlesIndexResponse>(`/dismissed.json${query ? `?${query}` : ''}`, {
+    signal: params?.signal,
+  })
 }
 
-export function fetchRecentlyDismissed() {
-  return apiRequest<RecentlyDismissedResponse>('/recently_dismissed.json')
+export function fetchRecentlyDismissed(params?: { signal?: AbortSignal }) {
+  return apiRequest<RecentlyDismissedResponse>('/recently_dismissed.json', {
+    signal: params?.signal,
+  })
 }

--- a/app/frontend/api/readArticles.ts
+++ b/app/frontend/api/readArticles.ts
@@ -1,11 +1,17 @@
 import { apiRequest } from './client'
 import type { ReadArticlesIndexResponse } from '../types/readArticle'
 
-export function fetchReadArticles(params?: { page?: number; per_page?: number }) {
+export function fetchReadArticles(params?: {
+  page?: number
+  per_page?: number
+  signal?: AbortSignal
+}) {
   const search = new URLSearchParams()
   if (params?.page) search.set('page', String(params.page))
   if (params?.per_page) search.set('per_page', String(params.per_page))
 
   const query = search.toString()
-  return apiRequest<ReadArticlesIndexResponse>(`/read.json${query ? `?${query}` : ''}`)
+  return apiRequest<ReadArticlesIndexResponse>(`/read.json${query ? `?${query}` : ''}`, {
+    signal: params?.signal,
+  })
 }

--- a/app/frontend/hooks/useAsyncResource.test.ts
+++ b/app/frontend/hooks/useAsyncResource.test.ts
@@ -2,10 +2,10 @@ import { act, renderHook, waitFor } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { useAsyncResource } from './useAsyncResource'
 
-function deferred() {
-  let resolve
-  let reject
-  const promise = new Promise((res, rej) => {
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
     resolve = res
     reject = rej
   })
@@ -14,7 +14,7 @@ function deferred() {
 
 describe('useAsyncResource', () => {
   it('loads data successfully', async () => {
-    const loader = vi.fn(async (_signal) => 'ok')
+    const loader = vi.fn(async (_signal: AbortSignal) => 'ok')
 
     const { result } = renderHook(() => useAsyncResource(loader))
 
@@ -26,7 +26,7 @@ describe('useAsyncResource', () => {
   })
 
   it('sets error state when loader fails', async () => {
-    const loader = vi.fn(async () => {
+    const loader = vi.fn(async (_signal: AbortSignal) => {
       throw new Error('boom')
     })
 
@@ -40,8 +40,8 @@ describe('useAsyncResource', () => {
   })
 
   it('does not treat AbortError as a failure', async () => {
-    const loader = vi.fn(async (signal) => {
-      await new Promise((_resolve, reject) => {
+    const loader = vi.fn(async (signal: AbortSignal) => {
+      await new Promise<void>((_resolve, reject) => {
         signal.addEventListener('abort', () => {
           reject(new DOMException('Aborted', 'AbortError'))
         })
@@ -63,31 +63,30 @@ describe('useAsyncResource', () => {
   })
 
   it('aborts in-flight request when loader identity changes and keeps newer data', async () => {
-    const first = deferred()
-    const second = deferred()
+    const first = deferred<string>()
+    const second = deferred<string>()
     let call = 0
 
-    const { result, rerender } = renderHook(
-      ({ loader }) => useAsyncResource(loader),
-      {
-        initialProps: {
-          loader: async (signal) => {
-            call += 1
-            if (call === 1) {
-              signal.addEventListener('abort', () => {
-                first.reject(new DOMException('Aborted', 'AbortError'))
-              })
-              return first.promise
-            }
-            return second.promise
-          },
-        },
+    type Loader = (signal: AbortSignal) => Promise<string>
+    const initialLoader: Loader = async (signal) => {
+      call += 1
+      if (call === 1) {
+        signal.addEventListener('abort', () => {
+          first.reject(new DOMException('Aborted', 'AbortError'))
+        })
+        return first.promise
       }
+      return second.promise
+    }
+
+    const { result, rerender } = renderHook(
+      ({ loader }: { loader: Loader }) => useAsyncResource(loader),
+      { initialProps: { loader: initialLoader } }
     )
 
     expect(result.current.loading).toBe(true)
 
-    const nextLoader = async (_signal) => second.promise
+    const nextLoader: Loader = async () => second.promise
     rerender({ loader: nextLoader })
 
     await act(async () => {
@@ -107,11 +106,11 @@ describe('useAsyncResource', () => {
   })
 
   it('aborts previous request on reload', async () => {
-    const signals = []
-    const pending = deferred()
+    const signals: AbortSignal[] = []
+    const pending = deferred<string>()
     let resolveCount = 0
 
-    const loader = vi.fn(async (signal) => {
+    const loader = vi.fn(async (signal: AbortSignal) => {
       signals.push(signal)
       if (signals.length === 1) {
         signal.addEventListener('abort', () => {

--- a/app/frontend/hooks/useAsyncResource.test.ts
+++ b/app/frontend/hooks/useAsyncResource.test.ts
@@ -62,47 +62,30 @@ describe('useAsyncResource', () => {
     expect(result.current.data).toBeNull()
   })
 
-  it('aborts in-flight request when loader identity changes and keeps newer data', async () => {
-    const first = deferred<string>()
-    const second = deferred<string>()
-    let call = 0
-
-    type Loader = (signal: AbortSignal) => Promise<string>
-    const initialLoader: Loader = async (signal) => {
-      call += 1
-      if (call === 1) {
-        signal.addEventListener('abort', () => {
-          first.reject(new DOMException('Aborted', 'AbortError'))
-        })
-        return first.promise
-      }
-      return second.promise
-    }
+  it('does not restart load when only the loader function identity changes', async () => {
+    const pending = deferred<string>()
+    const loader = vi.fn(async (_signal: AbortSignal) => pending.promise)
 
     const { result, rerender } = renderHook(
-      ({ loader }: { loader: Loader }) => useAsyncResource(loader),
-      { initialProps: { loader: initialLoader } }
+      ({ loader: current }: { loader: typeof loader }) => useAsyncResource(current),
+      { initialProps: { loader } }
     )
 
-    expect(result.current.loading).toBe(true)
+    expect(loader).toHaveBeenCalledTimes(1)
 
-    const nextLoader: Loader = async () => second.promise
-    rerender({ loader: nextLoader })
+    // Inline-style identity churn must not abort/restart the in-flight request.
+    rerender({ loader: vi.fn(async (_signal: AbortSignal) => pending.promise) })
+    rerender({ loader: vi.fn(async (_signal: AbortSignal) => pending.promise) })
 
-    await act(async () => {
-      second.resolve('fresh')
-    })
-
-    await waitFor(() => expect(result.current.data).toBe('fresh'))
-    expect(result.current.error).toBeNull()
-    expect(result.current.loading).toBe(false)
+    expect(loader).toHaveBeenCalledTimes(1)
 
     await act(async () => {
-      first.resolve('stale')
+      pending.resolve('stable')
     })
 
-    expect(result.current.data).toBe('fresh')
+    await waitFor(() => expect(result.current.data).toBe('stable'))
     expect(result.current.error).toBeNull()
+    expect(loader).toHaveBeenCalledTimes(1)
   })
 
   it('aborts previous request on reload', async () => {

--- a/app/frontend/hooks/useAsyncResource.test.ts
+++ b/app/frontend/hooks/useAsyncResource.test.ts
@@ -1,0 +1,138 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { useAsyncResource } from './useAsyncResource'
+
+function deferred() {
+  let resolve
+  let reject
+  const promise = new Promise((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+describe('useAsyncResource', () => {
+  it('loads data successfully', async () => {
+    const loader = vi.fn(async (_signal) => 'ok')
+
+    const { result } = renderHook(() => useAsyncResource(loader))
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.data).toBe('ok')
+    expect(result.current.error).toBeNull()
+    expect(loader).toHaveBeenCalledTimes(1)
+    expect(loader.mock.calls[0][0]).toBeInstanceOf(AbortSignal)
+  })
+
+  it('sets error state when loader fails', async () => {
+    const loader = vi.fn(async () => {
+      throw new Error('boom')
+    })
+
+    const { result } = renderHook(() =>
+      useAsyncResource(loader, { errorMessage: 'Could not load.' })
+    )
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.data).toBeNull()
+    expect(result.current.error).toBe('Could not load.')
+  })
+
+  it('does not treat AbortError as a failure', async () => {
+    const loader = vi.fn(async (signal) => {
+      await new Promise((_resolve, reject) => {
+        signal.addEventListener('abort', () => {
+          reject(new DOMException('Aborted', 'AbortError'))
+        })
+      })
+      return 'never'
+    })
+
+    const { result, unmount } = renderHook(() => useAsyncResource(loader))
+
+    expect(result.current.loading).toBe(true)
+    unmount()
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(result.current.error).toBeNull()
+    expect(result.current.data).toBeNull()
+  })
+
+  it('aborts in-flight request when loader identity changes and keeps newer data', async () => {
+    const first = deferred()
+    const second = deferred()
+    let call = 0
+
+    const { result, rerender } = renderHook(
+      ({ loader }) => useAsyncResource(loader),
+      {
+        initialProps: {
+          loader: async (signal) => {
+            call += 1
+            if (call === 1) {
+              signal.addEventListener('abort', () => {
+                first.reject(new DOMException('Aborted', 'AbortError'))
+              })
+              return first.promise
+            }
+            return second.promise
+          },
+        },
+      }
+    )
+
+    expect(result.current.loading).toBe(true)
+
+    const nextLoader = async (_signal) => second.promise
+    rerender({ loader: nextLoader })
+
+    await act(async () => {
+      second.resolve('fresh')
+    })
+
+    await waitFor(() => expect(result.current.data).toBe('fresh'))
+    expect(result.current.error).toBeNull()
+    expect(result.current.loading).toBe(false)
+
+    await act(async () => {
+      first.resolve('stale')
+    })
+
+    expect(result.current.data).toBe('fresh')
+    expect(result.current.error).toBeNull()
+  })
+
+  it('aborts previous request on reload', async () => {
+    const signals = []
+    const pending = deferred()
+    let resolveCount = 0
+
+    const loader = vi.fn(async (signal) => {
+      signals.push(signal)
+      if (signals.length === 1) {
+        signal.addEventListener('abort', () => {
+          pending.reject(new DOMException('Aborted', 'AbortError'))
+        })
+        return pending.promise
+      }
+      resolveCount += 1
+      return `result-${resolveCount}`
+    })
+
+    const { result } = renderHook(() => useAsyncResource(loader))
+
+    await waitFor(() => expect(loader).toHaveBeenCalledTimes(1))
+
+    await act(async () => {
+      await result.current.reload()
+    })
+
+    await waitFor(() => expect(result.current.data).toBe('result-1'))
+    expect(signals[0].aborted).toBe(true)
+    expect(result.current.error).toBeNull()
+  })
+})

--- a/app/frontend/hooks/useAsyncResource.ts
+++ b/app/frontend/hooks/useAsyncResource.ts
@@ -23,6 +23,8 @@ export function useAsyncResource<T>(
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const abortRef = useRef<AbortController | null>(null)
+  const loaderRef = useRef(loader)
+  loaderRef.current = loader
 
   const load = useCallback(async () => {
     abortRef.current?.abort()
@@ -33,7 +35,7 @@ export function useAsyncResource<T>(
     setLoading(true)
     setError(null)
     try {
-      const result = await loader(signal)
+      const result = await loaderRef.current(signal)
       if (signal.aborted) return
       setData(result)
     } catch (err) {
@@ -42,7 +44,7 @@ export function useAsyncResource<T>(
     } finally {
       if (!signal.aborted) setLoading(false)
     }
-  }, [loader, errorMessage])
+  }, [errorMessage])
 
   useEffect(() => {
     void load()

--- a/app/frontend/hooks/useAsyncResource.ts
+++ b/app/frontend/hooks/useAsyncResource.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState, type Dispatch, type SetStateAction } from 'react'
+import { useCallback, useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react'
+import { isAbortError } from '../api/client'
 
 interface UseAsyncResourceOptions {
   errorMessage?: string
@@ -14,30 +15,41 @@ interface AsyncResourceState<T> {
 }
 
 export function useAsyncResource<T>(
-  loader: () => Promise<T>,
+  loader: (signal: AbortSignal) => Promise<T>,
   options: UseAsyncResourceOptions = {}
 ): AsyncResourceState<T> {
   const { errorMessage = 'Failed to load. Please try again.' } = options
   const [data, setData] = useState<T | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
 
-  const reload = useCallback(async () => {
+  const load = useCallback(async () => {
+    abortRef.current?.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+    const { signal } = controller
+
     setLoading(true)
     setError(null)
     try {
-      const result = await loader()
+      const result = await loader(signal)
+      if (signal.aborted) return
       setData(result)
-    } catch {
+    } catch (err) {
+      if (isAbortError(err) || signal.aborted) return
       setError(errorMessage)
     } finally {
-      setLoading(false)
+      if (!signal.aborted) setLoading(false)
     }
   }, [loader, errorMessage])
 
   useEffect(() => {
-    reload()
-  }, [reload])
+    void load()
+    return () => {
+      abortRef.current?.abort()
+    }
+  }, [load])
 
-  return { data, loading, error, reload, setData, setError }
+  return { data, loading, error, reload: load, setData, setError }
 }

--- a/app/frontend/hooks/useAsyncResource.ts
+++ b/app/frontend/hooks/useAsyncResource.ts
@@ -24,7 +24,10 @@ export function useAsyncResource<T>(
   const [error, setError] = useState<string | null>(null)
   const abortRef = useRef<AbortController | null>(null)
   const loaderRef = useRef(loader)
-  loaderRef.current = loader
+
+  useEffect(() => {
+    loaderRef.current = loader
+  }, [loader])
 
   const load = useCallback(async () => {
     abortRef.current?.abort()

--- a/app/frontend/pages/ArticlesIndexPage.tsx
+++ b/app/frontend/pages/ArticlesIndexPage.tsx
@@ -11,6 +11,7 @@ import {
   unmarkArticleAsRead,
   type Article,
 } from '../api/articles'
+import { isAbortError } from '../api/client'
 import type { ArticlesIndexResponse } from '../types/article'
 import { parameterize, truncate } from '../utils/format'
 import ArticleList from '../components/ArticleList'
@@ -61,8 +62,14 @@ export default function ArticlesIndexPage() {
 
   const countdownRef = useRef<number | null>(null)
   const pendingDismissRef = useRef<{ articleId: number; title: string } | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
 
   const loadArticles = useCallback(async (options?: { page?: number }) => {
+    abortRef.current?.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+    const { signal } = controller
+
     const page = options?.page ?? currentPage
     setLoading(true)
     setError(null)
@@ -71,7 +78,9 @@ export default function ArticlesIndexPage() {
         page,
         show_read: showRead,
         ...scoreFilterParams(activeScoreFilter),
+        signal,
       })
+      if (signal.aborted) return
       setData(response)
       setRemovedIds(new Set())
       if (options?.page !== undefined && options.page !== currentPage) {
@@ -80,15 +89,19 @@ export default function ArticlesIndexPage() {
           else params.set('page', String(options.page))
         })
       }
-    } catch {
+    } catch (err) {
+      if (isAbortError(err) || signal.aborted) return
       setError('Failed to load articles. Please try again.')
     } finally {
-      setLoading(false)
+      if (!signal.aborted) setLoading(false)
     }
   }, [showRead, activeScoreFilter, currentPage, patchSearchParams])
 
   useEffect(() => {
-    loadArticles()
+    void loadArticles()
+    return () => {
+      abortRef.current?.abort()
+    }
   }, [loadArticles])
 
   const articleCategories = useMemo(

--- a/app/frontend/pages/BookmarksIndexPage.tsx
+++ b/app/frontend/pages/BookmarksIndexPage.tsx
@@ -17,9 +17,12 @@ import { useAsyncResource } from '../hooks/useAsyncResource'
 import { useSearchParam } from '../hooks/useSearchParamState'
 
 export default function BookmarksIndexPage() {
-  const { data, loading, error, reload, setData, setError } = useAsyncResource(fetchBookmarks, {
-    errorMessage: 'Failed to load reading list. Please try again.',
-  })
+  const { data, loading, error, reload, setData, setError } = useAsyncResource(
+    (signal) => fetchBookmarks({ signal }),
+    {
+      errorMessage: 'Failed to load reading list. Please try again.',
+    }
+  )
   const [activeSource, setActiveSource] = useSearchParam('source', 'all')
 
   const articles = data?.articles ?? []

--- a/app/frontend/pages/DismissedArticlesIndexPage.tsx
+++ b/app/frontend/pages/DismissedArticlesIndexPage.tsx
@@ -12,9 +12,12 @@ import EmptyState from '../components/EmptyState'
 import { useAsyncResource } from '../hooks/useAsyncResource'
 
 export default function DismissedArticlesIndexPage() {
-  const { data, loading, error, reload, setData, setError } = useAsyncResource(fetchDismissedArticles, {
-    errorMessage: 'Failed to load dismissed articles. Please try again.',
-  })
+  const { data, loading, error, reload, setData, setError } = useAsyncResource(
+    (signal) => fetchDismissedArticles({ signal }),
+    {
+      errorMessage: 'Failed to load dismissed articles. Please try again.',
+    }
+  )
 
   const articles = data?.articles ?? []
   const totalCount = data?.pagination.total_count ?? 0

--- a/app/frontend/pages/ReadArticlesIndexPage.tsx
+++ b/app/frontend/pages/ReadArticlesIndexPage.tsx
@@ -13,9 +13,12 @@ import { useAsyncResource } from '../hooks/useAsyncResource'
 import { useSearchParam } from '../hooks/useSearchParamState'
 
 export default function ReadArticlesIndexPage() {
-  const { data, loading, error, reload, setData, setError } = useAsyncResource(fetchReadArticles, {
-    errorMessage: 'Failed to load read articles. Please try again.',
-  })
+  const { data, loading, error, reload, setData, setError } = useAsyncResource(
+    (signal) => fetchReadArticles({ signal }),
+    {
+      errorMessage: 'Failed to load read articles. Please try again.',
+    }
+  )
   const [activeSource, setActiveSource] = useSearchParam('source', 'all')
 
   const articles = data?.articles ?? []

--- a/app/frontend/pages/RecentlyDismissedPage.tsx
+++ b/app/frontend/pages/RecentlyDismissedPage.tsx
@@ -12,9 +12,12 @@ import EmptyState from '../components/EmptyState'
 import { useAsyncResource } from '../hooks/useAsyncResource'
 
 export default function RecentlyDismissedPage() {
-  const { data, loading, error, reload, setData, setError } = useAsyncResource(fetchRecentlyDismissed, {
-    errorMessage: 'Failed to load recently dismissed articles. Please try again.',
-  })
+  const { data, loading, error, reload, setData, setError } = useAsyncResource(
+    (signal) => fetchRecentlyDismissed({ signal }),
+    {
+      errorMessage: 'Failed to load recently dismissed articles. Please try again.',
+    }
+  )
 
   const articles = data?.articles ?? []
 


### PR DESCRIPTION
## Summary
- Thread `AbortSignal` through API helpers and `useAsyncResource`; abort in-flight loads on param change/unmount.
- Ignore `AbortError` so cancelled requests do not surface as UI errors.
- Add Vitest coverage for signal passthrough and cancellation.

Closes #247

## Test plan
- [x] `npm test` (52 tests) pass locally
- [ ] CI frontend jobs green