### PR TITLE
fix(cache): install and configure solid_cache for production (#239)

### DIFF
--- a/config/cache.yml
+++ b/config/cache.yml
@@ -1,0 +1,16 @@
+default: &default
+  store_options:
+    # Cap age of oldest cache entry to fulfill retention policies
+    # max_age: <%= 60.days.to_i %>
+    max_size: <%= 256.megabytes %>
+    namespace: <%= Rails.env %>
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  database: cache
+  <<: *default

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,7 +47,8 @@ Rails.application.configure do
   config.active_support.report_deprecations = false
 
   # Replace the default in-process memory cache store with a durable alternative.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :solid_cache_store
+  config.solid_cache.connects_to = { database: { writing: :cache } }
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
   config.active_job.queue_adapter = :solid_queue

--- a/db/cache_schema.rb
+++ b/db/cache_schema.rb
@@ -1,0 +1,12 @@
+ActiveRecord::Schema[7.2].define(version: 1) do
+  create_table "solid_cache_entries", force: :cascade do |t|
+    t.binary "key", limit: 1024, null: false
+    t.binary "value", limit: 536870912, null: false
+    t.datetime "created_at", null: false
+    t.integer "key_hash", limit: 8, null: false
+    t.integer "byte_size", limit: 4, null: false
+    t.index ["byte_size"], name: "index_solid_cache_entries_on_byte_size"
+    t.index ["key_hash", "byte_size"], name: "index_solid_cache_entries_on_key_hash_and_byte_size"
+    t.index ["key_hash"], name: "index_solid_cache_entries_on_key_hash", unique: true
+  end
+end


### PR DESCRIPTION
## Summary
- Install Solid Cache (`config/cache.yml`, `db/cache_schema.rb`) and set production `cache_store` to `:solid_cache_store` on the dedicated cache DB.
- Enables shared rate-limit/cache state across Puma workers.

Closes #239

## Test plan
- [ ] CI green
- [ ] Production config loads with cache DB (`database.yml` `cache:` entry)