### PR TITLE
feat(api): add full-text article search (#242)

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -112,6 +112,7 @@ class ArticlesController < ApplicationController
     end
 
     scope = apply_score_filter(scope)
+    scope = scope.search(params[:q])
     scope = helpers.apply_category_filter(scope, params[:category]) if apply_category
     scope.includes(:bookmark, :read_article, :dismissed_article)
          .order(published_at: :desc)

--- a/app/frontend/api/articles.ts
+++ b/app/frontend/api/articles.ts
@@ -6,6 +6,7 @@ export function fetchArticles(params?: {
   per_page?: number
   show_read?: boolean
   category?: string
+  q?: string
   min_score?: number
   top_percent?: number
   signal?: AbortSignal
@@ -15,6 +16,7 @@ export function fetchArticles(params?: {
   if (params?.per_page) search.set('per_page', String(params.per_page))
   if (params?.show_read) search.set('show_read', 'true')
   if (params?.category && params.category !== 'all') search.set('category', params.category)
+  if (params?.q?.trim()) search.set('q', params.q.trim())
   if (params?.min_score) search.set('min_score', String(params.min_score))
   if (params?.top_percent) search.set('top_percent', String(params.top_percent))
 

--- a/app/frontend/components/ArticleSearch.tsx
+++ b/app/frontend/components/ArticleSearch.tsx
@@ -1,0 +1,26 @@
+import Card from './ui/Card'
+
+interface ArticleSearchProps {
+  value: string
+  onChange: (value: string) => void
+}
+
+export default function ArticleSearch({ value, onChange }: ArticleSearchProps) {
+  return (
+    <Card tone="subtle" className="mb-8">
+      <label htmlFor="article-search" className="text-h3 text-gray-100 mb-4 block">
+        Search articles
+      </label>
+      <input
+        id="article-search"
+        type="search"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder="Search by title or description"
+        className="w-full px-4 py-2 bg-dark-800 border border-dark-700 rounded-xl text-gray-200 placeholder-gray-500 focus-visible:outline-none focus-visible:border-primary-500 focus-visible:ring-2 focus-visible:ring-primary-500"
+        data-testid="article-search-input"
+        autoComplete="off"
+      />
+    </Card>
+  )
+}

--- a/app/frontend/pages/ArticlesIndexPage.test.tsx
+++ b/app/frontend/pages/ArticlesIndexPage.test.tsx
@@ -109,6 +109,57 @@ describe('ArticlesIndexPage dismiss flow', () => {
     })
   })
 
+  it('requests search results when q is in the URL', async () => {
+    const filtered = buildArticlesIndexResponse({
+      articles: [buildArticle()],
+      articles_by_category: { 'Programming Languages': [1] },
+      category_counts: { 'Programming Languages': 1 },
+      pagination: {
+        current_page: 1,
+        per_page: 20,
+        total_count: 1,
+        total_pages: 1,
+      },
+    })
+    vi.mocked(articlesApi.fetchArticles).mockResolvedValue(filtered)
+
+    renderPage(['/articles?q=Rust'])
+
+    await waitForArticlesFeed()
+    expect(articlesApi.fetchArticles).toHaveBeenCalledWith(
+      expect.objectContaining({ q: 'Rust' })
+    )
+    expect(screen.getByTestId('article-search-input')).toHaveValue('Rust')
+  })
+
+  it('shows an empty search state when no articles match', async () => {
+    vi.mocked(articlesApi.fetchArticles).mockResolvedValue(
+      buildArticlesIndexResponse({
+        articles: [],
+        articles_by_category: {},
+        category_counts: {},
+        pagination: {
+          current_page: 1,
+          per_page: 20,
+          total_count: 0,
+          total_pages: 0,
+        },
+      })
+    )
+
+    renderPage(['/articles?q=zzzz-no-match'])
+
+    await screen.findByTestId('articles-page')
+    await waitFor(() => {
+      expect(articlesApi.fetchArticles).toHaveBeenCalledWith(
+        expect.objectContaining({ q: 'zzzz-no-match' })
+      )
+    })
+    expect(screen.getByText('No articles match your search')).toBeInTheDocument()
+    expect(screen.queryByText('Your feed is empty')).not.toBeInTheDocument()
+    expect(screen.getByTestId('article-search-input')).toHaveValue('zzzz-no-match')
+  })
+
   it('counts down dismiss toast and removes article after timeout', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true })
     const user = userEvent.setup()

--- a/app/frontend/pages/ArticlesIndexPage.tsx
+++ b/app/frontend/pages/ArticlesIndexPage.tsx
@@ -16,8 +16,10 @@ import type { ArticlesIndexResponse } from '../types/article'
 import { parameterize, truncate } from '../utils/format'
 import ArticleList from '../components/ArticleList'
 import ArticleListSkeleton from '../components/ArticleListSkeleton'
+import ArticleSearch from '../components/ArticleSearch'
 import CategoryFilter from '../components/CategoryFilter'
 import DismissToast from '../components/DismissToast'
+import EmptyState from '../components/EmptyState'
 import PageHeader from '../components/PageHeader'
 import PageHeaderSkeleton from '../components/PageHeaderSkeleton'
 import PageContainer from '../components/ui/PageContainer'
@@ -25,6 +27,8 @@ import Card from '../components/ui/Card'
 import PaginationControls from '../components/PaginationControls'
 import ScoreFilter, { parseScoreFilter, scoreFilterParams, type ScoreFilterValue } from '../components/ScoreFilter'
 import { usePatchSearchParams } from '../hooks/useSearchParamState'
+
+const SEARCH_DEBOUNCE_MS = 300
 
 const DISMISS_TIMEOUT_SECONDS = 15
 
@@ -50,7 +54,9 @@ export default function ArticlesIndexPage() {
   const activeFilter = searchParams.get('category') ?? 'all'
   const activeScoreFilter = parseScoreFilter(searchParams.get('score'))
   const showRead = searchParams.get('show_read') === 'true'
+  const searchQuery = (searchParams.get('q') ?? '').trim()
 
+  const [searchInput, setSearchInput] = useState(searchQuery)
   const [data, setData] = useState<ArticlesIndexResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -69,6 +75,25 @@ export default function ArticlesIndexPage() {
     toastRef.current = toast
   }, [toast])
 
+  useEffect(() => {
+    setSearchInput(searchQuery)
+  }, [searchQuery])
+
+  useEffect(() => {
+    const trimmed = searchInput.trim()
+    if (trimmed === searchQuery) return
+
+    const timeoutId = window.setTimeout(() => {
+      patchSearchParams((params) => {
+        if (trimmed) params.set('q', trimmed)
+        else params.delete('q')
+        params.delete('page')
+      })
+    }, SEARCH_DEBOUNCE_MS)
+
+    return () => window.clearTimeout(timeoutId)
+  }, [searchInput, searchQuery, patchSearchParams])
+
   const loadArticles = useCallback(async (options?: { page?: number }) => {
     abortRef.current?.abort()
     const controller = new AbortController()
@@ -83,6 +108,7 @@ export default function ArticlesIndexPage() {
         page,
         show_read: showRead,
         category: activeFilter !== 'all' ? activeFilter : undefined,
+        q: searchQuery || undefined,
         ...scoreFilterParams(activeScoreFilter),
         signal,
       })
@@ -101,7 +127,7 @@ export default function ArticlesIndexPage() {
     } finally {
       if (!signal.aborted) setLoading(false)
     }
-  }, [showRead, activeScoreFilter, activeFilter, currentPage, patchSearchParams])
+  }, [showRead, activeScoreFilter, activeFilter, searchQuery, currentPage, patchSearchParams])
 
   useEffect(() => {
     void loadArticles()
@@ -333,7 +359,9 @@ export default function ArticlesIndexPage() {
     )
   }
 
-  const showEmptyFeed = !data || (allArticlesCount === 0 && articles.length === 0)
+  const showEmptyFeed = !data || (!searchQuery && allArticlesCount === 0 && articles.length === 0)
+  const showNoSearchResults =
+    Boolean(searchQuery) && articles.length === 0 && (data?.pagination.total_count ?? 0) === 0
 
   if (showEmptyFeed) {
     return (
@@ -387,6 +415,8 @@ export default function ArticlesIndexPage() {
         <div className="mb-4 text-sm text-red-400">{error}</div>
       )}
 
+      <ArticleSearch value={searchInput} onChange={setSearchInput} />
+
       <ScoreFilter
         activeScoreFilter={activeScoreFilter}
         onScoreFilterChange={handleScoreFilterChange}
@@ -400,23 +430,42 @@ export default function ArticlesIndexPage() {
         onFilterChange={handleFilterChange}
       />
 
-      <ArticleList
-        articles={articles}
-        articleCategories={articleCategories}
-        dismissingIds={dismissingIds}
-        onDismiss={handleDismiss}
-        onUndoDismiss={handleUndoDismiss}
-        onBookmarkToggle={handleBookmarkToggle}
-        onReadToggle={handleReadToggle}
-      />
+      {showNoSearchResults ? (
+        <EmptyState
+          icon={
+            <svg className="w-10 h-10 text-primary-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+              />
+            </svg>
+          }
+          title="No articles match your search"
+          description={`Nothing matched “${searchQuery}”. Try a different term or clear the search.`}
+        />
+      ) : (
+        <>
+          <ArticleList
+            articles={articles}
+            articleCategories={articleCategories}
+            dismissingIds={dismissingIds}
+            onDismiss={handleDismiss}
+            onUndoDismiss={handleUndoDismiss}
+            onBookmarkToggle={handleBookmarkToggle}
+            onReadToggle={handleReadToggle}
+          />
 
-      <PaginationControls
-        currentPage={data.pagination.current_page}
-        totalPages={data.pagination.total_pages}
-        totalCount={data.pagination.total_count}
-        perPage={data.pagination.per_page}
-        onPageChange={handlePageChange}
-      />
+          <PaginationControls
+            currentPage={data.pagination.current_page}
+            totalPages={data.pagination.total_pages}
+            totalCount={data.pagination.total_count}
+            perPage={data.pagination.per_page}
+            onPageChange={handlePageChange}
+          />
+        </>
+      )}
 
       {toast && (
         <DismissToast

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -14,6 +14,15 @@ class Article < ApplicationRecord
   scope :not_dismissed, -> { left_joins(:dismissed_article).where("dismissed_articles.id IS NULL OR dismissed_articles.permanent = false") }
   scope :dismissed, -> { joins(:dismissed_article).where(dismissed_articles: { permanent: true }) }
   scope :pending_dismissal, -> { joins(:dismissed_article).where(dismissed_articles: { permanent: false }) }
+  scope :search, ->(query) {
+    q = query.to_s.strip
+    if q.blank?
+      all
+    else
+      pattern = "%#{sanitize_sql_like(q)}%"
+      where("title ILIKE :q OR COALESCE(description, '') ILIKE :q", q: pattern)
+    end
+  }
 
   def bookmarked?
     bookmark.present?

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -67,6 +67,59 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
     assert_not_includes scores, @dev_to_article.score
   end
 
+  test "index JSON should filter by q on title and description" do
+    get articles_url(q: "Rust"), as: :json
+    assert_response :success
+
+    body = JSON.parse(response.body)
+    titles = body["articles"].map { |article| article["title"] }
+    assert_includes titles, @rust_article.title
+    assert_not_includes titles, @article.title
+    assert_equal body["articles"].size, body["pagination"]["total_count"]
+    assert body["pagination"]["total_count"].positive?
+  end
+
+  test "index JSON q filter paginates across the filtered dataset" do
+    5.times do |i|
+      Article.create!(
+        title: "Extra Rust #{i}",
+        url: "https://example.com/search-rust-#{i}",
+        external_id: "search-rust-#{i}",
+        source_type: "reddit_rust",
+        published_at: i.hours.ago,
+        score: 10,
+        comment_count: 0,
+        description: "Rust search fixture"
+      )
+    end
+
+    get articles_url(q: "Rust", page: 1, per_page: 2), as: :json
+    assert_response :success
+    page_one = JSON.parse(response.body)
+
+    get articles_url(q: "Rust", page: 2, per_page: 2), as: :json
+    assert_response :success
+    page_two = JSON.parse(response.body)
+
+    assert_equal 2, page_one["articles"].size
+    assert_operator page_two["articles"].size, :>=, 1
+    assert_equal page_one["pagination"]["total_count"], page_two["pagination"]["total_count"]
+    assert_operator page_one["pagination"]["total_pages"], :>=, 2
+
+    page_one_ids = page_one["articles"].map { |article| article["id"] }
+    page_two_ids = page_two["articles"].map { |article| article["id"] }
+    assert_empty page_one_ids & page_two_ids
+  end
+
+  test "index JSON returns empty results for unmatched q" do
+    get articles_url(q: "zzzz-no-such-article"), as: :json
+    assert_response :success
+
+    body = JSON.parse(response.body)
+    assert_empty body["articles"]
+    assert_equal 0, body["pagination"]["total_count"]
+  end
+
   test "index JSON should filter by top_percent" do
     get articles_url(top_percent: 50), as: :json
     assert_response :success

--- a/test/models/article_test.rb
+++ b/test/models/article_test.rb
@@ -331,4 +331,34 @@ class ArticleTest < ActiveSupport::TestCase
     assert_not article.valid?
     assert_includes article.errors[:url], "is invalid"
   end
+
+  test "search returns all articles when query is blank" do
+    assert_equal Article.count, Article.search("").count
+    assert_equal Article.count, Article.search("   ").count
+    assert_equal Article.count, Article.search(nil).count
+  end
+
+  test "search matches title and description case-insensitively" do
+    titles = Article.search("rust").pluck(:title)
+    assert_includes titles, articles(:reddit_rust_article).title
+    assert_not_includes titles, articles(:hacker_news_article).title
+
+    titles = Article.search("cleaner").pluck(:title)
+    assert_includes titles, articles(:dev_to_article).title
+  end
+
+  test "search escapes LIKE wildcards in the query" do
+    Article.create!(
+      title: "100% coverage tips",
+      url: "https://example.com/coverage",
+      external_id: "coverage-percent",
+      source_type: "hacker_news",
+      published_at: Time.current,
+      description: "literal percent"
+    )
+
+    titles = Article.search("100%").pluck(:title)
+    assert_includes titles, "100% coverage tips"
+    assert_equal 1, titles.size
+  end
 end


### PR DESCRIPTION
## Summary
- Add `Article.search` ILIKE scope on title/description and wire `q` into `ArticlesController#index` (composes with score, category, pagination)
- Add search input on the React articles index with debounced URL `?q=` and a distinct no-results empty state
- Cover with model, controller, and Vitest page tests

Closes #242

## Test plan
- [ ] `GET /articles.json?q=Rust` returns matching articles and correct `pagination.total_count`
- [ ] Blank `q` leaves the feed unfiltered
- [ ] Search + pagination returns disjoint pages over the filtered set
- [ ] Articles index shows search box; unmatched query shows "No articles match your search" (not Fetch News empty feed)
- [ ] CI green (Rails tests + npm test)