### PR TITLE
security: enable CSP and config.hosts for production (#248)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,10 @@ POSTGRES_DB=dev_news_aggregator_development
 RAILS_ENV=development
 SECRET_KEY_BASE=your_secret_key_base_here
 
+# Production host authorization (config/environments/production.rb).
+# Comma-separated list; must match the public hostname(s) and Kamal proxy.host.
+# APP_HOSTS=app.example.com
+
 # Optional: API Keys (if needed in future)
 # HACKER_NEWS_API_KEY=
 # DEVTO_API_KEY=

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -40,6 +40,9 @@ env:
     # When you start using multiple servers, you should split out job processing to a dedicated machine.
     SOLID_QUEUE_IN_PUMA: true
 
+    # Allowed Host headers (comma-separated). Must include proxy.host above.
+    APP_HOSTS: app.example.com
+
     # Set number of processes dedicated to Solid Queue (default: 1)
     # JOB_CONCURRENCY: 3
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,11 +81,9 @@ Rails.application.configure do
   config.active_record.attributes_for_inspect = [ :id ]
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
-  #
+  # Comma-separated hosts, e.g. APP_HOSTS=app.example.com,www.example.com
+  config.hosts = ENV.fetch("APP_HOSTS", "app.example.com").split(",").map(&:strip)
+
   # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,25 +1,29 @@
 # Be sure to restart your server when you modify this file.
 
-# Define an application-wide content security policy.
-# See the Securing Rails Applications Guide for more information:
-# https://guides.rubyonrails.org/security.html#content-security-policy-header
+# Content Security Policy for the React/Vite shell + same-origin Rails API.
+# See https://guides.rubyonrails.org/security.html#content-security-policy-header
+#
+# Nonces are not required in production: Vite emits external module scripts and
+# stylesheets under /vite (script-src/style-src 'self'). React style={{}} attributes
+# need style-src 'unsafe-inline' (nonces do not cover style attributes).
+# Enable a nonce_generator only if you add inline <script> tags or Vite refresh tags.
+#
+# CSP is skipped in development so Vite HMR (localhost:3036 / websockets) keeps working.
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src style-src)
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+Rails.application.configure do
+  next if Rails.env.development?
+
+  config.content_security_policy do |policy|
+    policy.default_src :self
+    policy.font_src    :self, :data
+    policy.img_src     :self, :https, :data
+    policy.object_src  :none
+    policy.script_src  :self
+    policy.style_src   :self, :unsafe_inline
+    policy.connect_src :self
+    policy.worker_src  :self
+    policy.base_uri    :self
+    policy.form_action :self
+    policy.frame_ancestors :none
+  end
+end

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -272,6 +272,25 @@ Copy `.env.example` to `.env` before starting the stack. Docker Compose reads it
 3. Use consistent `source_type` naming pattern
 4. Update category grouping in `articles_helper.rb` if needed
 
+## Production security (CSP and hosts)
+
+### Content Security Policy
+
+`config/initializers/content_security_policy.rb` enables CSP in **production and test** (not development, so Vite HMR keeps working).
+
+| Directive | Value | Why |
+|-----------|--------|-----|
+| `script-src` | `'self'` | Vite ships external `type="module"` scripts under `/vite` |
+| `style-src` | `'self' 'unsafe-inline'` | Bundled CSS plus React `style={{}}` attributes |
+| `connect-src` | `'self'` | Same-origin JSON API (`fetch`) |
+| `worker-src` | `'self'` | PWA service worker |
+
+**Nonces are not required** for the current React shell: there are no inline `<script>` tags. Add `content_security_policy_nonce_generator` only if you introduce inline scripts, importmap, or Vite React Refresh tags under an enforcing CSP.
+
+### Host authorization
+
+Production sets `config.hosts` from `APP_HOSTS` (comma-separated; default `app.example.com`) and excludes `/up` from host checks. Kamal injects `APP_HOSTS` in `config/deploy.yml` — keep it aligned with `proxy.host`.
+
 ## Coding guidelines
 
 ### General principles

--- a/test/integration/content_security_policy_test.rb
+++ b/test/integration/content_security_policy_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class ContentSecurityPolicyTest < ActionDispatch::IntegrationTest
+  test "should send Content-Security-Policy header on HTML responses" do
+    get root_url
+    assert_response :success
+
+    policy = response.headers["Content-Security-Policy"]
+    assert_not_nil policy
+    assert_includes policy, "default-src 'self'"
+    assert_includes policy, "script-src 'self'"
+    assert_includes policy, "style-src 'self' 'unsafe-inline'"
+    assert_includes policy, "connect-src 'self'"
+    assert_includes policy, "frame-ancestors 'none'"
+  end
+
+  test "should keep Vite module scripts allowed under CSP" do
+    get articles_url
+    assert_response :success
+
+    assert_select "script[type='module'][src*='application']"
+    assert_includes response.headers["Content-Security-Policy"], "script-src 'self'"
+  end
+end


### PR DESCRIPTION
## Summary
- Enable Content-Security-Policy in production/test (skip development for Vite HMR) with `script-src 'self'` and `style-src 'self' 'unsafe-inline'` for React style attributes
- Set `config.hosts` from `APP_HOSTS` (Kamal + `.env.example`) and exclude `/up` from host authorization
- Document CSP/nonce and hosts in `docs/DEVELOPMENT.md`; add integration tests for the CSP header

Closes #248

## Test plan
- [ ] CI green (CSP integration tests + existing React shell tests)
- [ ] After deploy: document response includes `Content-Security-Policy`; console clean; React loads
- [ ] `/up` still healthy when probed by IP/load balancer
- [ ] `APP_HOSTS` matches Kamal `proxy.host`