### PR TITLE
ci: add Kamal-based CD workflow for deployments (#189)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,51 @@
+name: Deploy
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: kamal-deploy-production
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  deploy:
+    name: kamal_deploy
+    runs-on: ubuntu-latest
+    environment: production
+    if: ${{ vars.KAMAL_DEPLOY_ENABLED == 'true' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Start SSH agent
+        uses: webfactory/ssh-agent@v0.9.1
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Trust deploy host
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          ssh-keyscan -H "${{ vars.KAMAL_SERVER_HOST }}" >> ~/.ssh/known_hosts
+
+      - name: Deploy with Kamal
+        env:
+          KAMAL_REGISTRY_USERNAME: ${{ github.actor }}
+          KAMAL_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+          MUTATING_AUTH_USERNAME: ${{ secrets.MUTATING_AUTH_USERNAME }}
+          MUTATING_AUTH_PASSWORD: ${{ secrets.MUTATING_AUTH_PASSWORD }}
+        run: bundle exec kamal deploy

--- a/.kamal/secrets
+++ b/.kamal/secrets
@@ -7,15 +7,13 @@
 # KAMAL_REGISTRY_PASSWORD=$(kamal secrets extract KAMAL_REGISTRY_PASSWORD ${SECRETS})
 # RAILS_MASTER_KEY=$(kamal secrets extract RAILS_MASTER_KEY ${SECRETS})
 
-# Use a GITHUB_TOKEN if private repositories are needed for the image
-# GITHUB_TOKEN=$(gh config get -h github.com oauth_token)
-
-# Grab the registry password from ENV
+# Registry credentials (GHCR: username = GitHub user/org; password = PAT or GITHUB_TOKEN in Actions)
+KAMAL_REGISTRY_USERNAME=$KAMAL_REGISTRY_USERNAME
 KAMAL_REGISTRY_PASSWORD=$KAMAL_REGISTRY_PASSWORD
 
-# Improve security by using a password manager. Never check config/master.key into git!
-RAILS_MASTER_KEY=$(cat config/master.key)
+# Prefer ENV (CI); fall back to local config/master.key for developer deploys.
+RAILS_MASTER_KEY=${RAILS_MASTER_KEY:-$(cat config/master.key)}
 
-# Mutating API HTTP Basic (required when deploying publicly)
+# Mutating API HTTP Basic (uncomment and set when deploying publicly)
 # MUTATING_AUTH_USERNAME=$MUTATING_AUTH_USERNAME
 # MUTATING_AUTH_PASSWORD=$MUTATING_AUTH_PASSWORD

--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ No manual intervention needed for routine security patches and minor updates!
 
 For public deployments, enable mutating API HTTP Basic via `MUTATING_AUTH_USERNAME` / `MUTATING_AUTH_PASSWORD`, plus CSP, `APP_HOSTS`, and Rack::Attack throttles. Reads stay public; mutations return `401` without credentials. Details: [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md#production-security-csp-hosts-and-rate-limiting).
 
+## Deploy
+
+Production deploys use Kamal via the **Deploy** GitHub Actions workflow (manual). See [Deployment (Kamal)](docs/DEVELOPMENT.md#deployment-kamal) for secrets, enable flag, and rollback.
+
 ## Development
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the contributor entry point, [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) for development guidelines, and [docs/REPO_STRUCTURE.md](docs/REPO_STRUCTURE.md) for the repository map (keep it updated when structure changes).

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -1,10 +1,10 @@
 # Name of your application. Used to uniquely configure containers.
 service: dev_news_aggregator
 
-# Name of the container image.
-image: your-user/dev_news_aggregator
+# Container image on GHCR (must be lowercase). Override if forking.
+image: ghcr.io/marcoslorejan/dev-news-aggregator
 
-# Deploy to these servers.
+# Deploy to these servers. Replace with your production host before enabling CI deploy.
 servers:
   web:
     - 192.168.0.1
@@ -21,13 +21,11 @@ proxy:
   ssl: true
   host: app.example.com
 
-# Credentials for your image host.
+# Credentials for GHCR (see docs/DEVELOPMENT.md — Deployment).
 registry:
-  # Specify the registry server, if you're not using Docker Hub
-  # server: registry.digitalocean.com / ghcr.io / ...
-  username: your-user
-
-  # Always use an access token rather than real password when possible.
+  server: ghcr.io
+  username:
+    - KAMAL_REGISTRY_USERNAME
   password:
     - KAMAL_REGISTRY_PASSWORD
 
@@ -81,6 +79,10 @@ asset_path: /rails/public/assets
 # Configure the image builder.
 builder:
   arch: amd64
+  # GitHub Actions cache when building from the Deploy workflow.
+  cache:
+    type: gha
+    options: mode=max
 
   # # Build image via remote server (useful for faster amd64 builds on arm64 computers)
   # remote: ssh://docker@docker-builder-server

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -317,6 +317,44 @@ Protected actions: article fetch/bookmark/dismiss, mark/unmark read, source crea
 
 The React client sends `Authorization: Basic …` from `sessionStorage` when set, and prompts once on a mutating `401`. For public deploys, set both env vars in Kamal secrets (`config/deploy.yml`). Alternative: terminate auth at a reverse proxy and leave app env unset.
 
+## Deployment (Kamal)
+
+CD is implemented as `.github/workflows/deploy.yml` (manual `workflow_dispatch`). The job is a no-op until you opt in — it only runs when the repository variable `KAMAL_DEPLOY_ENABLED` is `true`.
+
+### Prerequisites
+
+1. Set real values in `config/deploy.yml`: `servers.web`, `proxy.host`, and `APP_HOSTS` (must match).
+2. Server accepts SSH from the deploy key and can pull from GHCR / run Docker.
+3. Configure GitHub:
+
+| Kind | Name | Purpose |
+|------|------|---------|
+| Variable | `KAMAL_DEPLOY_ENABLED` | Set to `true` to allow the Deploy workflow |
+| Variable | `KAMAL_SERVER_HOST` | Host/IP for `ssh-keyscan` (same as `servers.web`) |
+| Secret | `SSH_PRIVATE_KEY` | Private key for the deploy user |
+| Secret | `RAILS_MASTER_KEY` | Production credentials key |
+| Secret | `MUTATING_AUTH_USERNAME` / `MUTATING_AUTH_PASSWORD` | Optional; enable mutating Basic auth |
+
+Images push to `ghcr.io/marcoslorejan/dev-news-aggregator` using `GITHUB_TOKEN`. Use a GitHub Environment named `production` for optional approval gates.
+
+### Run a deploy
+
+1. Ensure CI is green on the commit you intend to ship.
+2. Actions → **Deploy** → **Run workflow**.
+3. Locally: export registry/SSH-related env vars, then `bundle exec kamal deploy`.
+
+### Rollback
+
+```bash
+# List recent app versions on the server
+bundle exec kamal app containers
+
+# Roll back to a previous version tag
+bundle exec kamal rollback <VERSION>
+```
+
+After a bad deploy from Actions, re-run Deploy on a known-good commit, or SSH/local Kamal rollback as above.
+
 ## Coding guidelines
 
 ### General principles

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -178,6 +178,7 @@ dev-news-aggregator/
 | Path | Purpose |
 |------|---------|
 | `workflows/ci.yml` | CI pipeline (tests, lint, security, Docker build + Trivy scan) |
+| `workflows/deploy.yml` | Manual Kamal CD (`workflow_dispatch`; gated by `KAMAL_DEPLOY_ENABLED`) |
 | `workflows/dependabot-auto-merge.yml` | Auto-merge patch/minor Dependabot PRs only after green `quality_gate` |
 | `dependabot.yml` | Dependency update schedule |
 | `pull_request_template.md` | Default PR body checklist |


### PR DESCRIPTION
## Summary
- Add `.github/workflows/deploy.yml` (manual `workflow_dispatch`, gated by `KAMAL_DEPLOY_ENABLED`)
- Point `config/deploy.yml` at GHCR + GHA builder cache; ENV-first `.kamal/secrets`
- Document required secrets/vars, enable flag, and rollback in `docs/DEVELOPMENT.md`

Closes #189

**Note:** Host/domain placeholders remain until a real server is configured. First live deploy is a maintainer step after setting secrets and `KAMAL_DEPLOY_ENABLED=true`.

## Test plan
- [ ] Workflow file validates in Actions UI (Deploy appears under Actions)
- [ ] With `KAMAL_DEPLOY_ENABLED` unset/false, dispatch skips the job
- [ ] After configuring host + secrets + enable flag, manual deploy succeeds
- [ ] Rollback docs match `kamal app containers` / `kamal rollback`
- [ ] CI on this PR stays green (no live deploy required)