### PR TITLE
fix(rake): batch article cleanup in news:clean task (#240)

### DIFF
--- a/lib/tasks/news.rake
+++ b/lib/tasks/news.rake
@@ -48,7 +48,10 @@ namespace :news do
     cutoff = retention_days.days.ago
     old_articles = Article.where("published_at < ?", cutoff)
     count = old_articles.count
-    old_articles.destroy_all
+    # Destroy in batches so dependents run callbacks without loading the full set.
+    old_articles.in_batches(of: 500) do |batch|
+      batch.destroy_all
+    end
     puts "Removed #{count} articles older than #{retention_days} days (before #{cutoff.to_date})"
   end
 end

--- a/test/tasks/news_rake_test.rb
+++ b/test/tasks/news_rake_test.rb
@@ -49,4 +49,38 @@ class NewsRakeTest < ActiveSupport::TestCase
   ensure
     Rake::Task["news:clean"].reenable
   end
+
+  test "news:clean removes multiple old articles and all dependents in batches" do
+    retention_days = NewsAggregatorConfig.retention_days
+    cutoff = (retention_days + 1).days.ago
+
+    3.times do |i|
+      article = Article.create!(
+        title: "Old batch #{i}",
+        url: "https://example.com/old-batch-#{i}",
+        external_id: "old-batch-#{i}",
+        source_type: "hacker_news",
+        published_at: cutoff,
+        score: 1,
+        comment_count: 0
+      )
+      article.bookmark!
+      article.mark_as_read!
+    end
+
+    # setup already has one old bookmarked article; three more with bookmark + read.
+    assert_difference "Article.count", -4 do
+      assert_difference "Bookmark.count", -4 do
+        assert_difference "ReadArticle.count", -3 do
+          capture_io do
+            Rake::Task["news:clean"].invoke
+          end
+        end
+      end
+    end
+
+    assert_equal 0, Article.where("published_at < ?", retention_days.days.ago).count
+  ensure
+    Rake::Task["news:clean"].reenable
+  end
 end


### PR DESCRIPTION
## Summary
- Replace `destroy_all` on the full retention set with `in_batches` + per-batch `destroy_all` so dependents still run callbacks without loading every old article into memory
- Extend rake tests to cover multi-article cleanup with bookmark/read dependents

## Test plan
- [ ] `bin/rails test test/tasks/news_rake_test.rb`
- [ ] Seed many old articles with bookmarks/reads and run `bin/rails news:clean`; confirm they are removed and recent articles remain
- [ ] Confirm task output still reports the removed count

Closes #240