### PR TITLE
perf(frontend): memoize ArticleCard to reduce list re-renders (#254)

### DIFF
--- a/app/frontend/components/ArticleCard.test.tsx
+++ b/app/frontend/components/ArticleCard.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, expect, it } from 'vitest'
 import ArticleCard from './ArticleCard'
+import type { Article } from '../types/article'
 
 const baseArticle = {
   id: 1,
@@ -14,22 +15,28 @@ const baseArticle = {
   published_at: '2024-01-15T10:00:00Z',
 }
 
+const feedArticle: Article = {
+  ...baseArticle,
+  external_id: 'hn-1',
+  created_at: '2024-01-15T10:00:00Z',
+  updated_at: '2024-01-15T10:00:00Z',
+  bookmarked: false,
+  read: false,
+  dismissed: false,
+  pending_dismissal: false,
+}
+
 describe('ArticleCard', () => {
+  it('is wrapped in React.memo', () => {
+    expect(ArticleCard).toHaveProperty('$$typeof', Symbol.for('react.memo'))
+  })
+
   it('renders feed variant with dismiss and bookmark controls', () => {
     render(
       <MemoryRouter>
         <ArticleCard
           variant="feed"
-          article={{
-            ...baseArticle,
-            external_id: 'hn-1',
-            created_at: '2024-01-15T10:00:00Z',
-            updated_at: '2024-01-15T10:00:00Z',
-            bookmarked: false,
-            read: false,
-            dismissed: false,
-            pending_dismissal: false,
-          }}
+          article={feedArticle}
           categorySlug="programming"
           index={0}
           isDismissing={false}

--- a/app/frontend/components/ArticleCard.tsx
+++ b/app/frontend/components/ArticleCard.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react'
 import type { Article } from '../types/article'
 import type { BookmarkArticle } from '../types/bookmark'
 import type { DismissedArticle } from '../types/dismissedArticle'
@@ -50,7 +51,7 @@ type DismissedCardProps = {
 
 export type ArticleCardProps = FeedCardProps | BookmarkCardProps | ReadCardProps | DismissedCardProps
 
-export default function ArticleCard(props: ArticleCardProps) {
+function ArticleCard(props: ArticleCardProps) {
   const { confirm, dialog } = useConfirmDialog()
   const { variant, article, index } = props
   const theme = variantTheme(variant)
@@ -217,5 +218,7 @@ export default function ArticleCard(props: ArticleCardProps) {
     </>
   )
 }
+
+export default memo(ArticleCard)
 
 export type { ArticleCardData } from './articleCard/cardThemes'

--- a/app/frontend/pages/ArticlesIndexPage.tsx
+++ b/app/frontend/pages/ArticlesIndexPage.tsx
@@ -63,6 +63,8 @@ export default function ArticlesIndexPage() {
   const countdownRef = useRef<number | null>(null)
   const pendingDismissRef = useRef<{ articleId: number; title: string } | null>(null)
   const abortRef = useRef<AbortController | null>(null)
+  const toastRef = useRef(toast)
+  toastRef.current = toast
 
   const loadArticles = useCallback(async (options?: { page?: number }) => {
     abortRef.current?.abort()
@@ -142,7 +144,7 @@ export default function ArticlesIndexPage() {
   }, [])
 
   const handleUndoDismiss = useCallback(async (article?: Article) => {
-    const articleId = article?.id ?? toast?.articleId
+    const articleId = article?.id ?? toastRef.current?.articleId
     if (!articleId) return
 
     try {
@@ -158,11 +160,11 @@ export default function ArticlesIndexPage() {
     } catch {
       setError('Failed to restore article.')
     }
-  }, [toast])
+  }, [])
 
   const handleDismiss = useCallback(async (article: Article) => {
-    if (toast) {
-      finalizeDismiss(toast.articleId)
+    if (toastRef.current) {
+      finalizeDismiss(toastRef.current.articleId)
     }
 
     setDismissingIds(new Set([article.id]))
@@ -195,7 +197,7 @@ export default function ArticlesIndexPage() {
       })
       setError('Failed to dismiss article.')
     }
-  }, [finalizeDismiss, toast])
+  }, [finalizeDismiss])
 
   const handleShowReadChange = (value: boolean) => {
     patchSearchParams((params) => {
@@ -260,7 +262,7 @@ export default function ArticlesIndexPage() {
 
   useEffect(() => () => clearDismissTimer(), [])
 
-  const updateArticle = (articleId: number, changes: Partial<Article>) => {
+  const updateArticle = useCallback((articleId: number, changes: Partial<Article>) => {
     setData((current) => {
       if (!current) return current
       return {
@@ -270,9 +272,9 @@ export default function ArticlesIndexPage() {
         ),
       }
     })
-  }
+  }, [])
 
-  const handleBookmarkToggle = async (article: Article) => {
+  const handleBookmarkToggle = useCallback(async (article: Article) => {
     try {
       if (article.bookmarked) {
         await unbookmarkArticle(article.id)
@@ -284,9 +286,9 @@ export default function ArticlesIndexPage() {
     } catch {
       setError('Failed to update bookmark.')
     }
-  }
+  }, [updateArticle])
 
-  const handleReadToggle = async (article: Article) => {
+  const handleReadToggle = useCallback(async (article: Article) => {
     try {
       if (article.read) {
         await unmarkArticleAsRead(article.id)
@@ -302,7 +304,7 @@ export default function ArticlesIndexPage() {
     } catch {
       setError('Failed to update read status.')
     }
-  }
+  }, [showRead, updateArticle])
 
   if (loading) {
     return (

--- a/app/frontend/pages/ArticlesIndexPage.tsx
+++ b/app/frontend/pages/ArticlesIndexPage.tsx
@@ -64,7 +64,10 @@ export default function ArticlesIndexPage() {
   const pendingDismissRef = useRef<{ articleId: number; title: string } | null>(null)
   const abortRef = useRef<AbortController | null>(null)
   const toastRef = useRef(toast)
-  toastRef.current = toast
+
+  useEffect(() => {
+    toastRef.current = toast
+  }, [toast])
 
   const loadArticles = useCallback(async (options?: { page?: number }) => {
     abortRef.current?.abort()

--- a/app/frontend/pages/BookmarksIndexPage.tsx
+++ b/app/frontend/pages/BookmarksIndexPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { fetchBookmarks } from '../api/bookmarks'
 import {
   markArticleAsRead,
@@ -36,7 +36,7 @@ export default function BookmarksIndexPage() {
     [articlesBySource, sources]
   )
 
-  const handleRemoveBookmark = async (article: BookmarkArticle) => {
+  const handleRemoveBookmark = useCallback(async (article: BookmarkArticle) => {
     try {
       await unbookmarkArticle(article.id)
       setData((current) => {
@@ -60,9 +60,9 @@ export default function BookmarksIndexPage() {
     } catch {
       setError('Failed to remove bookmark.')
     }
-  }
+  }, [setData, setError])
 
-  const handleReadToggle = async (article: BookmarkArticle) => {
+  const handleReadToggle = useCallback(async (article: BookmarkArticle) => {
     try {
       if (article.read) {
         await unmarkArticleAsRead(article.id)
@@ -92,7 +92,7 @@ export default function BookmarksIndexPage() {
     } catch {
       setError('Failed to update read status.')
     }
-  }
+  }, [setData, setError])
 
   return (
     <PageShell

--- a/app/frontend/pages/DismissedArticlesIndexPage.tsx
+++ b/app/frontend/pages/DismissedArticlesIndexPage.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react'
 import { undismissArticle } from '../api/articles'
 import { fetchDismissedArticles } from '../api/dismissedArticles'
 import type { DismissedArticle } from '../types/dismissedArticle'
@@ -22,7 +23,7 @@ export default function DismissedArticlesIndexPage() {
   const articles = data?.articles ?? []
   const totalCount = data?.pagination.total_count ?? 0
 
-  const handleRestore = async (article: DismissedArticle) => {
+  const handleRestore = useCallback(async (article: DismissedArticle) => {
     try {
       await undismissArticle(article.id)
       setData((current) =>
@@ -40,7 +41,7 @@ export default function DismissedArticlesIndexPage() {
     } catch {
       setError('Failed to restore article.')
     }
-  }
+  }, [setData, setError])
 
   return (
     <PageShell

--- a/app/frontend/pages/ReadArticlesIndexPage.tsx
+++ b/app/frontend/pages/ReadArticlesIndexPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { unmarkArticleAsRead } from '../api/articles'
 import { fetchReadArticles } from '../api/readArticles'
 import type { ReadArticle } from '../types/readArticle'
@@ -32,7 +32,7 @@ export default function ReadArticlesIndexPage() {
     [articlesBySource, sources]
   )
 
-  const handleUnmarkRead = async (article: ReadArticle) => {
+  const handleUnmarkRead = useCallback(async (article: ReadArticle) => {
     try {
       await unmarkArticleAsRead(article.id)
       setData((current) => {
@@ -56,7 +56,7 @@ export default function ReadArticlesIndexPage() {
     } catch {
       setError('Failed to mark article as unread.')
     }
-  }
+  }, [setData, setError])
 
   return (
     <PageShell

--- a/app/frontend/pages/RecentlyDismissedPage.tsx
+++ b/app/frontend/pages/RecentlyDismissedPage.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react'
 import { undismissArticle } from '../api/articles'
 import { fetchRecentlyDismissed } from '../api/dismissedArticles'
 import type { DismissedArticle } from '../types/dismissedArticle'
@@ -21,7 +22,7 @@ export default function RecentlyDismissedPage() {
 
   const articles = data?.articles ?? []
 
-  const handleRestore = async (article: DismissedArticle) => {
+  const handleRestore = useCallback(async (article: DismissedArticle) => {
     try {
       await undismissArticle(article.id)
       setData((current) =>
@@ -35,7 +36,7 @@ export default function RecentlyDismissedPage() {
     } catch {
       setError('Failed to restore article.')
     }
-  }
+  }, [setData, setError])
 
   return (
     <PageShell


### PR DESCRIPTION
## Summary
- Wrap `ArticleCard` in `React.memo` so unchanged cards skip re-renders when list parents update
- Stabilize card callback props on feed/bookmarks/read/dismissed pages (including toast ref for dismiss handlers) so memo equality holds during dismiss timer ticks and bookmark toggles
- Assert `ArticleCard` is memo-wrapped in unit tests

## Test plan
- [x] `npm test -- app/frontend/components/ArticleCard.test.tsx`
- [x] `npm test -- app/frontend/pages/ArticlesIndexPage.test.tsx`
- [ ] Manually dismiss an article and confirm toast countdown does not visibly thrash the whole list
- [ ] Toggle bookmark/read on one card and confirm interactions still work

Closes #254