### PR TITLE
fix(frontend): move category filtering to server-side API (#241)

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -7,8 +7,11 @@ class ArticlesController < ApplicationController
     @show_read = params[:show_read] == "true"
     page, per_page = pagination_params
 
+    count_scope = article_index_scope(apply_category: false)
+    @category_counts = helpers.category_counts_for_scope(count_scope)
+
     base_scope = article_index_scope
-    @total_count = base_scope.count
+    @total_count = base_scope.unscope(:includes, :order, :select).count
     @articles = base_scope.limit(per_page).offset((page - 1) * per_page)
 
     @articles_by_source = @articles.group_by(&:source_type)
@@ -21,7 +24,8 @@ class ArticlesController < ApplicationController
         render json: {
           articles: @articles.map { |article| ArticleSerializer.as_json(article) },
           articles_by_category: @articles_by_category.transform_values { |articles| articles.map(&:id) },
-          categories: @articles_by_category.keys.map { |name| { name: name, icon: helpers.category_icon(name) } },
+          category_counts: @category_counts,
+          categories: @category_counts.keys.map { |name| { name: name, icon: helpers.category_icon(name) } },
           pagination: {
             current_page: page,
             per_page: per_page,
@@ -101,7 +105,7 @@ class ArticlesController < ApplicationController
 
   private
 
-  def article_index_scope
+  def article_index_scope(apply_category: true)
     scope = if @show_read
               Article.not_dismissed
     else
@@ -109,6 +113,7 @@ class ArticlesController < ApplicationController
     end
 
     scope = apply_score_filter(scope)
+    scope = helpers.apply_category_filter(scope, params[:category]) if apply_category
     scope.includes(:bookmark, :read_article, :dismissed_article)
          .order(published_at: :desc)
   end

--- a/app/frontend/api/articles.ts
+++ b/app/frontend/api/articles.ts
@@ -5,6 +5,7 @@ export function fetchArticles(params?: {
   page?: number
   per_page?: number
   show_read?: boolean
+  category?: string
   min_score?: number
   top_percent?: number
 }) {
@@ -12,6 +13,7 @@ export function fetchArticles(params?: {
   if (params?.page) search.set('page', String(params.page))
   if (params?.per_page) search.set('per_page', String(params.per_page))
   if (params?.show_read) search.set('show_read', 'true')
+  if (params?.category && params.category !== 'all') search.set('category', params.category)
   if (params?.min_score) search.set('min_score', String(params.min_score))
   if (params?.top_percent) search.set('top_percent', String(params.top_percent))
 

--- a/app/frontend/components/ArticleList.tsx
+++ b/app/frontend/components/ArticleList.tsx
@@ -4,7 +4,6 @@ import ArticleCard from './ArticleCard'
 interface ArticleListProps {
   articles: Article[]
   articleCategories: Record<number, string>
-  activeFilter: string
   dismissingIds: Set<number>
   onDismiss: (article: Article) => void
   onUndoDismiss: (article: Article) => void
@@ -15,22 +14,15 @@ interface ArticleListProps {
 export default function ArticleList({
   articles,
   articleCategories,
-  activeFilter,
   dismissingIds,
   onDismiss,
   onUndoDismiss,
   onBookmarkToggle,
   onReadToggle,
 }: ArticleListProps) {
-  const visibleArticles = articles.filter((article) => {
-    if (activeFilter === 'all') return true
-    const categorySlug = articleCategories[article.id] ?? 'other'
-    return categorySlug === activeFilter
-  })
-
   return (
     <div className="grid gap-5 md:gap-6 motion-safe:animate-scale-in motion-sensitive">
-      {visibleArticles.map((article, index) => (
+      {articles.map((article, index) => (
         <ArticleCard
           key={article.id}
           variant="feed"

--- a/app/frontend/pages/ArticlesIndexPage.test.tsx
+++ b/app/frontend/pages/ArticlesIndexPage.test.tsx
@@ -4,7 +4,7 @@ import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import ArticlesIndexPage from '../pages/ArticlesIndexPage'
 import * as articlesApi from '../api/articles'
-import { buildArticlesIndexResponse } from '../test/fixtures'
+import { buildArticle, buildArticlesIndexResponse } from '../test/fixtures'
 
 vi.mock('../api/articles', () => ({
   fetchArticles: vi.fn(),
@@ -72,16 +72,38 @@ describe('ArticlesIndexPage dismiss flow', () => {
     expect(screen.queryByRole('status')).not.toBeInTheDocument()
   })
 
-  it('filters articles when category changes in the URL', async () => {
+  it('requests filtered articles when category is in the URL', async () => {
+    const filtered = buildArticlesIndexResponse({
+      articles: [buildArticle()],
+      articles_by_category: { 'Programming Languages': [1] },
+      category_counts: { 'Programming Languages': 1, Frameworks: 1 },
+      pagination: {
+        current_page: 1,
+        per_page: 20,
+        total_count: 1,
+        total_pages: 1,
+      },
+    })
+    vi.mocked(articlesApi.fetchArticles).mockResolvedValue(filtered)
+
     const user = userEvent.setup()
     renderPage(['/articles?category=programming-languages'])
 
     await waitForArticlesFeed()
+    expect(articlesApi.fetchArticles).toHaveBeenCalledWith(
+      expect.objectContaining({ category: 'programming-languages' })
+    )
     expect(screen.getByText('Rust 2024 Edition Highlights')).toBeInTheDocument()
     expect(screen.queryByText('Ruby 3.3 Performance Tips')).not.toBeInTheDocument()
 
+    vi.mocked(articlesApi.fetchArticles).mockResolvedValue(buildArticlesIndexResponse())
     await user.click(screen.getByRole('button', { name: /All Articles/ }))
 
+    await waitFor(() => {
+      expect(articlesApi.fetchArticles).toHaveBeenCalledWith(
+        expect.objectContaining({ category: undefined })
+      )
+    })
     await waitFor(() => {
       expect(screen.getByText('Ruby 3.3 Performance Tips')).toBeInTheDocument()
     })

--- a/app/frontend/pages/ArticlesIndexPage.tsx
+++ b/app/frontend/pages/ArticlesIndexPage.tsx
@@ -70,6 +70,7 @@ export default function ArticlesIndexPage() {
       const response = await fetchArticles({
         page,
         show_read: showRead,
+        category: activeFilter !== 'all' ? activeFilter : undefined,
         ...scoreFilterParams(activeScoreFilter),
       })
       setData(response)
@@ -85,7 +86,7 @@ export default function ArticlesIndexPage() {
     } finally {
       setLoading(false)
     }
-  }, [showRead, activeScoreFilter, currentPage, patchSearchParams])
+  }, [showRead, activeScoreFilter, activeFilter, currentPage, patchSearchParams])
 
   useEffect(() => {
     loadArticles()
@@ -96,12 +97,12 @@ export default function ArticlesIndexPage() {
     [data]
   )
 
-  const categoryCounts = useMemo(() => {
-    if (!data) return {}
-    return Object.fromEntries(
-      Object.entries(data.articles_by_category).map(([name, ids]) => [name, ids.length])
-    )
-  }, [data])
+  const categoryCounts = useMemo(() => data?.category_counts ?? {}, [data])
+
+  const allArticlesCount = useMemo(
+    () => Object.values(categoryCounts).reduce((sum, count) => sum + count, 0),
+    [categoryCounts]
+  )
 
   const articles = useMemo(
     () => data?.articles.filter((article) => !removedIds.has(article.id)) ?? [],
@@ -314,7 +315,7 @@ export default function ArticlesIndexPage() {
     )
   }
 
-  const showEmptyFeed = !data || ((data.pagination.total_count ?? 0) === 0 && articles.length === 0)
+  const showEmptyFeed = !data || (allArticlesCount === 0 && articles.length === 0)
 
   if (showEmptyFeed) {
     return (
@@ -376,7 +377,7 @@ export default function ArticlesIndexPage() {
       <CategoryFilter
         categories={data.categories}
         categoryCounts={categoryCounts}
-        totalCount={articles.length}
+        totalCount={allArticlesCount}
         activeFilter={activeFilter}
         onFilterChange={handleFilterChange}
       />
@@ -384,7 +385,6 @@ export default function ArticlesIndexPage() {
       <ArticleList
         articles={articles}
         articleCategories={articleCategories}
-        activeFilter={activeFilter}
         dismissingIds={dismissingIds}
         onDismiss={handleDismiss}
         onUndoDismiss={handleUndoDismiss}

--- a/app/frontend/test/fixtures.ts
+++ b/app/frontend/test/fixtures.ts
@@ -37,6 +37,10 @@ export function buildArticlesIndexResponse(
       'Programming Languages': [first.id],
       Frameworks: [second.id],
     },
+    category_counts: {
+      'Programming Languages': 1,
+      Frameworks: 1,
+    },
     categories: [
       { name: 'Programming Languages', icon: '🔨' },
       { name: 'Frameworks', icon: '🧱' },

--- a/app/frontend/types/article.ts
+++ b/app/frontend/types/article.ts
@@ -31,6 +31,7 @@ export interface Pagination {
 export interface ArticlesIndexResponse {
   articles: Article[]
   articles_by_category: Record<string, number[]>
+  category_counts: Record<string, number>
   categories: Category[]
   pagination: Pagination
   last_updated: string | null

--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -1,16 +1,18 @@
 module ArticlesHelper
-  def group_sources_by_category(articles_by_source)
-    categories = {
-      "Programming Languages" => %w[reddit_ruby reddit_rust reddit_javascript],
-      "Web Development" => %w[reddit_webdev reddit_programming],
-      "Security" => %w[reddit_netsec reddit_cybersecurity],
-      "AI & Machine Learning" => %w[reddit_MachineLearning reddit_artificial reddit_LocalLLaMA],
-      "General Tech" => %w[hacker_news dev_to reddit_technology]
-    }
+  CATEGORIES = {
+    "Programming Languages" => %w[reddit_ruby reddit_rust reddit_javascript],
+    "Web Development" => %w[reddit_webdev reddit_programming],
+    "Security" => %w[reddit_netsec reddit_cybersecurity],
+    "AI & Machine Learning" => %w[reddit_MachineLearning reddit_artificial reddit_LocalLLaMA],
+    "General Tech" => %w[hacker_news dev_to reddit_technology]
+  }.freeze
 
+  KNOWN_SOURCE_TYPES = CATEGORIES.values.flatten.freeze
+
+  def group_sources_by_category(articles_by_source)
     grouped = {}
 
-    categories.each do |category_name, source_types|
+    CATEGORIES.each do |category_name, source_types|
       category_articles = []
       source_types.each do |source_type|
         category_articles.concat(articles_by_source[source_type] || [])
@@ -19,7 +21,7 @@ module ArticlesHelper
     end
 
     # Add any sources not in predefined categories
-    other_sources = articles_by_source.keys - categories.values.flatten
+    other_sources = articles_by_source.keys - KNOWN_SOURCE_TYPES
     if other_sources.any?
       other_articles = []
       other_sources.each do |source_type|
@@ -41,5 +43,53 @@ module ArticlesHelper
       "Other" => "📰"
     }
     icons[category_name] || "📄"
+  end
+
+  # Matches frontend parameterize(): lowercase + spaces to hyphens (keeps & etc.)
+  def category_slug(name)
+    name.to_s.downcase.gsub(/\s+/, "-")
+  end
+
+  def source_types_for_category_slug(slug)
+    return nil if slug.blank? || slug == "all"
+
+    CATEGORIES.each do |name, source_types|
+      return source_types if category_slug(name) == slug
+    end
+
+    return :other if category_slug("Other") == slug
+
+    nil
+  end
+
+  def apply_category_filter(scope, slug)
+    source_types = source_types_for_category_slug(slug)
+    return scope if source_types.nil? && (slug.blank? || slug == "all")
+    return scope.none if source_types.nil?
+
+    if source_types == :other
+      scope.where.not(source_type: KNOWN_SOURCE_TYPES)
+    else
+      scope.where(source_type: source_types)
+    end
+  end
+
+  def category_counts_for_scope(scope)
+    counts_by_source = scope.unscope(:includes, :order, :select).group(:source_type).count
+    group_counts_by_category(counts_by_source)
+  end
+
+  def group_counts_by_category(counts_by_source)
+    grouped = {}
+
+    CATEGORIES.each do |category_name, source_types|
+      count = source_types.sum { |source_type| counts_by_source[source_type] || 0 }
+      grouped[category_name] = count if count.positive?
+    end
+
+    other_count = counts_by_source.except(*KNOWN_SOURCE_TYPES).values.sum
+    grouped["Other"] = other_count if other_count.positive?
+
+    grouped
   end
 end

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -320,11 +320,72 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
     assert json_response.key?("pagination")
     assert json_response.key?("categories")
     assert json_response.key?("articles_by_category")
+    assert json_response.key?("category_counts")
     assert json_response.key?("last_updated")
 
     assert json_response["articles"].is_a?(Array)
     assert json_response["pagination"]["current_page"] == 1
     assert json_response["pagination"]["per_page"] == 50
+  end
+
+  test "index JSON should filter by category and keep full category counts" do
+    get articles_url(category: "programming-languages"), as: :json
+    assert_response :success
+
+    body = JSON.parse(response.body)
+    source_types = body["articles"].map { |article| article["source_type"] }
+    assert source_types.all? { |source_type| %w[reddit_rust reddit_ruby reddit_javascript].include?(source_type) }
+    assert_includes source_types, @rust_article.source_type
+    assert_not_includes source_types, @article.source_type
+
+    assert body["category_counts"]["Programming Languages"] >= 2
+    assert body["category_counts"]["General Tech"] >= 2
+    assert_equal body["articles"].size, body["pagination"]["total_count"]
+    assert body["pagination"]["total_count"] < body["category_counts"].values.sum
+  end
+
+  test "index JSON category filter paginates across the filtered dataset" do
+    5.times do |i|
+      Article.create!(
+        title: "Extra Rust #{i}",
+        url: "https://example.com/rust-#{i}",
+        external_id: "rust-extra-#{i}",
+        source_type: "reddit_rust",
+        published_at: i.hours.ago,
+        score: 10,
+        comment_count: 0
+      )
+    end
+
+    get articles_url(category: "programming-languages", page: 1, per_page: 2), as: :json
+    assert_response :success
+    page_one = JSON.parse(response.body)
+
+    get articles_url(category: "programming-languages", page: 2, per_page: 2), as: :json
+    assert_response :success
+    page_two = JSON.parse(response.body)
+
+    assert_equal 2, page_one["articles"].size
+    assert_operator page_two["articles"].size, :>=, 1
+    assert_equal page_one["pagination"]["total_count"], page_two["pagination"]["total_count"]
+    assert_operator page_one["pagination"]["total_pages"], :>=, 2
+
+    page_one_ids = page_one["articles"].map { |article| article["id"] }
+    page_two_ids = page_two["articles"].map { |article| article["id"] }
+    assert_empty page_one_ids & page_two_ids
+
+    assert_equal page_one["category_counts"], page_two["category_counts"]
+    assert_equal page_one["category_counts"]["Programming Languages"], page_one["pagination"]["total_count"]
+  end
+
+  test "index JSON should return empty results for unknown category" do
+    get articles_url(category: "not-a-real-category"), as: :json
+    assert_response :success
+
+    body = JSON.parse(response.body)
+    assert_empty body["articles"]
+    assert_equal 0, body["pagination"]["total_count"]
+    assert body["category_counts"].values.sum.positive?
   end
 
   test "index JSON should clamp invalid pagination params" do

--- a/test/helpers/articles_helper_test.rb
+++ b/test/helpers/articles_helper_test.rb
@@ -74,4 +74,30 @@ class ArticlesHelperTest < ActionView::TestCase
 
     assert_equal 3, grouped["Programming Languages"].length
   end
+
+  test "category_slug matches frontend parameterization" do
+    assert_equal "programming-languages", category_slug("Programming Languages")
+    assert_equal "ai-&-machine-learning", category_slug("AI & Machine Learning")
+  end
+
+  test "source_types_for_category_slug resolves known categories" do
+    assert_equal %w[reddit_ruby reddit_rust reddit_javascript],
+                 source_types_for_category_slug("programming-languages")
+    assert_equal :other, source_types_for_category_slug("other")
+    assert_nil source_types_for_category_slug("all")
+    assert_nil source_types_for_category_slug("unknown")
+  end
+
+  test "apply_category_filter restricts to matching source types" do
+    scope = apply_category_filter(Article.all, "programming-languages")
+    assert_includes scope, articles(:reddit_rust_article)
+    assert_not_includes scope, articles(:hacker_news_article)
+  end
+
+  test "category_counts_for_scope aggregates across the full relation" do
+    counts = category_counts_for_scope(Article.all)
+
+    assert_equal 2, counts["Programming Languages"]
+    assert_equal 2, counts["General Tech"]
+  end
 end

--- a/test/system/category_filter_turbo_test.rb
+++ b/test/system/category_filter_turbo_test.rb
@@ -93,4 +93,37 @@ class CategoryFilterTurboTest < ApplicationSystemTestCase
       skip "No articles found"
     end
   end
+
+  test "category filter paginates server-side across matching articles" do
+    55.times do |i|
+      Article.create!(
+        title: "Paged Rust #{i}",
+        url: "https://example.com/paged-rust-#{i}",
+        external_id: "paged-rust-#{i}",
+        source_type: "reddit_rust",
+        published_at: i.hours.ago,
+        score: 10,
+        comment_count: 0
+      )
+    end
+
+    visit articles_path(category: "programming-languages")
+    assert_selector "[data-testid='articles-page']", wait: 10
+    assert_selector "article.article-card[data-category='programming-languages']", visible: true, minimum: 1
+    assert_no_selector "article.article-card[data-category='general-tech']"
+    assert_match(/category=programming-languages/, page.current_url)
+
+    assert_selector "[data-testid='articles-pagination']", wait: 5
+    page_one_titles = all("article.article-card").map { |card| card.text }
+
+    find("[data-testid='pagination-next']").click
+
+    assert_match(/page=2/, page.current_url)
+    assert_match(/category=programming-languages/, page.current_url)
+    assert_selector "article.article-card[data-category='programming-languages']", visible: true, minimum: 1
+    assert_no_selector "article.article-card[data-category='general-tech']"
+
+    page_two_titles = all("article.article-card").map { |card| card.text }
+    assert_empty page_one_titles & page_two_titles
+  end
 end


### PR DESCRIPTION
## Summary
- Add `category` query param filtering to `article_index_scope` via `ArticlesHelper`, mapping category slugs to `source_type`s
- Return full-scope `category_counts` from the articles JSON API so CategoryFilter totals are not page-local
- Remove client-side category filtering in `ArticleList` / `ArticlesIndexPage`; the index refetches with `category` and paginates over the filtered dataset
- Update controller, helper, frontend, and system tests for the React flow

## Test plan
- [ ] Filter by a category on `/articles` and confirm only matching cards render
- [ ] Confirm category button counts stay stable across pages (not page size)
- [ ] Paginate while a category is active and confirm page 2 stays filtered with distinct articles
- [ ] Clear the filter via All Articles and confirm the full feed returns
- [ ] `bin/rails test test/controllers/articles_controller_test.rb test/helpers/articles_helper_test.rb test/system/category_filter_turbo_test.rb`
- [ ] `npm test -- --run app/frontend/pages/ArticlesIndexPage.test.tsx`

Closes #241