### PR TITLE
feat(api): add Atom feeds for articles and bookmarks (#256)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A Rails application that aggregates developer news from Hacker News, Dev.to, and
 
 - **Multi-source aggregation**: Fetches from 12+ sources including Hacker News, Dev.to, and programming subreddits
 - **Article bookmarking**: Save articles for later reading with category filtering  
+- **Atom feeds**: Subscribe to `/articles.atom` (main feed) and `/bookmarks.atom` (reading list)
 - **Automated updates**: Hourly fetching during business hours via cron jobs
 - **Responsive interface**: React SPA with source-based filtering and Vite HMR in development
 

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -44,6 +44,7 @@ class ArticlesController < ApplicationController
           last_updated: @last_updated
         }
       end
+      format.atom
     end
   end
 

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -26,6 +26,7 @@ class BookmarksController < ApplicationController
           }
         }
       end
+      format.atom
     end
   end
 end

--- a/app/views/articles/index.atom.builder
+++ b/app/views/articles/index.atom.builder
@@ -1,0 +1,19 @@
+atom_feed(language: "en-US", root_url: articles_url, url: articles_url(format: :atom)) do |feed|
+  feed.title("Dev News Aggregator")
+  feed.updated(@articles.first&.published_at || @last_updated || Time.current)
+
+  @articles.each do |article|
+    feed.entry(
+      article,
+      url: article.url,
+      id: article_url(article),
+      published: article.published_at,
+      updated: article.updated_at
+    ) do |entry|
+      entry.title(article.title)
+      entry.content(article.description.to_s, type: "text")
+      entry.author { |author| author.name(article.source_type.to_s.tr("_", " ")) }
+      entry.category(term: article.source_type)
+    end
+  end
+end

--- a/app/views/bookmarks/index.atom.builder
+++ b/app/views/bookmarks/index.atom.builder
@@ -1,0 +1,19 @@
+atom_feed(language: "en-US", root_url: bookmarks_url, url: bookmarks_url(format: :atom)) do |feed|
+  feed.title("Dev News Aggregator — Reading List")
+  feed.updated(@bookmarked_articles.first&.bookmark&.bookmarked_at || Time.current)
+
+  @bookmarked_articles.each do |article|
+    feed.entry(
+      article,
+      url: article.url,
+      id: article_url(article),
+      published: article.bookmark&.bookmarked_at || article.published_at,
+      updated: article.updated_at
+    ) do |entry|
+      entry.title(article.title)
+      entry.content(article.description.to_s, type: "text")
+      entry.author { |author| author.name(article.source_type.to_s.tr("_", " ")) }
+      entry.category(term: article.source_type)
+    end
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,9 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <%= auto_discovery_link_tag :atom, articles_url(format: :atom), title: "Articles" %>
+    <%= auto_discovery_link_tag :atom, bookmarks_url(format: :atom), title: "Reading List" %>
+
     <%= yield :head %>
 
     <%# Enable PWA manifest for installable apps (routes are defined in config/routes.rb) %>

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -222,8 +222,10 @@ Agents should start here, then use this file as the navigation map:
 | Path | Controller#action |
 |------|-------------------|
 | `/` | `articles#index` |
+| `/articles.atom` | `articles#index` (Atom feed; honors `q`, `category`, `sort`, score filters) |
 | `/articles/:id` | `articles#show` |
 | `/bookmarks` | `bookmarks#index` |
+| `/bookmarks.atom` | `bookmarks#index` (Atom feed) |
 | `/read` | `read_articles#index` |
 | `/dismissed` | `dismissed_articles#index` |
 | `/recently_dismissed` | `dismissed_articles#recently_dismissed` |

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -25,6 +25,37 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
 
     assert_select "#root"
     assert_select "script[type='module'][src*='application']"
+    assert_select "link[rel='alternate'][type='application/atom+xml'][href=?]", articles_url(format: :atom)
+    assert_select "link[rel='alternate'][type='application/atom+xml'][href=?]", bookmarks_url(format: :atom)
+  end
+
+  test "index Atom should return a feed of unread articles" do
+    @article.mark_as_read!
+
+    get articles_url(format: :atom)
+    assert_response :success
+    assert_includes response.media_type, "atom"
+
+    assert_select "feed"
+    assert_select "feed>title", text: "Dev News Aggregator"
+    assert_select "entry" do |entries|
+      titles = entries.map { |entry| entry.at_css("title").text }
+      assert_includes titles, @dev_to_article.title
+      assert_not_includes titles, @article.title
+    end
+    assert_select "entry>id", text: article_url(@dev_to_article)
+    assert_select "entry>link[href=?]", @dev_to_article.url
+  end
+
+  test "index Atom should respect q filter" do
+    get articles_url(format: :atom, q: "Rust")
+    assert_response :success
+
+    assert_select "entry" do |entries|
+      titles = entries.map { |entry| entry.at_css("title").text }
+      assert_includes titles, @rust_article.title
+      assert_not_includes titles, @article.title
+    end
   end
 
   test "index should expose categories in JSON" do

--- a/test/controllers/bookmarks_controller_test.rb
+++ b/test/controllers/bookmarks_controller_test.rb
@@ -66,4 +66,28 @@ class BookmarksControllerTest < ActionDispatch::IntegrationTest
     assert_equal 1, json_response["pagination"]["current_page"]
     assert_equal 5, json_response["pagination"]["per_page"]
   end
+
+  test "index Atom should return bookmarked articles only" do
+    get bookmarks_url(format: :atom)
+    assert_response :success
+    assert_includes response.media_type, "atom"
+
+    assert_select "feed>title", text: "Dev News Aggregator — Reading List"
+    assert_select "entry" do |entries|
+      titles = entries.map { |entry| entry.at_css("title").text }
+      assert_includes titles, @bookmarked_article.title
+      assert_not_includes titles, @unbookmarked_article.title
+    end
+    assert_select "entry>link[href=?]", @bookmarked_article.url
+  end
+
+  test "index Atom should return an empty feed when no bookmarks exist" do
+    Bookmark.destroy_all
+
+    get bookmarks_url(format: :atom)
+    assert_response :success
+
+    assert_select "feed"
+    assert_select "entry", count: 0
+  end
 end


### PR DESCRIPTION
## Summary
- Add Atom feeds on articles and bookmarks index (`/articles.atom`, `/bookmarks.atom`)
- Articles feed reuses existing filters (`q`, category, score, sort, show_read, pagination)
- Advertise feeds via `auto_discovery_link_tag` in the layout; document in README and route map
- Controller tests for structure, unread default, `q` filter, and bookmarks-only entries

Closes #256

## Test plan
- [ ] `GET /articles.atom` returns Atom XML with unread entries by default
- [ ] `GET /articles.atom?q=Rust` filters entries
- [ ] `GET /bookmarks.atom` only includes bookmarked articles
- [ ] HTML pages include Atom alternate link tags
- [ ] CI green