### PR TITLE
perf(api): replace top_percent score filter pluck with SQL (#260)

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -123,11 +123,14 @@ class ArticlesController < ApplicationController
       scope.where("score >= ?", params[:min_score].to_i)
     elsif params[:top_percent].present?
       percent = params[:top_percent].to_i.clamp(1, 100)
-      scores = scope.where.not(score: nil).order(score: :desc).pluck(:score)
-      return scope if scores.empty?
+      scored = scope.where.not(score: nil)
+      count = scored.count
+      return scope if count.zero?
 
-      index = [ (scores.size * percent / 100.0).ceil - 1, 0 ].max
-      scope.where("score >= ?", scores[index])
+      # Same discrete threshold as former pluck + index: top N scores by OFFSET.
+      index = [ (count * percent / 100.0).ceil - 1, 0 ].max
+      threshold = scored.order(score: :desc).offset(index).limit(1).pick(:score)
+      scope.where("score >= ?", threshold)
     else
       scope
     end

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -76,6 +76,45 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
     assert body["pagination"]["total_count"] <= Article.not_read.not_dismissed.count
   end
 
+  test "index JSON top_percent returns unfiltered scope when no scored articles" do
+    Article.update_all(score: nil)
+
+    get articles_url(top_percent: 50), as: :json
+    assert_response :success
+
+    body = JSON.parse(response.body)
+    assert_equal Article.not_read.not_dismissed.count, body["pagination"]["total_count"]
+  end
+
+  test "index JSON top_percent includes tied scores at the threshold" do
+    Article.find_each(&:mark_as_read!)
+    now = Time.current
+    [
+      [ "high-a", 100 ],
+      [ "high-b", 100 ],
+      [ "mid", 50 ],
+      [ "low", 10 ]
+    ].each_with_index do |(slug, score), i|
+      Article.create!(
+        title: "Tie #{slug}",
+        url: "https://example.com/#{slug}",
+        external_id: "tie-#{slug}",
+        source_type: "hacker_news",
+        published_at: now - i.hours,
+        score: score,
+        comment_count: 0
+      )
+    end
+
+    # 4 scored articles, top 50% → index 1 → threshold 100; both 100s included.
+    get articles_url(top_percent: 50), as: :json
+    assert_response :success
+
+    scores = JSON.parse(response.body)["articles"].map { |article| article["score"] }
+    assert_equal [ 100, 100 ], scores.sort.reverse
+    assert scores.all? { |score| score >= 100 }
+  end
+
   test "fetch should enqueue FetchNewsJob" do
     assert_enqueued_with(job: FetchNewsJob) do
       post fetch_articles_url, as: :json


### PR DESCRIPTION
## Summary
- Compute `top_percent` threshold via SQL `ORDER BY score DESC OFFSET … LIMIT 1` instead of `pluck(:score)` into Ruby
- Preserve the same discrete index semantics (including ties at the cutoff)
- Add controller tests for empty scored set and tied threshold scores

## Test plan
- [ ] `bin/rails test test/controllers/articles_controller_test.rb`
- [ ] Manually hit `GET /articles.json?top_percent=50` and confirm results match prior behavior on a seeded DB
- [ ] Confirm no full-table score array is loaded (query uses count + offset pick)

Closes #260