### PR TITLE
ci: validate Docker image builds in CI (#186)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,15 +219,36 @@ jobs:
           path: ${{ github.workspace }}/tmp/screenshots
           if-no-files-found: ignore
 
+  docker_build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build production Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          tags: dev-news-aggregator:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   quality_gate:
     runs-on: ubuntu-latest
     permissions: {}
-    needs: [scan_ruby, scan_dependencies, scan_js, lint, frontend_lint, typecheck, frontend_test, test]
+    needs: [scan_ruby, scan_dependencies, scan_js, lint, frontend_lint, typecheck, frontend_test, test, docker_build]
     if: always()
     steps:
       - name: Check all jobs status
         run: |
-          if [[ "${{ needs.scan_ruby.result }}" == "failure" || "${{ needs.scan_dependencies.result }}" == "failure" || "${{ needs.scan_js.result }}" == "failure" || "${{ needs.lint.result }}" == "failure" || "${{ needs.frontend_lint.result }}" == "failure" || "${{ needs.typecheck.result }}" == "failure" || "${{ needs.frontend_test.result }}" == "failure" || "${{ needs.test.result }}" == "failure" ]]; then
+          if [[ "${{ needs.scan_ruby.result }}" == "failure" || "${{ needs.scan_dependencies.result }}" == "failure" || "${{ needs.scan_js.result }}" == "failure" || "${{ needs.lint.result }}" == "failure" || "${{ needs.frontend_lint.result }}" == "failure" || "${{ needs.typecheck.result }}" == "failure" || "${{ needs.frontend_test.result }}" == "failure" || "${{ needs.test.result }}" == "failure" || "${{ needs.docker_build.result }}" == "failure" ]]; then
             echo "One or more jobs failed"
             exit 1
           fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,16 +28,27 @@ ENV RAILS_ENV="production" \
 # Throw-away build stage to reduce size of final image
 FROM base AS build
 
-# Install packages needed to build gems
+# Install packages needed to build gems and Node.js
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential git libpq-dev libyaml-dev pkg-config && \
+    apt-get install --no-install-recommends -y build-essential curl git libpq-dev libyaml-dev pkg-config && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+# Install Node.js for Vite (vite_rails hooks into assets:precompile)
+ARG NODE_VERSION=20.19.0
+ENV PATH=/usr/local/node/bin:$PATH
+RUN curl -fsSL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz -C /tmp/ && \
+    /tmp/node-build-master/bin/node-build "${NODE_VERSION}" /usr/local/node && \
+    rm -rf /tmp/node-build-master
 
 # Install application gems
 COPY Gemfile Gemfile.lock ./
 RUN bundle install && \
     rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git && \
     bundle exec bootsnap precompile --gemfile
+
+# Install JS deps (vite lives in devDependencies; keep them for the build)
+COPY package.json package-lock.json ./
+RUN npm ci
 
 # Copy application code
 COPY . .
@@ -46,7 +57,10 @@ COPY . .
 RUN bundle exec bootsnap precompile app/ lib/
 
 # Precompiling assets for production without requiring secret RAILS_MASTER_KEY
-RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
+# Skip vite_rails' internal npm install — we already ran npm ci above.
+RUN VITE_RUBY_SKIP_ASSETS_PRECOMPILE_INSTALL=true \
+    SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile && \
+    rm -rf node_modules
 
 
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,8 +47,8 @@ Rails.application.configure do
   config.active_support.report_deprecations = false
 
   # Replace the default in-process memory cache store with a durable alternative.
+  # Database role comes from config/cache.yml (`production.database: cache`).
   config.cache_store = :solid_cache_store
-  config.solid_cache.connects_to = { database: { writing: :cache } }
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
   config.active_job.queue_adapter = :solid_queue

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -150,6 +150,7 @@ bin/validate --fast   # skips Brakeman and Rails tests
 | `rails test:system` | no | `test` |
 | `npm audit` | no | `scan_js` |
 | `bundle-audit` | no | `scan_dependencies` |
+| `docker build .` | no | `docker_build` |
 
 ### Cron jobs
 

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -177,7 +177,7 @@ dev-news-aggregator/
 
 | Path | Purpose |
 |------|---------|
-| `workflows/ci.yml` | CI pipeline (tests, lint, security) |
+| `workflows/ci.yml` | CI pipeline (tests, lint, security, Docker image build) |
 | `workflows/dependabot-auto-merge.yml` | Auto-merge patch/minor Dependabot PRs only after green `quality_gate` |
 | `dependabot.yml` | Dependency update schedule |
 | `pull_request_template.md` | Default PR body checklist |


### PR DESCRIPTION
## Summary
- Add `docker_build` CI job that runs a production `docker build` (Buildx + GHA cache) and gates `quality_gate`
- Fix `Dockerfile` for Vite: install Node 20, `npm ci`, then `assets:precompile` (with `VITE_RUBY_SKIP_ASSETS_PRECOMPILE_INSTALL`)
- Document the new job in DEVELOPMENT / REPO_STRUCTURE

Closes #186

## Test plan
- [ ] CI `docker_build` passes
- [ ] `quality_gate` fails if `docker_build` fails
- [ ] Image includes Vite-built frontend assets