### PR TITLE
chore(docker): fix docker-compose dev/prod mismatch (#187)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ bundle install
 # Copy the environment template (holds the local database credentials)
 cp .env.example .env
 
-# Start PostgreSQL container
-sudo docker-compose up -d
+# Start PostgreSQL only (Rails/Vite run on the host; see below)
+docker compose up -d
 
 # Setup database
 bin/rails db:migrate

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,6 @@
+# Local development: PostgreSQL only.
+# Rails and Vite run on the host (see README / docs/DEVELOPMENT.md).
+# The production Dockerfile is for Kamal / image builds, not this compose file.
 services:
   db:
     image: postgres:15
@@ -15,19 +18,6 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-
-  web:
-    build: .
-    command: bundle exec rails server -b 0.0.0.0
-    volumes:
-      - .:/app
-    ports:
-      - "3000:3000"
-    depends_on:
-      db:
-        condition: service_healthy
-    environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER:-dev_news_user}:${POSTGRES_PASSWORD:-dev_password}@db:5432/${POSTGRES_DB:-dev_news_aggregator_development}
 
 volumes:
   postgres_data:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -12,8 +12,8 @@ For the directory map, see [REPO_STRUCTURE.md](REPO_STRUCTURE.md). **Update that
 # Install dependencies
 bundle install
 
-# Start PostgreSQL container
-sudo docker-compose up -d
+# Start PostgreSQL only (compose has no app service; Rails runs on the host)
+docker compose up -d
 
 # Setup primary and queue databases
 bin/rails db:prepare


### PR DESCRIPTION
## Summary
- Remove the broken `web` service that built the production Dockerfile while mounting `.:/app` (WORKDIR is `/rails`) and conflicting ports/commands with Thruster
- Document that `docker compose up -d` starts PostgreSQL only; Rails and Vite run on the host
- Keep the production `Dockerfile` for Kamal / image builds

Closes #187

## Test plan
- [ ] `docker compose up -d` starts only the `db` service
- [ ] `docker compose config` shows no `web` service
- [ ] README Quick Start still matches: Postgres via compose, Rails/Vite on host
- [ ] App connects to Postgres on localhost:5432 with `.env` / defaults