### PR TITLE
security: add Rack::Attack rate limiting for public deployments (#250)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,9 @@ gem "thruster", require: false
 # HTTP client for API requests
 gem "httparty", "~> 0.24"
 
+# Request throttling for public deployments
+gem "rack-attack"
+
 # Cron job scheduling
 gem "whenever", "~> 1.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,6 +222,8 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.6)
+    rack-attack (6.8.0)
+      rack (>= 1.0, < 4)
     rack-proxy (0.8.3)
       rack
     rack-session (2.1.2)
@@ -401,6 +403,7 @@ DEPENDENCIES
   pg (~> 1.6)
   propshaft
   puma (>= 5.0)
+  rack-attack
   rails (~> 8.1.3)
   rexml (>= 3.3.9)
   rubocop-rails-omakase

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,46 @@
+# Be sure to restart your server when you modify this file.
+#
+# Global and mutating-request throttles for public deployments.
+# Skipped in development so local UI usage is never blocked.
+# Complements ArticlesController#fetch (1 request / 2 minutes per IP).
+
+Rack::Attack.enabled = !Rails.env.development?
+
+if Rails.env.test?
+  Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+end
+
+class Rack::Attack
+  GLOBAL_LIMIT = Integer(ENV.fetch("RACK_ATTACK_GLOBAL_LIMIT", "300"))
+  GLOBAL_PERIOD = Integer(ENV.fetch("RACK_ATTACK_GLOBAL_PERIOD", "300"))
+  MUTATE_LIMIT = Integer(ENV.fetch("RACK_ATTACK_MUTATE_LIMIT", "60"))
+  MUTATE_PERIOD = Integer(ENV.fetch("RACK_ATTACK_MUTATE_PERIOD", "60"))
+
+  safelist("healthcheck") do |request|
+    request.path == "/up"
+  end
+
+  throttle("req/ip", limit: GLOBAL_LIMIT, period: GLOBAL_PERIOD) do |request|
+    request.ip
+  end
+
+  throttle("mutations/ip", limit: MUTATE_LIMIT, period: MUTATE_PERIOD) do |request|
+    request.ip if request.post? || request.patch? || request.put? || request.delete?
+  end
+
+  self.throttled_responder = lambda do |request|
+    match_data = request.env["rack.attack.match_data"] || {}
+    now = match_data[:epoch_time] || Time.now.to_i
+    period = match_data[:period] || MUTATE_PERIOD
+    retry_after = period - (now % period)
+
+    [
+      429,
+      {
+        "Content-Type" => "application/json",
+        "Retry-After" => retry_after.to_s
+      },
+      [ { error: "Rate limit exceeded. Please try again later." }.to_json ]
+    ]
+  end
+end

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -272,7 +272,7 @@ Copy `.env.example` to `.env` before starting the stack. Docker Compose reads it
 3. Use consistent `source_type` naming pattern
 4. Update category grouping in `articles_helper.rb` if needed
 
-## Production security (CSP and hosts)
+## Production security (CSP, hosts, and rate limiting)
 
 ### Content Security Policy
 
@@ -290,6 +290,19 @@ Copy `.env.example` to `.env` before starting the stack. Docker Compose reads it
 ### Host authorization
 
 Production sets `config.hosts` from `APP_HOSTS` (comma-separated; default `app.example.com`) and excludes `/up` from host checks. Kamal injects `APP_HOSTS` in `config/deploy.yml` — keep it aligned with `proxy.host`.
+
+### Rate limiting (Rack::Attack)
+
+`config/initializers/rack_attack.rb` enables throttles in **production and test** (disabled in development). Defaults:
+
+| Rule | Scope | Limit | Notes |
+|------|--------|-------|--------|
+| Health check | `GET /up` | unlimited | Safelisted for load balancers |
+| Global | all requests / IP | 300 / 5 minutes | Soft DoS ceiling |
+| Mutations | `POST`/`PATCH`/`PUT`/`DELETE` / IP | 60 / minute | bookmark, dismiss, read, sources |
+| Fetch news | `POST /articles/fetch` | 1 / 2 minutes | Separate controller limit (unchanged) |
+
+Exceeded limits return `429` with JSON `{ "error": "Rate limit exceeded. Please try again later." }` and a `Retry-After` header. Override limits with `RACK_ATTACK_GLOBAL_LIMIT`, `RACK_ATTACK_GLOBAL_PERIOD`, `RACK_ATTACK_MUTATE_LIMIT`, and `RACK_ATTACK_MUTATE_PERIOD` (seconds).
 
 ## Coding guidelines
 

--- a/test/integration/rack_attack_test.rb
+++ b/test/integration/rack_attack_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+class RackAttackTest < ActionDispatch::IntegrationTest
+  setup do
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+    @article = articles(:hacker_news_article)
+  end
+
+  test "should return 429 JSON when mutate throttle is exceeded" do
+    limit = Rack::Attack::MUTATE_LIMIT
+
+    limit.times do
+      post bookmark_article_url(@article), as: :json
+      assert_response :success
+    end
+
+    post bookmark_article_url(@article), as: :json
+    assert_response :too_many_requests
+    assert_equal "application/json", response.media_type
+    assert_equal "Rate limit exceeded. Please try again later.", JSON.parse(response.body)["error"]
+    assert response.headers["Retry-After"].present?
+  end
+
+  test "should not throttle health check endpoint" do
+    (Rack::Attack::MUTATE_LIMIT + 2).times do
+      get rails_health_check_url
+      assert_response :success
+    end
+  end
+
+  test "should allow normal read traffic under global limit" do
+    3.times do
+      get articles_url, as: :json
+      assert_response :success
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -57,5 +57,10 @@ module ActiveSupport
 
     # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
     fixtures :all
+
+    setup do
+      store = Rack::Attack.cache.store
+      store.clear if store.respond_to?(:clear)
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Add `rack-attack` with global (300/5min) and mutation (60/min) per-IP throttles; safelist `/up`
- Return `429` JSON `{ error: ... }` with `Retry-After`; leave `POST /articles/fetch` 2-minute controller limit in place
- Document defaults in `docs/DEVELOPMENT.md`; clear throttle counters between tests; add integration coverage

Closes #250

## Test plan
- [ ] CI green (including `RackAttackTest`)
- [ ] Normal articles UI browsing/bookmarking not blocked under defaults
- [ ] Burst mutating requests past 60/min returns 429 JSON
- [ ] `GET /up` remains unthrottled
- [ ] Development still has Rack::Attack disabled