### PR TITLE
chore(hooks): align overcommit with conventional commits (#188)

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -2,9 +2,10 @@
 # repository. Uncomment the hooks you want to enable.
 #
 # For more information, see: https://github.com/sds/overcommit
+# Setup and Conventional Commits: docs/PRE_COMMIT_HOOKS.md
 
-# Verify signatures for overcommit gem
-verify_signatures: false
+# Require signed hook/config verification (run: bundle exec overcommit --sign)
+verify_signatures: true
 
 # Loads Bundler context from a Gemfile
 gemfile: Gemfile
@@ -33,8 +34,21 @@ PreCommit:
     enabled: true
     description: 'Scan for Rails security warnings'
     required: true
+    required_executable: 'bundle'
     command: ['bundle', 'exec', 'brakeman', '--no-pager', '--quiet']
     on_warn: fail
+
+  Typecheck:
+    enabled: true
+    description: 'Run TypeScript compiler checks'
+    required: true
+    required_executable: 'npm'
+    command: ['npm', 'run', 'typecheck']
+    include:
+      - '**/*.ts'
+      - '**/*.tsx'
+      - 'tsconfig.json'
+      - 'package.json'
 
   BundleCheck:
     enabled: true
@@ -51,9 +65,16 @@ CommitMsg:
     requires_files: false
     quiet: false
 
+  # Conflicts with Conventional Commits (lowercase subject after type:)
   CapitalizedSubject:
+    enabled: false
+
+  MessageFormat:
     enabled: true
-    description: 'Check subject capitalization'
+    description: 'Check Conventional Commits format'
+    pattern: '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-z0-9][a-z0-9/_-]*\))?(!)?: [a-z0-9].+'
+    expected_pattern_message: '<type>(optional-scope)!: <lowercase subject>'
+    sample_message: 'feat(api): add article dismiss endpoint'
 
   EmptyMessage:
     enabled: true

--- a/bin/setup
+++ b/bin/setup
@@ -20,6 +20,11 @@ FileUtils.chdir APP_ROOT do
   #   FileUtils.cp "config/database.yml.sample", "config/database.yml"
   # end
 
+  puts "\n== Installing Overcommit Git hooks =="
+  system! "bundle exec overcommit --install"
+  system! "bundle exec overcommit --sign"
+  puts "   Conventional Commits are enforced; see docs/PRE_COMMIT_HOOKS.md"
+
   puts "\n== Preparing database =="
   system! "bin/rails db:prepare"
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -308,13 +308,15 @@ Copy `.env.example` to `.env` before starting the stack. Docker Compose reads it
 ### Git commit guidelines
 
 - **Always run tests and RuboCop before committing** — run `bin/rails test` and `bin/rubocop`
-- Use conventional commit format (e.g., `feat:`, `fix:`, `test:`, `refactor:`)
+- Use conventional commit format (e.g., `feat:`, `fix:`, `test:`, `refactor:`) — enforced by Overcommit commit-msg (`MessageFormat`); see [PRE_COMMIT_HOOKS.md](PRE_COMMIT_HOOKS.md)
+- Subject after `type:` must be lowercase (e.g. `feat: add bookmarks`, not `feat: Add bookmarks`)
 - One line commit messages only — no body or additional description
 - One commit per file (exceptions allowed for large PRs with same context)
 - No co-authored comments
 - Keep commit messages concise and descriptive
 - Commit frequently to save changes — don't wait until everything is perfect
 - Push commits regularly to avoid losing work
+- Install hooks via `bin/setup` / `.\setup-local-env.ps1`, or manually with `bundle exec overcommit --install` and `bundle exec overcommit --sign`
 
 ### GitHub issue and branch workflow
 

--- a/docs/PRE_COMMIT_HOOKS.md
+++ b/docs/PRE_COMMIT_HOOKS.md
@@ -2,22 +2,29 @@
 
 This project uses [Overcommit](https://github.com/sds/overcommit) to manage Git hooks that run automatically before commits and when writing commit messages.
 
+Commit messages must follow [Conventional Commits](https://www.conventionalcommits.org/) (see below). The commit-msg hook enforces that format.
+
 ## What Gets Checked
 
 ### Pre-commit Checks
 - **RuboCop**: Lints Ruby code for style violations
 - **Brakeman**: Fails on new Rails security warnings (see `config/brakeman.ignore` for baselined findings)
+- **Typecheck**: Runs `npm run typecheck` when TypeScript or related config files are staged
 - **Bundle Audit**: Checks for vulnerable gem dependencies
 - **Bundle Check**: Verifies Gemfile dependencies are satisfied
 - **YAML Syntax**: Validates YAML file syntax
 
 ### Commit Message Checks
-- **Capitalized Subject**: Ensures commit message starts with capital letter
+- **Message Format**: Enforces Conventional Commits (`type: subject` / `type(scope): subject`)
 - **Empty Message**: Prevents empty commit messages
 - **Text Width**: Enforces max 72 characters for subject, 80 for body
 - **Trailing Period**: Disallows trailing periods in subject line
 
+`CapitalizedSubject` is disabled because Conventional Commits use a lowercase subject after the type prefix (e.g. `feat: add bookmarks`).
+
 ## Installation
+
+Hooks are installed automatically by `bin/setup` and `.\setup-local-env.ps1`. You can also install them manually:
 
 ### First Time Setup
 
@@ -31,12 +38,14 @@ bundle install
 bundle exec overcommit --install
 ```
 
-3. Sign the configuration (one-time):
+3. Sign the configuration (required; `verify_signatures` is enabled):
 ```bash
 bundle exec overcommit --sign
 ```
 
 That's it! The hooks will now run automatically.
+
+After pulling changes to `.overcommit.yml` (or custom hook plugins), run `bundle exec overcommit --sign` again so signature verification stays in sync.
 
 ## Usage
 
@@ -47,7 +56,7 @@ git add .
 git commit -m "feat: add new feature"
 ```
 
-The hooks will run automatically before the commit is created.
+The hooks will run automatically before the commit is created. Messages that do not match Conventional Commits are rejected by the commit-msg hook.
 
 ### Skipping Hooks
 If you need to skip hooks (not recommended), use:
@@ -77,8 +86,19 @@ bundle exec overcommit --sign
 ### "Hook failed" Messages
 If a hook fails, you'll see output explaining what went wrong:
 - **RuboCop failures**: Fix the style issues or run `bin/rubocop -a` to auto-fix
+- **Brakeman failures**: Fix or baseline new findings (see `config/brakeman.ignore`)
+- **Typecheck failures**: Fix TypeScript errors (`npm run typecheck`)
 - **Bundle Audit failures**: Update vulnerable gems in Gemfile
 - **YAML syntax errors**: Fix syntax in the affected YAML file
+- **Message Format failures**: Rewrite the subject to Conventional Commits (examples below)
+
+### Signature Verification Errors
+If Overcommit reports that the configuration signature changed:
+```bash
+bundle exec overcommit --sign
+```
+
+Do not set `verify_signatures: false` to bypass this; signing keeps local hooks aligned with the shared config.
 
 ### Hooks Not Running
 If hooks aren't running:
@@ -89,10 +109,13 @@ bundle exec overcommit --sign
 ```
 
 ### Performance
-The hooks are designed to be fast:
+The hooks are designed to be fast where possible:
 - RuboCop only checks staged files
+- Typecheck runs only when TypeScript-related files are staged
 - Bundle checks use caching
 - Hooks run in parallel when possible
+
+Brakeman scans the app and is slower; skip it for an urgent commit with `SKIP=Brakeman` only when necessary.
 
 ## Conventional Commits
 
@@ -101,7 +124,14 @@ This project follows the [Conventional Commits](https://www.conventionalcommits.
 ```
 type: subject
 
-body (optional)
+body (optional; prefer a one-line subject — see docs/DEVELOPMENT.md)
+```
+
+Optional scope and breaking-change marker:
+
+```
+type(scope): subject
+type(scope)!: subject
 ```
 
 ### Commit Types
@@ -113,6 +143,9 @@ body (optional)
 - `style:` - Code style changes (formatting, etc.)
 - `chore:` - Maintenance tasks
 - `perf:` - Performance improvements
+- `ci:` - CI configuration
+- `build:` - Build system or dependencies
+- `revert:` - Revert a previous commit
 
 ### Examples
 ```bash
@@ -120,6 +153,14 @@ git commit -m "feat: add user authentication"
 git commit -m "fix: resolve database connection issue"
 git commit -m "test: add tests for article model"
 git commit -m "refactor: simplify news fetcher logic"
+git commit -m "feat(api): add article dismiss endpoint"
+```
+
+Invalid (rejected by the commit-msg hook):
+```bash
+git commit -m "Add user authentication"         # missing type prefix
+git commit -m "feat: Add user authentication"   # subject must start lowercase
+git commit -m "feat:add auth"                   # missing space after colon
 ```
 
 ## Disabling Hooks Permanently (Not Recommended)
@@ -141,5 +182,6 @@ The same checks that run locally also run in CI:
 - RuboCop (lint job)
 - Bundle Audit (scan_dependencies job)
 - Brakeman security scan (scan_ruby job)
+- TypeScript check (typecheck job)
 
 This ensures consistent code quality whether committing locally or via pull requests.

--- a/setup-local-env.ps1
+++ b/setup-local-env.ps1
@@ -11,6 +11,19 @@ bundle install
 Write-Host "==> Installing npm packages..." -ForegroundColor Cyan
 npm install
 
+Write-Host "==> Installing Overcommit Git hooks..." -ForegroundColor Cyan
+bundle exec overcommit --install
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Overcommit install failed. See docs/PRE_COMMIT_HOOKS.md" -ForegroundColor Red
+    exit 1
+}
+bundle exec overcommit --sign
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Overcommit sign failed. See docs/PRE_COMMIT_HOOKS.md" -ForegroundColor Red
+    exit 1
+}
+Write-Host "    Conventional Commits are enforced; see docs/PRE_COMMIT_HOOKS.md" -ForegroundColor DarkGray
+
 if (Get-Command docker -ErrorAction SilentlyContinue) {
     Write-Host "==> Starting PostgreSQL via Docker..." -ForegroundColor Cyan
     # --wait blocks until the healthcheck passes (first boot can take 1-2 min)


### PR DESCRIPTION
## Summary
- Replace `CapitalizedSubject` with `MessageFormat` so Conventional Commits (`feat: lowercase subject`) pass the commit-msg hook
- Enable `verify_signatures`, add TypeScript `typecheck` pre-commit hook (Brakeman kept), and auto-install/sign Overcommit from `bin/setup` and `setup-local-env.ps1`
- Update `docs/PRE_COMMIT_HOOKS.md` and `docs/DEVELOPMENT.md` for frictionless hook setup

## Test plan
- [ ] `bundle exec overcommit --install && bundle exec overcommit --sign`
- [ ] `git commit` with `feat: add example` succeeds commit-msg checks
- [ ] `git commit` with `feat: Add example` or `Add example` is rejected
- [ ] Staging a `.ts`/`.tsx` file runs `npm run typecheck`
- [ ] Fresh `bin/setup` / `.\setup-local-env.ps1` installs and signs hooks

Closes #188