### PR TITLE
feat(ui): show FetchRun status on Sources page (#251)

### DIFF
--- a/app/controllers/sources_controller.rb
+++ b/app/controllers/sources_controller.rb
@@ -59,16 +59,34 @@ class SourcesController < ApplicationController
   end
 
   def sources_json
-    NewsSource.order(:source_type, :name).map { |source| source_json(source) }
+    sources = NewsSource.order(:source_type, :name).to_a
+    runs_by_key = FetchRun.where(source_key: sources.map(&:source_key)).index_by(&:source_key)
+    sources.map { |source| source_json(source, runs_by_key[source.source_key]) }
   end
 
-  def source_json(source)
+  def source_json(source, fetch_run = nil)
+    fetch_run ||= FetchRun.find_by(source_key: source.source_key)
+
     {
       id: source.id,
       name: source.name,
       source_type: source.source_type,
       subreddit: source.subreddit,
-      active: source.active
+      active: source.active,
+      last_fetch: last_fetch_json(fetch_run)
+    }
+  end
+
+  def last_fetch_json(fetch_run)
+    return nil unless fetch_run
+
+    {
+      status: fetch_run.status,
+      finished_at: fetch_run.finished_at,
+      articles_count: fetch_run.articles_count,
+      duration_seconds: fetch_run.duration_seconds,
+      error_class: fetch_run.error_class,
+      error_message: fetch_run.error_message
     }
   end
 end

--- a/app/frontend/api/sources.ts
+++ b/app/frontend/api/sources.ts
@@ -1,11 +1,21 @@
 import { apiRequest } from './client'
 
+export interface SourceLastFetch {
+  status: 'success' | 'failure'
+  finished_at: string
+  articles_count: number
+  duration_seconds: number | null
+  error_class: string | null
+  error_message: string | null
+}
+
 export interface NewsSource {
   id: number
   name: string
   source_type: 'hacker_news' | 'dev_to' | 'reddit'
   subreddit: string | null
   active: boolean
+  last_fetch: SourceLastFetch | null
 }
 
 export interface SourcesIndexResponse {

--- a/app/frontend/pages/SourcesIndexPage.test.tsx
+++ b/app/frontend/pages/SourcesIndexPage.test.tsx
@@ -66,6 +66,55 @@ describe('SourcesIndexPage', () => {
     expect(screen.getByTestId('source-toggle-dev_to')).not.toBeChecked()
   })
 
+  it('shows last fetch status badges and failure messages', async () => {
+    vi.mocked(sourcesApi.fetchSources).mockResolvedValue(
+      buildSourcesIndexResponse({
+        sources: [
+          buildNewsSource({
+            last_fetch: {
+              status: 'success',
+              finished_at: new Date(Date.now() - 5 * 60_000).toISOString(),
+              articles_count: 10,
+              duration_seconds: 1.2,
+              error_class: null,
+              error_message: null,
+            },
+          }),
+          buildNewsSource({
+            id: 2,
+            name: 'DEV.to',
+            source_type: 'dev_to',
+            active: false,
+            last_fetch: null,
+          }),
+          buildNewsSource({
+            id: 3,
+            name: 'rust',
+            source_type: 'reddit',
+            subreddit: 'rust',
+            active: true,
+            last_fetch: {
+              status: 'failure',
+              finished_at: new Date(Date.now() - 60_000).toISOString(),
+              articles_count: 0,
+              duration_seconds: 0.4,
+              error_class: 'StandardError',
+              error_message: 'rate limited',
+            },
+          }),
+        ],
+      })
+    )
+
+    renderPage()
+    await waitForSourcesPage()
+
+    expect(screen.getByText('Ok')).toBeInTheDocument()
+    expect(screen.getByText('Error')).toBeInTheDocument()
+    expect(screen.getByText('Never fetched')).toBeInTheDocument()
+    expect(screen.getByTestId('source-fetch-error')).toHaveTextContent('rate limited')
+  })
+
   it('shows an error when sources fail to load', async () => {
     vi.mocked(sourcesApi.fetchSources).mockRejectedValue(new Error('network'))
 

--- a/app/frontend/pages/SourcesIndexPage.tsx
+++ b/app/frontend/pages/SourcesIndexPage.tsx
@@ -5,8 +5,10 @@ import {
   removeSource,
   updateSource,
   type NewsSource,
+  type SourceLastFetch,
 } from '../api/sources'
 import { useConfirmDialog } from '../hooks/useConfirmDialog'
+import Badge from '../components/ui/Badge'
 import Button from '../components/ui/Button'
 import Card from '../components/ui/Card'
 import PageContainer from '../components/ui/PageContainer'
@@ -14,12 +16,43 @@ import Breadcrumbs from '../components/Breadcrumbs'
 import { sourcesBreadcrumbs } from '../components/breadcrumbTrails'
 import SourcesIndexSkeleton from '../components/SourcesIndexSkeleton'
 import PageHeading from '../components/ui/PageHeading'
+import { formatTimeAgo } from '../utils/format'
 
 function sourceLabel(source: NewsSource): string {
   if (source.source_type === 'reddit') {
     return `r/${source.subreddit ?? source.name}`
   }
   return source.name
+}
+
+function SourceFetchStatus({ lastFetch }: { lastFetch: SourceLastFetch | null }) {
+  if (!lastFetch) {
+    return (
+      <p className="text-caption text-gray-500 mt-1" data-testid="source-fetch-status">
+        Never fetched
+      </p>
+    )
+  }
+
+  const ok = lastFetch.status === 'success'
+
+  return (
+    <div className="mt-1 space-y-1" data-testid="source-fetch-status">
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge variant={ok ? 'green' : 'red'} size="sm">
+          {ok ? 'Ok' : 'Error'}
+        </Badge>
+        <span className="text-caption text-gray-500">
+          Last fetch {formatTimeAgo(lastFetch.finished_at)}
+        </span>
+      </div>
+      {!ok && lastFetch.error_message && (
+        <p className="text-caption text-red-400" data-testid="source-fetch-error">
+          {lastFetch.error_message}
+        </p>
+      )}
+    </div>
+  )
 }
 
 export default function SourcesIndexPage() {
@@ -116,9 +149,12 @@ export default function SourcesIndexPage() {
         <h2 className="text-h3 text-gray-200 mb-4">Built-in sources</h2>
         <div className="space-y-3">
           {fixedSources.map((source) => (
-            <div key={source.id} className="flex items-center justify-between py-3 border-b border-dark-700 last:border-0">
-              <span className="text-gray-200 font-medium">{sourceLabel(source)}</span>
-              <label className="flex items-center gap-2 text-sm text-gray-400 cursor-pointer">
+            <div key={source.id} className="flex items-center justify-between gap-4 py-3 border-b border-dark-700 last:border-0">
+              <div className="min-w-0">
+                <span className="text-gray-200 font-medium">{sourceLabel(source)}</span>
+                <SourceFetchStatus lastFetch={source.last_fetch} />
+              </div>
+              <label className="flex items-center gap-2 text-sm text-gray-400 cursor-pointer shrink-0">
                 <input
                   type="checkbox"
                   className="rounded border-dark-600 bg-dark-800 text-primary-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
@@ -156,9 +192,12 @@ export default function SourcesIndexPage() {
 
         <div className="space-y-3">
           {redditSources.map((source) => (
-            <div key={source.id} className="flex items-center justify-between py-3 border-b border-dark-700 last:border-0">
-              <span className="text-gray-200">r/{source.subreddit ?? source.name}</span>
-              <div className="flex items-center gap-4">
+            <div key={source.id} className="flex items-center justify-between gap-4 py-3 border-b border-dark-700 last:border-0">
+              <div className="min-w-0">
+                <span className="text-gray-200">r/{source.subreddit ?? source.name}</span>
+                <SourceFetchStatus lastFetch={source.last_fetch} />
+              </div>
+              <div className="flex items-center gap-4 shrink-0">
                 <label className="flex items-center gap-2 text-sm text-gray-400 cursor-pointer">
                   <input
                     type="checkbox"

--- a/app/frontend/test/fixtures.ts
+++ b/app/frontend/test/fixtures.ts
@@ -108,6 +108,7 @@ export function buildNewsSource(overrides: Partial<NewsSource> = {}): NewsSource
     source_type: 'hacker_news',
     subreddit: null,
     active: true,
+    last_fetch: null,
     ...overrides,
   }
 }

--- a/app/models/news_source.rb
+++ b/app/models/news_source.rb
@@ -32,6 +32,11 @@ class NewsSource < ApplicationRecord
     config["subreddit"]
   end
 
+  # Matches NewsFetchers::*#source_key used by FetchRun rows.
+  def source_key
+    source_type == "reddit" ? "reddit_#{subreddit}" : source_type
+  end
+
   def build_fetcher
     case source_type
     when "hacker_news"

--- a/test/controllers/sources_controller_test.rb
+++ b/test/controllers/sources_controller_test.rb
@@ -14,6 +14,40 @@ class SourcesControllerTest < ActionDispatch::IntegrationTest
     assert json["sources"].any? { |source| source["source_type"] == "hacker_news" }
   end
 
+  test "index JSON includes last_fetch for sources with FetchRun" do
+    FetchRun.record_outcome(
+      source_key: "hacker_news",
+      status: "success",
+      articles_count: 12,
+      duration_seconds: 1.5
+    )
+
+    FetchRun.record_outcome(
+      source_key: "reddit_rust",
+      status: "failure",
+      articles_count: 0,
+      error: StandardError.new("rate limited")
+    )
+
+    get sources_url, as: :json
+    assert_response :success
+
+    sources = JSON.parse(response.body)["sources"]
+    hn = sources.find { |source| source["source_type"] == "hacker_news" }
+    rust = sources.find { |source| source["subreddit"] == "rust" }
+    never_fetched = sources.find { |source| source["source_type"] == "dev_to" }
+
+    assert_equal "success", hn["last_fetch"]["status"]
+    assert_equal 12, hn["last_fetch"]["articles_count"]
+    assert_not_nil hn["last_fetch"]["finished_at"]
+
+    assert_equal "failure", rust["last_fetch"]["status"]
+    assert_equal "rate limited", rust["last_fetch"]["error_message"]
+    assert_equal "StandardError", rust["last_fetch"]["error_class"]
+
+    assert_nil never_fetched["last_fetch"]
+  end
+
   test "should toggle source active state" do
     patch source_url(@reddit_source), params: { active: false }, as: :json
     assert_response :success

--- a/test/models/news_source_test.rb
+++ b/test/models/news_source_test.rb
@@ -24,6 +24,12 @@ class NewsSourceTest < ActiveSupport::TestCase
     assert_equal "rust", fetcher.instance_variable_get(:@subreddit)
   end
 
+  test "source_key matches fetcher keys" do
+    assert_equal "hacker_news", news_sources(:hacker_news).source_key
+    assert_equal "dev_to", news_sources(:dev_to).source_key
+    assert_equal "reddit_rust", news_sources(:reddit_rust).source_key
+  end
+
   test "bootstrap_defaults creates default sources" do
     NewsSource.delete_all
     NewsSource.bootstrap_defaults!


### PR DESCRIPTION
## Summary
- Nest `last_fetch` (status, finished_at, errors) on Sources JSON using existing `FetchRun` rows
- Add `NewsSource#source_key` aligned with fetcher keys
- Show Ok/Error badges, relative time, and failure messages on `SourcesIndexPage`
- API + frontend tests

Closes #251

## Test plan
- [ ] `SourcesController` index includes `last_fetch` for success/failure/never-fetched
- [ ] Sources page shows badges and error text
- [ ] CI `frontend_test` + `test` green