### PR TITLE
security: authenticate mutating API endpoints (#246)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,11 @@ SECRET_KEY_BASE=your_secret_key_base_here
 # Comma-separated list; must match the public hostname(s) and Kamal proxy.host.
 # APP_HOSTS=app.example.com
 
+# Mutating API HTTP Basic (optional). When both are set, bookmark/dismiss/fetch/sources
+# mutations require Authorization: Basic. Leave unset for open local development.
+# MUTATING_AUTH_USERNAME=admin
+# MUTATING_AUTH_PASSWORD=change-me
+
 # Optional: API Keys (if needed in future)
 # HACKER_NEWS_API_KEY=
 # DEVTO_API_KEY=

--- a/.kamal/secrets
+++ b/.kamal/secrets
@@ -15,3 +15,7 @@ KAMAL_REGISTRY_PASSWORD=$KAMAL_REGISTRY_PASSWORD
 
 # Improve security by using a password manager. Never check config/master.key into git!
 RAILS_MASTER_KEY=$(cat config/master.key)
+
+# Mutating API HTTP Basic (required when deploying publicly)
+# MUTATING_AUTH_USERNAME=$MUTATING_AUTH_USERNAME
+# MUTATING_AUTH_PASSWORD=$MUTATING_AUTH_PASSWORD

--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ The automation runs on all Dependabot PRs for:
 
 No manual intervention needed for routine security patches and minor updates!
 
+## Production security
+
+For public deployments, enable mutating API HTTP Basic via `MUTATING_AUTH_USERNAME` / `MUTATING_AUTH_PASSWORD`, plus CSP, `APP_HOSTS`, and Rack::Attack throttles. Reads stay public; mutations return `401` without credentials. Details: [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md#production-security-csp-hosts-and-rate-limiting).
+
 ## Development
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the contributor entry point, [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) for development guidelines, and [docs/REPO_STRUCTURE.md](docs/REPO_STRUCTURE.md) for the repository map (keep it updated when structure changes).

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,5 +1,6 @@
 class ArticlesController < ApplicationController
   include Pagination
+  include MutatingAuthentication
 
   FETCH_RATE_LIMIT = 2.minutes
 
@@ -8,6 +9,8 @@ class ArticlesController < ApplicationController
     "score" => Arel.sql("score DESC NULLS LAST, published_at DESC"),
     "comment_count" => Arel.sql("comment_count DESC NULLS LAST, published_at DESC")
   }.freeze
+
+  before_action :authenticate_mutation!, only: %i[fetch bookmark unbookmark dismiss undismiss]
 
   def index
     @show_read = params[:show_read] == "true"

--- a/app/controllers/concerns/mutating_authentication.rb
+++ b/app/controllers/concerns/mutating_authentication.rb
@@ -1,0 +1,32 @@
+module MutatingAuthentication
+  extend ActiveSupport::Concern
+
+  private
+
+  def authenticate_mutation!
+    return unless mutating_auth_configured?
+
+    username = ENV.fetch("MUTATING_AUTH_USERNAME")
+    password = ENV.fetch("MUTATING_AUTH_PASSWORD")
+
+    authenticated = authenticate_with_http_basic do |user, pass|
+      secure_credential_match?(user, username) && secure_credential_match?(pass, password)
+    end
+
+    return if authenticated
+
+    response.set_header("WWW-Authenticate", 'Basic realm="Dev News Aggregator"')
+    render json: { error: "Unauthorized" }, status: :unauthorized
+  end
+
+  def mutating_auth_configured?
+    ENV["MUTATING_AUTH_USERNAME"].present? && ENV["MUTATING_AUTH_PASSWORD"].present?
+  end
+
+  def secure_credential_match?(provided, expected)
+    ActiveSupport::SecurityUtils.secure_compare(
+      Digest::SHA256.hexdigest(provided.to_s),
+      Digest::SHA256.hexdigest(expected.to_s)
+    )
+  end
+end

--- a/app/controllers/read_articles_controller.rb
+++ b/app/controllers/read_articles_controller.rb
@@ -1,5 +1,8 @@
 class ReadArticlesController < ApplicationController
   include Pagination
+  include MutatingAuthentication
+
+  before_action :authenticate_mutation!, only: %i[create destroy]
 
   def index
     page, per_page = pagination_params

--- a/app/controllers/sources_controller.rb
+++ b/app/controllers/sources_controller.rb
@@ -1,4 +1,7 @@
 class SourcesController < ApplicationController
+  include MutatingAuthentication
+
+  before_action :authenticate_mutation!, only: %i[create update destroy]
   before_action :set_source, only: [ :update, :destroy ]
 
   def index

--- a/app/frontend/api/client.test.ts
+++ b/app/frontend/api/client.test.ts
@@ -1,8 +1,18 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
-import { apiRequest, isAbortError } from './client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  apiRequest,
+  clearMutatingAuthCredentials,
+  isAbortError,
+  setMutatingAuthCredentials,
+} from './client'
 
 describe('apiRequest', () => {
+  beforeEach(() => {
+    clearMutatingAuthCredentials()
+  })
+
   afterEach(() => {
+    clearMutatingAuthCredentials()
     vi.unstubAllGlobals()
     vi.restoreAllMocks()
   })
@@ -20,6 +30,51 @@ describe('apiRequest', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock.mock.calls[0][1].signal).toBe(controller.signal)
+  })
+
+  it('sends Basic Authorization when mutating credentials are stored', async () => {
+    setMutatingAuthCredentials('admin', 'secret')
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ bookmarked: true }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await apiRequest('/articles/1/bookmark', { method: 'POST' })
+
+    const headers = fetchMock.mock.calls[0][1].headers as Headers
+    expect(headers.get('Authorization')).toBe(`Basic ${btoa('admin:secret')}`)
+  })
+
+  it('prompts and retries once on mutating 401', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        json: async () => ({ error: 'Unauthorized' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ bookmarked: true }),
+      })
+    vi.stubGlobal('fetch', fetchMock)
+    vi.stubGlobal(
+      'prompt',
+      vi
+        .fn()
+        .mockReturnValueOnce('admin')
+        .mockReturnValueOnce('secret')
+    )
+
+    await expect(apiRequest('/articles/1/bookmark', { method: 'POST' })).resolves.toEqual({
+      bookmarked: true,
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const retryHeaders = fetchMock.mock.calls[1][1].headers as Headers
+    expect(retryHeaders.get('Authorization')).toBe(`Basic ${btoa('admin:secret')}`)
   })
 
   it('isAbortError detects AbortError', () => {

--- a/app/frontend/api/client.ts
+++ b/app/frontend/api/client.ts
@@ -2,6 +2,8 @@ function csrfToken(): string {
   return document.querySelector<HTMLMetaElement>('meta[name="csrf-token"]')?.content ?? ''
 }
 
+const MUTATING_AUTH_STORAGE_KEY = 'mutatingAuthBasic'
+
 export function isAbortError(error: unknown): boolean {
   return (
     (typeof DOMException !== 'undefined' && error instanceof DOMException && error.name === 'AbortError') ||
@@ -9,9 +11,43 @@ export function isAbortError(error: unknown): boolean {
   )
 }
 
+export function setMutatingAuthCredentials(username: string, password: string): void {
+  sessionStorage.setItem(MUTATING_AUTH_STORAGE_KEY, btoa(`${username}:${password}`))
+}
+
+export function clearMutatingAuthCredentials(): void {
+  sessionStorage.removeItem(MUTATING_AUTH_STORAGE_KEY)
+}
+
+function mutatingAuthHeader(): string | null {
+  try {
+    return sessionStorage.getItem(MUTATING_AUTH_STORAGE_KEY)
+  } catch {
+    return null
+  }
+}
+
+function isMutatingMethod(method?: string): boolean {
+  const normalized = (method ?? 'GET').toUpperCase()
+  return normalized === 'POST' || normalized === 'PATCH' || normalized === 'PUT' || normalized === 'DELETE'
+}
+
+function promptMutatingAuth(): boolean {
+  if (typeof window === 'undefined' || typeof window.prompt !== 'function') return false
+
+  const username = window.prompt('Username required for this action:')
+  if (!username) return false
+  const password = window.prompt('Password:')
+  if (password === null) return false
+
+  setMutatingAuthCredentials(username, password)
+  return true
+}
+
 export async function apiRequest<T>(
   path: string,
-  options: RequestInit = {}
+  options: RequestInit = {},
+  retryOnUnauthorized = true
 ): Promise<T> {
   const headers = new Headers(options.headers)
   headers.set('Accept', 'application/json')
@@ -21,7 +57,21 @@ export async function apiRequest<T>(
     headers.set('Content-Type', 'application/json')
   }
 
+  const basic = mutatingAuthHeader()
+  if (basic) {
+    headers.set('Authorization', `Basic ${basic}`)
+  }
+
   const response = await fetch(path, { ...options, headers })
+
+  if (
+    response.status === 401 &&
+    retryOnUnauthorized &&
+    isMutatingMethod(options.method) &&
+    promptMutatingAuth()
+  ) {
+    return apiRequest(path, options, false)
+  }
 
   if (!response.ok) {
     let message = `Request failed: ${response.status}`

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -35,6 +35,8 @@ registry:
 env:
   secret:
     - RAILS_MASTER_KEY
+    # For public deploys, also add MUTATING_AUTH_USERNAME and MUTATING_AUTH_PASSWORD
+    # here and define them in .kamal/secrets (see docs/DEVELOPMENT.md).
   clear:
     # Run the Solid Queue Supervisor inside the web server's Puma process to do jobs.
     # When you start using multiple servers, you should split out job processing to a dedicated machine.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -304,6 +304,19 @@ Production sets `config.hosts` from `APP_HOSTS` (comma-separated; default `app.e
 
 Exceeded limits return `429` with JSON `{ "error": "Rate limit exceeded. Please try again later." }` and a `Retry-After` header. Override limits with `RACK_ATTACK_GLOBAL_LIMIT`, `RACK_ATTACK_GLOBAL_PERIOD`, `RACK_ATTACK_MUTATE_LIMIT`, and `RACK_ATTACK_MUTATE_PERIOD` (seconds).
 
+### Mutating API authentication
+
+**Decision:** ENV-gated HTTP Basic on mutating actions only. Read endpoints (`GET` articles, bookmarks, sources, etc.) stay public. No multi-user accounts.
+
+| Mode | Behavior |
+|------|----------|
+| `MUTATING_AUTH_USERNAME` + `MUTATING_AUTH_PASSWORD` unset | Mutations open (local/dev default) |
+| Both set | Mutations require HTTP Basic; missing/invalid creds → `401` JSON `{ "error": "Unauthorized" }` |
+
+Protected actions: article fetch/bookmark/dismiss, mark/unmark read, source create/update/destroy.
+
+The React client sends `Authorization: Basic …` from `sessionStorage` when set, and prompts once on a mutating `401`. For public deploys, set both env vars in Kamal secrets (`config/deploy.yml`). Alternative: terminate auth at a reverse proxy and leave app env unset.
+
 ## Coding guidelines
 
 ### General principles

--- a/test/integration/mutating_authentication_test.rb
+++ b/test/integration/mutating_authentication_test.rb
@@ -1,0 +1,66 @@
+require "test_helper"
+
+class MutatingAuthenticationTest < ActionDispatch::IntegrationTest
+  setup do
+    @article = articles(:hacker_news_article)
+    @previous_username = ENV["MUTATING_AUTH_USERNAME"]
+    @previous_password = ENV["MUTATING_AUTH_PASSWORD"]
+    ENV["MUTATING_AUTH_USERNAME"] = "admin"
+    ENV["MUTATING_AUTH_PASSWORD"] = "secret"
+  end
+
+  teardown do
+    if @previous_username
+      ENV["MUTATING_AUTH_USERNAME"] = @previous_username
+    else
+      ENV.delete("MUTATING_AUTH_USERNAME")
+    end
+
+    if @previous_password
+      ENV["MUTATING_AUTH_PASSWORD"] = @previous_password
+    else
+      ENV.delete("MUTATING_AUTH_PASSWORD")
+    end
+  end
+
+  test "should reject unauthenticated mutating requests with 401 JSON" do
+    post bookmark_article_url(@article), as: :json
+
+    assert_response :unauthorized
+    assert_equal "Unauthorized", JSON.parse(response.body)["error"]
+    assert_includes response.headers["WWW-Authenticate"].to_s, "Basic"
+  end
+
+  test "should reject mutating requests with invalid credentials" do
+    post bookmark_article_url(@article),
+         headers: { "Authorization" => ActionController::HttpAuthentication::Basic.encode_credentials("admin", "wrong") },
+         as: :json
+
+    assert_response :unauthorized
+  end
+
+  test "should allow mutating requests with valid credentials" do
+    post bookmark_article_url(@article),
+         headers: { "Authorization" => ActionController::HttpAuthentication::Basic.encode_credentials("admin", "secret") },
+         as: :json
+
+    assert_response :success
+    assert JSON.parse(response.body)["bookmarked"]
+  end
+
+  test "should leave read endpoints public when mutating auth is enabled" do
+    get articles_url, as: :json
+    assert_response :success
+
+    get sources_url, as: :json
+    assert_response :success
+  end
+
+  test "should allow mutations without credentials when auth is not configured" do
+    ENV.delete("MUTATING_AUTH_USERNAME")
+    ENV.delete("MUTATING_AUTH_PASSWORD")
+
+    post bookmark_article_url(@article), as: :json
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## Summary
- Add `MutatingAuthentication` (ENV-gated HTTP Basic) on mutating article/source/read actions; reads stay public
- When `MUTATING_AUTH_USERNAME`/`PASSWORD` are unset, behavior unchanged for local/dev
- React client sends Basic from `sessionStorage` and prompts once on mutating `401`
- Document decision in README + `docs/DEVELOPMENT.md`; Kamal secrets notes

Closes #246

## Test plan
- [ ] Without auth env: existing mutation tests / UI still work
- [ ] With auth env: unauthenticated mutation → `401` JSON; valid Basic → success; `GET /articles.json` still public
- [ ] SPA: first protected action prompts for credentials and retries
- [ ] CI green