### PR TITLE
feat(api): add article list sort options (#243)

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -3,6 +3,12 @@ class ArticlesController < ApplicationController
 
   FETCH_RATE_LIMIT = 2.minutes
 
+  ALLOWED_SORTS = {
+    "published_at" => { published_at: :desc },
+    "score" => Arel.sql("score DESC NULLS LAST, published_at DESC"),
+    "comment_count" => Arel.sql("comment_count DESC NULLS LAST, published_at DESC")
+  }.freeze
+
   def index
     @show_read = params[:show_read] == "true"
     page, per_page = pagination_params
@@ -114,8 +120,12 @@ class ArticlesController < ApplicationController
     scope = apply_score_filter(scope)
     scope = scope.search(params[:q])
     scope = helpers.apply_category_filter(scope, params[:category]) if apply_category
-    scope.includes(:bookmark, :read_article, :dismissed_article)
-         .order(published_at: :desc)
+    apply_sort(scope.includes(:bookmark, :read_article, :dismissed_article))
+  end
+
+  def apply_sort(scope)
+    key = params[:sort].presence_in(ALLOWED_SORTS.keys) || "published_at"
+    scope.order(ALLOWED_SORTS[key])
   end
 
   def apply_score_filter(scope)

--- a/app/frontend/api/articles.ts
+++ b/app/frontend/api/articles.ts
@@ -7,6 +7,7 @@ export function fetchArticles(params?: {
   show_read?: boolean
   category?: string
   q?: string
+  sort?: string
   min_score?: number
   top_percent?: number
   signal?: AbortSignal
@@ -17,6 +18,7 @@ export function fetchArticles(params?: {
   if (params?.show_read) search.set('show_read', 'true')
   if (params?.category && params.category !== 'all') search.set('category', params.category)
   if (params?.q?.trim()) search.set('q', params.q.trim())
+  if (params?.sort && params.sort !== 'published_at') search.set('sort', params.sort)
   if (params?.min_score) search.set('min_score', String(params.min_score))
   if (params?.top_percent) search.set('top_percent', String(params.top_percent))
 

--- a/app/frontend/components/SortControl.tsx
+++ b/app/frontend/components/SortControl.tsx
@@ -1,0 +1,46 @@
+import Button from './ui/Button'
+import Card from './ui/Card'
+
+export type SortValue = 'published_at' | 'score' | 'comment_count'
+
+interface SortControlProps {
+  activeSort: SortValue
+  onSortChange: (value: SortValue) => void
+}
+
+const OPTIONS: { value: SortValue; label: string }[] = [
+  { value: 'published_at', label: 'Newest' },
+  { value: 'score', label: 'Highest score' },
+  { value: 'comment_count', label: 'Most comments' },
+]
+
+const SORT_VALUES: SortValue[] = OPTIONS.map((option) => option.value)
+
+export default function SortControl({ activeSort, onSortChange }: SortControlProps) {
+  return (
+    <Card tone="subtle" className="mb-8">
+      <h2 className="text-h3 text-gray-100 mb-4">Sort by</h2>
+      <div className="flex flex-wrap gap-3">
+        {OPTIONS.map((option) => (
+          <Button
+            key={option.value}
+            variant="filter"
+            active={activeSort === option.value}
+            data-sort={option.value}
+            aria-pressed={activeSort === option.value}
+            onClick={() => onSortChange(option.value)}
+          >
+            {option.label}
+          </Button>
+        ))}
+      </div>
+    </Card>
+  )
+}
+
+export function parseSort(value: string | null): SortValue {
+  if (value && SORT_VALUES.includes(value as SortValue)) {
+    return value as SortValue
+  }
+  return 'published_at'
+}

--- a/app/frontend/pages/ArticlesIndexPage.test.tsx
+++ b/app/frontend/pages/ArticlesIndexPage.test.tsx
@@ -132,6 +132,30 @@ describe('ArticlesIndexPage dismiss flow', () => {
     expect(screen.getByTestId('article-search-input')).toHaveValue('Rust')
   })
 
+  it('requests sorted articles when sort is in the URL', async () => {
+    renderPage(['/articles?sort=score'])
+
+    await waitForArticlesFeed()
+    expect(articlesApi.fetchArticles).toHaveBeenCalledWith(
+      expect.objectContaining({ sort: 'score' })
+    )
+    expect(screen.getByRole('button', { name: 'Highest score' })).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('updates sort via the sort control', async () => {
+    const user = userEvent.setup()
+    renderPage()
+
+    await waitForArticlesFeed()
+    await user.click(screen.getByRole('button', { name: 'Most comments' }))
+
+    await waitFor(() => {
+      expect(articlesApi.fetchArticles).toHaveBeenCalledWith(
+        expect.objectContaining({ sort: 'comment_count' })
+      )
+    })
+  })
+
   it('shows an empty search state when no articles match', async () => {
     vi.mocked(articlesApi.fetchArticles).mockResolvedValue(
       buildArticlesIndexResponse({

--- a/app/frontend/pages/ArticlesIndexPage.tsx
+++ b/app/frontend/pages/ArticlesIndexPage.tsx
@@ -26,6 +26,7 @@ import PageContainer from '../components/ui/PageContainer'
 import Card from '../components/ui/Card'
 import PaginationControls from '../components/PaginationControls'
 import ScoreFilter, { parseScoreFilter, scoreFilterParams, type ScoreFilterValue } from '../components/ScoreFilter'
+import SortControl, { parseSort, type SortValue } from '../components/SortControl'
 import { usePatchSearchParams } from '../hooks/useSearchParamState'
 
 const SEARCH_DEBOUNCE_MS = 300
@@ -53,6 +54,7 @@ export default function ArticlesIndexPage() {
   })()
   const activeFilter = searchParams.get('category') ?? 'all'
   const activeScoreFilter = parseScoreFilter(searchParams.get('score'))
+  const activeSort = parseSort(searchParams.get('sort'))
   const showRead = searchParams.get('show_read') === 'true'
   const searchQuery = (searchParams.get('q') ?? '').trim()
 
@@ -109,6 +111,7 @@ export default function ArticlesIndexPage() {
         show_read: showRead,
         category: activeFilter !== 'all' ? activeFilter : undefined,
         q: searchQuery || undefined,
+        sort: activeSort,
         ...scoreFilterParams(activeScoreFilter),
         signal,
       })
@@ -127,7 +130,7 @@ export default function ArticlesIndexPage() {
     } finally {
       if (!signal.aborted) setLoading(false)
     }
-  }, [showRead, activeScoreFilter, activeFilter, searchQuery, currentPage, patchSearchParams])
+  }, [showRead, activeScoreFilter, activeFilter, activeSort, searchQuery, currentPage, patchSearchParams])
 
   useEffect(() => {
     void loadArticles()
@@ -240,6 +243,14 @@ export default function ArticlesIndexPage() {
     patchSearchParams((params) => {
       if (value === 'all') params.delete('score')
       else params.set('score', value)
+      params.delete('page')
+    })
+  }
+
+  const handleSortChange = (value: SortValue) => {
+    patchSearchParams((params) => {
+      if (value === 'published_at') params.delete('sort')
+      else params.set('sort', value)
       params.delete('page')
     })
   }
@@ -420,6 +431,11 @@ export default function ArticlesIndexPage() {
       <ScoreFilter
         activeScoreFilter={activeScoreFilter}
         onScoreFilterChange={handleScoreFilterChange}
+      />
+
+      <SortControl
+        activeSort={activeSort}
+        onSortChange={handleSortChange}
       />
 
       <CategoryFilter

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -120,6 +120,49 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 0, body["pagination"]["total_count"]
   end
 
+  test "index JSON sorts by published_at desc by default" do
+    get articles_url, as: :json
+    assert_response :success
+
+    published_ats = JSON.parse(response.body)["articles"].map { |article| article["published_at"] }
+    assert_equal published_ats, published_ats.sort.reverse
+  end
+
+  test "index JSON sorts by score descending" do
+    get articles_url(sort: "score"), as: :json
+    assert_response :success
+
+    scores = JSON.parse(response.body)["articles"].map { |article| article["score"] }
+    assert_equal scores, scores.sort.reverse
+    assert_operator scores.first, :>=, @dev_to_article.score
+  end
+
+  test "index JSON sorts by comment_count descending" do
+    get articles_url(sort: "comment_count"), as: :json
+    assert_response :success
+
+    counts = JSON.parse(response.body)["articles"].map { |article| article["comment_count"] }
+    assert_equal counts, counts.sort.reverse
+  end
+
+  test "index JSON falls back to published_at for invalid sort" do
+    get articles_url(sort: "not_a_column"), as: :json
+    assert_response :success
+
+    published_ats = JSON.parse(response.body)["articles"].map { |article| article["published_at"] }
+    assert_equal published_ats, published_ats.sort.reverse
+  end
+
+  test "index JSON sort composes with q and pagination" do
+    get articles_url(sort: "score", q: "Rust", page: 1, per_page: 1), as: :json
+    assert_response :success
+
+    body = JSON.parse(response.body)
+    assert_equal 1, body["articles"].size
+    assert body["pagination"]["total_count"].positive?
+    assert_includes body["articles"].first["title"], "Rust"
+  end
+
   test "index JSON should filter by top_percent" do
     get articles_url(top_percent: 50), as: :json
     assert_response :success


### PR DESCRIPTION
## Summary
- Add whitelisted `sort` param on articles index (`published_at`, `score`, `comment_count`) with NULLS LAST secondary `published_at`
- Add SortControl UI on the React articles index; persists in `?sort=` and resets page
- Controller + Vitest coverage for default, score, comment_count, invalid fallback, and composition with `q`/pagination

Closes #243

## Test plan
- [ ] Default feed still newest-first
- [ ] `?sort=score` and Highest score button order by score
- [ ] `?sort=comment_count` orders by comments
- [ ] Invalid sort falls back to newest
- [ ] Sort works with search/score/category filters and pagination
- [ ] CI green