### PR TITLE
test(frontend): add page tests for Sources, Bookmarks, and ArticleShow (#249)

### DIFF
--- a/app/frontend/pages/ArticleShowPage.test.tsx
+++ b/app/frontend/pages/ArticleShowPage.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import ArticleShowPage from '../pages/ArticleShowPage'
+import * as articlesApi from '../api/articles'
+import { buildArticle } from '../test/fixtures'
+
+vi.mock('../api/articles', () => ({
+  fetchArticle: vi.fn(),
+  bookmarkArticle: vi.fn(),
+  unbookmarkArticle: vi.fn(),
+  markArticleAsRead: vi.fn(),
+  unmarkArticleAsRead: vi.fn(),
+}))
+
+function renderPage(path = '/articles/1') {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path=/articles/:id element={<ArticleShowPage />} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+async function waitForArticleShow() {
+  await screen.findByTestId('article-show-page')
+  await screen.findByRole('heading', { name: 'Rust 2024 Edition Highlights' })
+}
+
+describe('ArticleShowPage', () => {
+  beforeEach(() => {
+    vi.mocked(articlesApi.fetchArticle).mockResolvedValue(buildArticle())
+    vi.mocked(articlesApi.bookmarkArticle).mockResolvedValue({ bookmarked: true })
+    vi.mocked(articlesApi.unbookmarkArticle).mockResolvedValue({ bookmarked: false })
+    vi.mocked(articlesApi.markArticleAsRead).mockResolvedValue({ read: true })
+    vi.mocked(articlesApi.unmarkArticleAsRead).mockResolvedValue({ read: false })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('loads and displays the article details', async () => {
+    renderPage()
+
+    await waitForArticleShow()
+
+    expect(articlesApi.fetchArticle).toHaveBeenCalledWith(1)
+    expect(screen.getByText('Reddit Rust')).toBeInTheDocument()
+    expect(screen.getByText('A summary of Rust changes.')).toBeInTheDocument()
+    expect(screen.getByText('120 points')).toBeInTheDocument()
+    expect(screen.getByText('8 comments')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Visit Source/i })).toHaveAttribute(
+      'href',
+      'https://example.com/rust'
+    )
+  })
+
+  it('shows not found when the article cannot be loaded', async () => {
+    vi.mocked(articlesApi.fetchArticle).mockRejectedValue(new Error('missing'))
+
+    renderPage()
+
+    expect(await screen.findByText('Article not found.')).toBeInTheDocument()
+  })
+
+  it('shows not found for an invalid article id', async () => {
+    renderPage('/articles/not-a-number')
+
+    expect(await screen.findByText('Article not found.')).toBeInTheDocument()
+    expect(articlesApi.fetchArticle).not.toHaveBeenCalled()
+  })
+
+  it('marks the article as read and unread', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await waitForArticleShow()
+
+    await user.click(screen.getByRole('button', { name: 'Mark as Read' }))
+
+    await waitFor(() => {
+      expect(articlesApi.markArticleAsRead).toHaveBeenCalledWith(1)
+    })
+    expect(screen.getByText('Already Read')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Mark as Unread' })).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Mark as Unread' }))
+
+    await waitFor(() => {
+      expect(articlesApi.unmarkArticleAsRead).toHaveBeenCalledWith(1)
+    })
+    expect(screen.queryByText('Already Read')).not.toBeInTheDocument()
+  })
+
+  it('adds the article to the reading list', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await waitForArticleShow()
+
+    await user.click(screen.getByRole('button', { name: 'Add to Reading List' }))
+
+    await waitFor(() => {
+      expect(articlesApi.bookmarkArticle).toHaveBeenCalledWith(1)
+    })
+    expect(screen.getByText('Bookmarked')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Remove from Reading List' })).toBeInTheDocument()
+  })
+
+  it('removes the article from the reading list after confirmation', async () => {
+    vi.mocked(articlesApi.fetchArticle).mockResolvedValue(buildArticle({ bookmarked: true }))
+    const user = userEvent.setup()
+    renderPage()
+    await waitForArticleShow()
+
+    await user.click(screen.getByRole('button', { name: 'Remove from Reading List' }))
+    expect(await screen.findByTestId('confirm-dialog')).toBeInTheDocument()
+    await user.click(screen.getByTestId('confirm-dialog-confirm'))
+
+    await waitFor(() => {
+      expect(articlesApi.unbookmarkArticle).toHaveBeenCalledWith(1)
+    })
+    expect(screen.queryByText('Bookmarked')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Add to Reading List' })).toBeInTheDocument()
+  })
+
+  it('shows an action error when bookmarking fails', async () => {
+    vi.mocked(articlesApi.bookmarkArticle).mockRejectedValue(new Error('fail'))
+    const user = userEvent.setup()
+    renderPage()
+    await waitForArticleShow()
+
+    await user.click(screen.getByRole('button', { name: 'Add to Reading List' }))
+
+    expect(await screen.findByText('Failed to update bookmark.')).toBeInTheDocument()
+  })
+})

--- a/app/frontend/pages/ArticleShowPage.test.tsx
+++ b/app/frontend/pages/ArticleShowPage.test.tsx
@@ -18,7 +18,7 @@ function renderPage(path = '/articles/1') {
   return render(
     <MemoryRouter initialEntries={[path]}>
       <Routes>
-        <Route path=/articles/:id element={<ArticleShowPage />} />
+        <Route path="/articles/:id" element={<ArticleShowPage />} />
       </Routes>
     </MemoryRouter>
   )

--- a/app/frontend/pages/BookmarksIndexPage.test.tsx
+++ b/app/frontend/pages/BookmarksIndexPage.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import BookmarksIndexPage from '../pages/BookmarksIndexPage'
+import * as bookmarksApi from '../api/bookmarks'
+import * as articlesApi from '../api/articles'
+import { buildBookmarksIndexResponse } from '../test/fixtures'
+
+vi.mock('../api/bookmarks', () => ({
+  fetchBookmarks: vi.fn(),
+}))
+
+vi.mock('../api/articles', () => ({
+  unbookmarkArticle: vi.fn(),
+  markArticleAsRead: vi.fn(),
+  unmarkArticleAsRead: vi.fn(),
+}))
+
+function renderPage(initialEntries = ['/bookmarks']) {
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <BookmarksIndexPage />
+    </MemoryRouter>
+  )
+}
+
+async function waitForBookmarksFeed() {
+  await screen.findByTestId('bookmarks-page')
+  await waitFor(() => {
+    expect(screen.getAllByRole('button', { name: 'Remove from reading list' }).length).toBeGreaterThan(
+      0
+    )
+  })
+}
+
+describe('BookmarksIndexPage', () => {
+  beforeEach(() => {
+    vi.mocked(bookmarksApi.fetchBookmarks).mockResolvedValue(buildBookmarksIndexResponse())
+    vi.mocked(articlesApi.unbookmarkArticle).mockResolvedValue({ bookmarked: false })
+    vi.mocked(articlesApi.markArticleAsRead).mockResolvedValue({ read: true })
+    vi.mocked(articlesApi.unmarkArticleAsRead).mockResolvedValue({ read: false })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('loads and displays bookmarked articles', async () => {
+    renderPage()
+
+    await waitForBookmarksFeed()
+
+    expect(screen.getByRole('heading', { name: 'Reading List' })).toBeInTheDocument()
+    expect(screen.getByText('Rust 2024 Edition Highlights')).toBeInTheDocument()
+    expect(screen.getByText('Ruby 3.3 Performance Tips')).toBeInTheDocument()
+    expect(screen.getByText(/Bookmarked:/)).toHaveTextContent('2')
+  })
+
+  it('shows empty state when there are no bookmarks', async () => {
+    vi.mocked(bookmarksApi.fetchBookmarks).mockResolvedValue(
+      buildBookmarksIndexResponse({
+        articles: [],
+        articles_by_source: {},
+        pagination: {
+          current_page: 1,
+          per_page: 20,
+          total_count: 0,
+          total_pages: 0,
+        },
+      })
+    )
+
+    renderPage()
+
+    expect(await screen.findByText('No bookmarked articles yet')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Browse Articles/i })).toHaveAttribute('href', '/articles')
+  })
+
+  it('shows a fatal error with retry when loading fails', async () => {
+    vi.mocked(bookmarksApi.fetchBookmarks).mockRejectedValueOnce(new Error('network'))
+    vi.mocked(bookmarksApi.fetchBookmarks).mockResolvedValueOnce(buildBookmarksIndexResponse())
+    const user = userEvent.setup()
+
+    renderPage()
+
+    expect(await screen.findByText('Failed to load reading list. Please try again.')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Retry' }))
+
+    await waitForBookmarksFeed()
+    expect(bookmarksApi.fetchBookmarks).toHaveBeenCalledTimes(2)
+  })
+
+  it('removes a bookmark from the list', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await waitForBookmarksFeed()
+
+    await user.click(screen.getAllByRole('button', { name: 'Remove from reading list' })[0])
+
+    await waitFor(() => {
+      expect(articlesApi.unbookmarkArticle).toHaveBeenCalledWith(1)
+    })
+    expect(screen.queryByText('Rust 2024 Edition Highlights')).not.toBeInTheDocument()
+    expect(screen.getByText('Ruby 3.3 Performance Tips')).toBeInTheDocument()
+  })
+
+  it('marks a bookmarked article as read', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await waitForBookmarksFeed()
+
+    await user.click(screen.getAllByRole('button', { name: 'Mark as read' })[0])
+
+    await waitFor(() => {
+      expect(articlesApi.markArticleAsRead).toHaveBeenCalledWith(1)
+    })
+    expect(await screen.findByRole('button', { name: 'Mark as unread' })).toBeInTheDocument()
+  })
+
+  it('filters bookmarks when source is in the URL', async () => {
+    renderPage(['/bookmarks?source=reddit_rust'])
+
+    await waitForBookmarksFeed()
+
+    expect(screen.getByText('Rust 2024 Edition Highlights')).toBeInTheDocument()
+    expect(screen.queryByText('Ruby 3.3 Performance Tips')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Reddit Rust/ })).toHaveAttribute('aria-pressed', 'true')
+  })
+})

--- a/app/frontend/pages/BookmarksIndexPage.test.tsx
+++ b/app/frontend/pages/BookmarksIndexPage.test.tsx
@@ -98,6 +98,8 @@ describe('BookmarksIndexPage', () => {
     await waitForBookmarksFeed()
 
     await user.click(screen.getAllByRole('button', { name: 'Remove from reading list' })[0])
+    expect(await screen.findByTestId('confirm-dialog')).toBeInTheDocument()
+    await user.click(screen.getByTestId('confirm-dialog-confirm'))
 
     await waitFor(() => {
       expect(articlesApi.unbookmarkArticle).toHaveBeenCalledWith(1)

--- a/app/frontend/pages/SourcesIndexPage.test.tsx
+++ b/app/frontend/pages/SourcesIndexPage.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import SourcesIndexPage from '../pages/SourcesIndexPage'
+import * as sourcesApi from '../api/sources'
+import { buildNewsSource, buildSourcesIndexResponse } from '../test/fixtures'
+
+vi.mock('../api/sources', () => ({
+  fetchSources: vi.fn(),
+  updateSource: vi.fn(),
+  addRedditSource: vi.fn(),
+  removeSource: vi.fn(),
+}))
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/sources']}>
+      <SourcesIndexPage />
+    </MemoryRouter>
+  )
+}
+
+async function waitForSourcesPage() {
+  await screen.findByTestId('sources-page')
+  await screen.findByRole('heading', { name: 'News Sources' })
+}
+
+describe('SourcesIndexPage', () => {
+  beforeEach(() => {
+    vi.mocked(sourcesApi.fetchSources).mockResolvedValue(buildSourcesIndexResponse())
+    vi.mocked(sourcesApi.updateSource).mockImplementation(async (id, active) =>
+      buildNewsSource({
+        id,
+        active,
+        source_type: id === 3 ? 'reddit' : 'hacker_news',
+        name: id === 3 ? 'rust' : 'Hacker News',
+        subreddit: id === 3 ? 'rust' : null,
+      })
+    )
+    vi.mocked(sourcesApi.addRedditSource).mockResolvedValue(
+      buildNewsSource({
+        id: 4,
+        name: 'programming',
+        source_type: 'reddit',
+        subreddit: 'programming',
+        active: true,
+      })
+    )
+    vi.mocked(sourcesApi.removeSource).mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('loads and displays built-in and Reddit sources', async () => {
+    renderPage()
+
+    await waitForSourcesPage()
+
+    expect(screen.getByText('Hacker News')).toBeInTheDocument()
+    expect(screen.getByText('DEV.to')).toBeInTheDocument()
+    expect(screen.getByText('r/rust')).toBeInTheDocument()
+    expect(screen.getByTestId('source-toggle-hacker_news')).toBeChecked()
+    expect(screen.getByTestId('source-toggle-dev_to')).not.toBeChecked()
+  })
+
+  it('shows an error when sources fail to load', async () => {
+    vi.mocked(sourcesApi.fetchSources).mockRejectedValue(new Error('network'))
+
+    renderPage()
+
+    expect(await screen.findByText('Failed to load news sources.')).toBeInTheDocument()
+  })
+
+  it('toggles a built-in source', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await waitForSourcesPage()
+
+    await user.click(screen.getByTestId('source-toggle-hacker_news'))
+
+    await waitFor(() => {
+      expect(sourcesApi.updateSource).toHaveBeenCalledWith(1, false)
+    })
+  })
+
+  it('adds a Reddit subreddit', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await waitForSourcesPage()
+
+    await user.type(screen.getByTestId('subreddit-input'), 'programming')
+    await user.click(screen.getByTestId('add-subreddit-button'))
+
+    await waitFor(() => {
+      expect(sourcesApi.addRedditSource).toHaveBeenCalledWith('programming')
+    })
+    expect(await screen.findByText('r/programming')).toBeInTheDocument()
+    expect(screen.getByTestId('subreddit-input')).toHaveValue('')
+  })
+
+  it('shows validation error when adding a subreddit fails', async () => {
+    vi.mocked(sourcesApi.addRedditSource).mockRejectedValue(new Error('Subreddit not found'))
+    const user = userEvent.setup()
+    renderPage()
+    await waitForSourcesPage()
+
+    await user.type(screen.getByTestId('subreddit-input'), 'notarealsub')
+    await user.click(screen.getByTestId('add-subreddit-button'))
+
+    expect(await screen.findByTestId('subreddit-validation-error')).toHaveTextContent(
+      'Subreddit not found'
+    )
+  })
+
+  it('removes a Reddit source after confirmation', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await waitForSourcesPage()
+
+    await user.click(screen.getByRole('button', { name: 'Remove' }))
+    expect(await screen.findByTestId('confirm-dialog')).toBeInTheDocument()
+    await user.click(screen.getByTestId('confirm-dialog-confirm'))
+
+    await waitFor(() => {
+      expect(sourcesApi.removeSource).toHaveBeenCalledWith(3)
+    })
+    expect(screen.queryByText('r/rust')).not.toBeInTheDocument()
+  })
+})

--- a/app/frontend/test/fixtures.ts
+++ b/app/frontend/test/fixtures.ts
@@ -1,4 +1,6 @@
 import type { Article, ArticlesIndexResponse } from '../types/article'
+import type { BookmarkArticle, BookmarksIndexResponse } from '../types/bookmark'
+import type { NewsSource, SourcesIndexResponse } from '../api/sources'
 
 export function buildArticle(overrides: Partial<Article> = {}): Article {
   return {
@@ -52,6 +54,84 @@ export function buildArticlesIndexResponse(
       total_pages: 1,
     },
     last_updated: '2024-06-01T12:00:00Z',
+    ...overrides,
+  }
+}
+
+export function buildBookmarkArticle(overrides: Partial<BookmarkArticle> = {}): BookmarkArticle {
+  return {
+    id: 1,
+    title: 'Rust 2024 Edition Highlights',
+    url: 'https://example.com/rust',
+    description: 'A summary of Rust changes.',
+    source_type: 'reddit_rust',
+    score: 120,
+    comment_count: 8,
+    external_id: 'rust-1',
+    published_at: '2024-06-01T12:00:00Z',
+    bookmarked_at: '2024-06-02T12:00:00Z',
+    read: false,
+    ...overrides,
+  }
+}
+
+export function buildBookmarksIndexResponse(
+  overrides: Partial<BookmarksIndexResponse> = {}
+): BookmarksIndexResponse {
+  const first = buildBookmarkArticle()
+  const second = buildBookmarkArticle({
+    id: 2,
+    title: 'Ruby 3.3 Performance Tips',
+    source_type: 'reddit_ruby',
+  })
+
+  return {
+    articles: [first, second],
+    articles_by_source: {
+      reddit_rust: [first.id],
+      reddit_ruby: [second.id],
+    },
+    pagination: {
+      current_page: 1,
+      per_page: 20,
+      total_count: 2,
+      total_pages: 1,
+    },
+    ...overrides,
+  }
+}
+
+export function buildNewsSource(overrides: Partial<NewsSource> = {}): NewsSource {
+  return {
+    id: 1,
+    name: 'Hacker News',
+    source_type: 'hacker_news',
+    subreddit: null,
+    active: true,
+    ...overrides,
+  }
+}
+
+export function buildSourcesIndexResponse(
+  overrides: Partial<SourcesIndexResponse> = {}
+): SourcesIndexResponse {
+  return {
+    sources: [
+      buildNewsSource(),
+      buildNewsSource({
+        id: 2,
+        name: 'DEV.to',
+        source_type: 'dev_to',
+        active: false,
+      }),
+      buildNewsSource({
+        id: 3,
+        name: 'rust',
+        source_type: 'reddit',
+        subreddit: 'rust',
+        active: true,
+      }),
+    ],
     ...overrides,
   }
 }


### PR DESCRIPTION
## Summary
- Add Vitest page tests for SourcesIndexPage, BookmarksIndexPage, and ArticleShowPage covering load, error, and primary action flows
- Extend shared frontend test fixtures for bookmarks and news sources

## Test plan
- [x] npx vitest run on the three new page test files (19 passed)
- [ ] CI frontend job passes

Closes #249