### PR TITLE
perf(hn): parallelize Hacker News item fetches (#259)

### DIFF
--- a/app/models/news_aggregator_config.rb
+++ b/app/models/news_aggregator_config.rb
@@ -28,6 +28,10 @@ module NewsAggregatorConfig
       fetching[:max_retries] || 3
     end
 
+    def hn_item_concurrency
+      fetching[:hn_item_concurrency] || 10
+    end
+
     def reddit_subreddits
       Array(config.dig(:apis, :reddit, :subreddits))
     end

--- a/app/services/news_fetchers/hacker_news_fetcher.rb
+++ b/app/services/news_fetchers/hacker_news_fetcher.rb
@@ -9,8 +9,12 @@ class NewsFetchers::HackerNewsFetcher < NewsFetchers::BaseFetcher
     top_story_ids = self.class.get("/topstories.json")
     return [] unless top_story_ids.is_a?(Array)
 
-    top_story_ids.first(NewsAggregatorConfig.max_articles_per_source).each do |story_id|
-      fetch_story(story_id)
+    story_ids = top_story_ids.first(NewsAggregatorConfig.max_articles_per_source)
+    story_payloads = fetch_story_payloads_in_parallel(story_ids)
+
+    story_payloads.each do |story_data|
+      article = persist_story(story_data)
+      @articles << article if article
     end
 
     Rails.logger.info "Fetched #{@articles.length} articles from Hacker News"
@@ -19,13 +23,43 @@ class NewsFetchers::HackerNewsFetcher < NewsFetchers::BaseFetcher
 
   private
 
-  def fetch_story(story_id)
+  # Parallelize only HTTP item fetches so ActiveRecord stays on the caller thread
+  # (NewsAggregatorService already holds a pool connection around fetch_articles).
+  def fetch_story_payloads_in_parallel(story_ids)
+    return [] if story_ids.empty?
+
+    mutex = Mutex.new
+    payloads = []
+    concurrency = [ NewsAggregatorConfig.hn_item_concurrency, story_ids.size ].min
+
+    story_ids.each_slice(concurrency) do |batch|
+      threads = batch.map do |story_id|
+        Thread.new do
+          story_data = fetch_story_payload(story_id)
+          mutex.synchronize { payloads << story_data } if story_data
+        end
+      end
+
+      threads.each(&:join)
+    end
+
+    payloads
+  end
+
+  def fetch_story_payload(story_id)
     story_data = self.class.get("/item/#{story_id}.json")
     return unless story_data && story_data["type"] == "story"
 
     # Skip stories without URLs (Ask HN, etc.)
     return unless story_data["url"]
 
+    story_data
+  rescue StandardError => e
+    Rails.logger.error "Error fetching HN story #{story_id}: #{e.message}"
+    nil
+  end
+
+  def persist_story(story_data)
     article_attributes = {
       title: story_data["title"],
       url: story_data["url"],
@@ -38,8 +72,9 @@ class NewsFetchers::HackerNewsFetcher < NewsFetchers::BaseFetcher
     }
 
     article = create_or_update_article(article_attributes)
-    @articles << article if article.persisted?
+    article if article.persisted?
   rescue StandardError => e
-    Rails.logger.error "Error fetching HN story #{story_id}: #{e.message}"
+    Rails.logger.error "Error persisting HN story #{story_data['id']}: #{e.message}"
+    nil
   end
 end

--- a/config/news_aggregator.yml
+++ b/config/news_aggregator.yml
@@ -9,6 +9,9 @@ development: &default
     
     # How often to retry failed requests
     max_retries: 3
+
+    # Max concurrent /item/{id} requests for Hacker News
+    hn_item_concurrency: 10
   
   # Data retention
   retention:
@@ -51,6 +54,7 @@ test:
   fetching:
     max_articles_per_source: 5
     request_timeout: 10
+    hn_item_concurrency: 3
   retention:
     article_retention_days: 7
 
@@ -60,5 +64,6 @@ production:
     max_articles_per_source: 50
     request_timeout: 60
     max_retries: 5
+    hn_item_concurrency: 10
   retention:
     article_retention_days: 60

--- a/test/models/news_aggregator_config_test.rb
+++ b/test/models/news_aggregator_config_test.rb
@@ -5,6 +5,7 @@ class NewsAggregatorConfigTest < ActiveSupport::TestCase
     assert_equal 5, NewsAggregatorConfig.max_articles_per_source
     assert_equal 10, NewsAggregatorConfig.request_timeout
     assert_equal 3, NewsAggregatorConfig.max_retries
+    assert_equal 3, NewsAggregatorConfig.hn_item_concurrency
   end
 
   test "loads retention days from news_aggregator.yml" do

--- a/test/services/news_fetchers/hacker_news_fetcher_test.rb
+++ b/test/services/news_fetchers/hacker_news_fetcher_test.rb
@@ -83,7 +83,7 @@ class NewsFetchers::HackerNewsFetcherTest < ActiveSupport::TestCase
 
       if (match = path.match(%r{\A/item/(\d+)\.json\z}))
         sleep 0.2
-        return stories.find { |story| story["id"] == match[1].to_i }
+        stories.find { |story| story["id"] == match[1].to_i }
       end
     }) do
       start = Process.clock_gettime(Process::CLOCK_MONOTONIC)

--- a/test/services/news_fetchers/hacker_news_fetcher_test.rb
+++ b/test/services/news_fetchers/hacker_news_fetcher_test.rb
@@ -64,6 +64,66 @@ class NewsFetchers::HackerNewsFetcherTest < ActiveSupport::TestCase
     end
   end
 
+  test "fetch_articles fetches story items concurrently" do
+    story_ids = [ 88_101, 88_102, 88_103 ]
+    stories = story_ids.map do |id|
+      {
+        "id" => id,
+        "type" => "story",
+        "title" => "HN Story #{id}",
+        "url" => "https://example.com/#{id}",
+        "time" => 1_700_000_000,
+        "score" => 1,
+        "descendants" => 0
+      }
+    end
+
+    with_stubbed_get(NewsFetchers::HackerNewsFetcher, lambda { |path, **_options|
+      return story_ids if path == "/topstories.json"
+
+      if (match = path.match(%r{\A/item/(\d+)\.json\z}))
+        sleep 0.2
+        return stories.find { |story| story["id"] == match[1].to_i }
+      end
+    }) do
+      start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      articles = @fetcher.fetch_articles
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+
+      assert_equal 3, articles.length
+      assert_operator elapsed, :<, 0.5, "expected parallel item fetch (~0.2s), took #{elapsed.round(2)}s"
+    end
+  end
+
+  test "fetch_articles continues when one story item fails" do
+    good_story = {
+      "id" => 88_201,
+      "type" => "story",
+      "title" => "Good HN Story",
+      "url" => "https://example.com/good",
+      "time" => 1_700_000_000,
+      "score" => 5,
+      "descendants" => 1
+    }
+
+    with_stubbed_get(NewsFetchers::HackerNewsFetcher, lambda { |path, **_options|
+      case path
+      when "/topstories.json"
+        [ 88_201, 88_202 ]
+      when "/item/88201.json"
+        good_story
+      when "/item/88202.json"
+        raise NewsFetchers::BaseFetcher::FetchError, "HTTP 500 for item"
+      end
+    }) do
+      assert_difference "Article.count", 1 do
+        articles = @fetcher.fetch_articles
+        assert_equal 1, articles.length
+        assert_equal "Good HN Story", articles.first.title
+      end
+    end
+  end
+
   private
 
   def with_stubbed_get(fetcher_class, implementation)


### PR DESCRIPTION
## Summary
- Parallelize Hacker News `/item/{id}` HTTP fetches with bounded concurrency (`hn_item_concurrency`)
- Keep ActiveRecord persistence on the caller thread to avoid connection-pool deadlocks under `NewsAggregatorService`
- Preserve per-item error handling and add concurrency + failure-isolation tests

## Test plan
- [x] `bin/rails test test/services/news_fetchers/hacker_news_fetcher_test.rb test/models/news_aggregator_config_test.rb`
- [ ] Confirm HN aggregation completes faster with multiple story IDs
- [ ] Confirm one failing item does not block others

Closes #259