### PR TITLE
docs: fix README and DEVELOPMENT drift with current stack (#140)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Rails application that aggregates developer news from Hacker News, Dev.to, and
 - **Multi-source aggregation**: Fetches from 12+ sources including Hacker News, Dev.to, and programming subreddits
 - **Article bookmarking**: Save articles for later reading with category filtering  
 - **Automated updates**: Hourly fetching during business hours via cron jobs
-- **Responsive interface**: Clean web UI with source-based filtering
+- **Responsive interface**: React SPA with source-based filtering and Vite HMR in development
 
 ## Quick Start
 
@@ -43,9 +43,9 @@ Visit http://localhost:3000.
 
 ## Tech Stack
 
-- **Backend**: Rails 8.0.2
+- **Backend**: Rails 8.1
 - **Database**: PostgreSQL (Docker)
-- **Styling**: Tailwind CSS  
+- **Frontend**: React + Vite; **Styling**: Tailwind CSS (CDN)  
 - **Scheduling**: Whenever gem with cron
 - **HTTP**: HTTParty gem
 
@@ -65,7 +65,7 @@ bin/rails news:fetch
 # Show latest 10 articles
 bin/rails news:latest
 
-# Clean old articles (7+ days)
+# Clean old articles (retention from config/news_aggregator.yml)
 bin/rails news:clean
 
 # Setup cron jobs

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -293,7 +293,7 @@ Copy `.env.example` to `.env` before starting the stack. Docker Compose reads it
 - All tests start with `should` (e.g., `test "should create bookmark when valid"`)
 - Do not use `send` in tests — test public interface only
 - Always prefer fixtures over `create` methods for consistency
-- Mock only when necessary (external APIs, slow operations) and use mocha gem for mocking
+- Mock only when necessary (external APIs, slow operations); prefer WebMock/stubs over heavy mocking frameworks
 - Do not use comments in tests — test names should be self-descriptive
 - Follow RuboCop conventions in test files
 - Apply SOLID and KISS principles to test code


### PR DESCRIPTION
## Summary
- Align README tech stack (Rails 8.1, React/Vite, CDN Tailwind) and retention wording with the codebase.
- Remove obsolete mocha reference from `docs/DEVELOPMENT.md` (WARP.md already gone; `news_aggregator.yml` is loaded via `NewsAggregatorConfig`).

Closes #140

## Test plan
- [ ] Docs-only review