### PR TITLE
feat(ops): report production errors and fetch failures (#255)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,9 @@ SECRET_KEY_BASE=your_secret_key_base_here
 # MUTATING_AUTH_USERNAME=admin
 # MUTATING_AUTH_PASSWORD=change-me
 
+# Optional production error alerts (JSON POST). Leave unset for structured logs only.
+# ERROR_WEBHOOK_URL=https://hooks.example.com/services/...
+
 # Optional: API Keys (if needed in future)
 # HACKER_NEWS_API_KEY=
 # DEVTO_API_KEY=

--- a/app/services/error_reporting/subscriber.rb
+++ b/app/services/error_reporting/subscriber.rb
@@ -3,30 +3,39 @@ module ErrorReporting
     WEBHOOK_DEDUP_TTL = 30.minutes
 
     def report(error, handled:, severity:, context:, source: nil)
+      safe_context = normalize_context(context)
       payload = {
-        event: "error.reported",
-        error_class: error.class.name,
-        error_message: error.message.to_s.truncate(500),
-        handled: handled,
-        severity: severity.to_s,
-        source: source,
-        context: context,
-        reported_at: Time.current.iso8601
+        "event" => "error.reported",
+        "error_class" => error.class.name,
+        "error_message" => error.message.to_s.truncate(500),
+        "handled" => handled,
+        "severity" => severity.to_s,
+        "source" => source,
+        "context" => safe_context,
+        "reported_at" => Time.current.iso8601
       }
 
-      Rails.logger.public_send(log_level_for(severity[:severity]), payload.to_json)
+      log_payload(severity.to_s, payload.to_json)
       notify_webhook(error, payload) if webhook_enabled?
     rescue StandardError => e
-      Rails.logger.warn({ event: "error.subscriber_failed", message: e.message }.to_json)
+      Rails.logger.warn({ "event" => "error.subscriber_failed", "message" => e.message }.to_json)
     end
 
     private
 
-    def log_level_for(severity)
-      case severity.to_s
-      when "error" then :error
-      when "warning" then :warn
-      else :info
+    def normalize_context(context)
+      return {} unless context.is_a?(Hash)
+
+      context.each_with_object({}) do |(key, value), memo|
+        memo[key.to_s] = value
+      end
+    end
+
+    def log_payload(severity, message)
+      case severity
+      when "error" then Rails.logger.error(message)
+      when "warning" then Rails.logger.warn(message)
+      else Rails.logger.info(message)
       end
     end
 
@@ -35,20 +44,19 @@ module ErrorReporting
     end
 
     def notify_webhook(error, payload)
-      context = payload[:context] || {}
-      source_key = context[:source_key] || context["source_key"]
+      source_key = payload.dig("context", "source_key")
 
       dedupe_key = [
         "error_webhook",
-        payload[:source].presence || "app",
-        payload[:error_class],
+        payload["source"].presence || "app",
+        payload["error_class"],
         source_key
       ].compact.join(":")
 
       return unless Rails.cache.write(dedupe_key, true, expires_in: WEBHOOK_DEDUP_TTL, unless_exist: true)
 
       WebhookNotifier.notify(payload.merge(
-        text: "[dev-news-aggregator] #{error.class}: #{error.message.to_s.truncate(200)}"
+        "text" => "[dev-news-aggregator] #{error.class}: #{error.message.to_s.truncate(200)}"
       ))
     end
   end

--- a/app/services/error_reporting/subscriber.rb
+++ b/app/services/error_reporting/subscriber.rb
@@ -1,0 +1,55 @@
+module ErrorReporting
+  class Subscriber
+    WEBHOOK_DEDUP_TTL = 30.minutes
+
+    def report(error, handled:, severity:, context:, source: nil)
+      payload = {
+        event: "error.reported",
+        error_class: error.class.name,
+        error_message: error.message.to_s.truncate(500),
+        handled: handled,
+        severity: severity.to_s,
+        source: source,
+        context: context,
+        reported_at: Time.current.iso8601
+      }
+
+      Rails.logger.public_send(log_level_for(severity[:severity]), payload.to_json)
+      notify_webhook(error, payload) if webhook_enabled?
+    rescue StandardError => e
+      Rails.logger.warn({ event: "error.subscriber_failed", message: e.message }.to_json)
+    end
+
+    private
+
+    def log_level_for(severity)
+      case severity.to_s
+      when "error" then :error
+      when "warning" then :warn
+      else :info
+      end
+    end
+
+    def webhook_enabled?
+      ENV["ERROR_WEBHOOK_URL"].present?
+    end
+
+    def notify_webhook(error, payload)
+      context = payload[:context] || {}
+      source_key = context[:source_key] || context["source_key"]
+
+      dedupe_key = [
+        "error_webhook",
+        payload[:source].presence || "app",
+        payload[:error_class],
+        source_key
+      ].compact.join(":")
+
+      return unless Rails.cache.write(dedupe_key, true, expires_in: WEBHOOK_DEDUP_TTL, unless_exist: true)
+
+      WebhookNotifier.notify(payload.merge(
+        text: "[dev-news-aggregator] #{error.class}: #{error.message.to_s.truncate(200)}"
+      ))
+    end
+  end
+end

--- a/app/services/error_reporting/webhook_notifier.rb
+++ b/app/services/error_reporting/webhook_notifier.rb
@@ -1,0 +1,17 @@
+module ErrorReporting
+  class WebhookNotifier
+    def self.notify(payload)
+      url = ENV["ERROR_WEBHOOK_URL"]
+      return if url.blank?
+
+      HTTParty.post(
+        url,
+        body: payload.to_json,
+        headers: { "Content-Type" => "application/json" },
+        timeout: 5
+      )
+    rescue StandardError => e
+      Rails.logger.warn({ event: "error.webhook_failed", message: e.message }.to_json)
+    end
+  end
+end

--- a/app/services/news_aggregator_service.rb
+++ b/app/services/news_aggregator_service.rb
@@ -89,6 +89,13 @@ class NewsAggregatorService
       error: e
     )
 
+    Rails.error.report(
+      e,
+      handled: true,
+      severity: :error,
+      context: { source_key: source_key },
+      source: "news_fetch"
+    )
     Rails.logger.error e.backtrace.join("\n")
     []
   end

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -43,6 +43,9 @@ env:
     # Allowed Host headers (comma-separated). Must include proxy.host above.
     APP_HOSTS: app.example.com
 
+    # Optional error alert webhook (Slack/Discord/generic). See docs/DEVELOPMENT.md.
+    # ERROR_WEBHOOK_URL: https://hooks.example.com/services/...
+
     # Set number of processes dedicated to Solid Queue (default: 1)
     # JOB_CONCURRENCY: 3
 

--- a/config/initializers/error_reporting.rb
+++ b/config/initializers/error_reporting.rb
@@ -2,5 +2,8 @@
 #
 # Subscribes to Rails.error so unhandled exceptions and explicit Rails.error.report
 # calls emit structured logs (and optional ERROR_WEBHOOK_URL alerts).
+# after_initialize ensures app/services constants are available (e.g. assets:precompile).
 
-Rails.error.subscribe(ErrorReporting::Subscriber.new)
+Rails.application.config.after_initialize do
+  Rails.error.subscribe(ErrorReporting::Subscriber.new)
+end

--- a/config/initializers/error_reporting.rb
+++ b/config/initializers/error_reporting.rb
@@ -1,0 +1,6 @@
+# Be sure to restart your server when you modify this file.
+#
+# Subscribes to Rails.error so unhandled exceptions and explicit Rails.error.report
+# calls emit structured logs (and optional ERROR_WEBHOOK_URL alerts).
+
+Rails.error.subscribe(ErrorReporting::Subscriber.new)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -355,6 +355,20 @@ bundle exec kamal rollback <VERSION>
 
 After a bad deploy from Actions, re-run Deploy on a known-good commit, or SSH/local Kamal rollback as above.
 
+### Error monitoring and fetch alerts
+
+Unhandled exceptions and explicit `Rails.error.report` calls are handled by `ErrorReporting::Subscriber` (`config/initializers/error_reporting.rb`):
+
+1. **Structured logs** — JSON lines with `event: "error.reported"` on stdout (visible via `bin/kamal app logs` / `kamal logs`).
+2. **Optional webhook** — set `ERROR_WEBHOOK_URL` to a Slack/Discord/generic HTTP endpoint. Posts JSON including a `text` field. Duplicate alerts for the same source + error class are suppressed for 30 minutes.
+3. **Fetch failures** — `NewsAggregatorService` reports rescued fetcher errors with `source: "news_fetch"` so they appear even though the job itself does not fail. Per-source status also remains on the Sources page (`FetchRun`).
+
+| ENV | Purpose |
+|-----|---------|
+| `ERROR_WEBHOOK_URL` | Optional alert webhook (leave unset for log-only) |
+
+No SaaS SDK is required; add Sentry later by installing the gem (it also subscribes to `Rails.error`) if you want a full dashboard.
+
 ## Coding guidelines
 
 ### General principles

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -54,6 +54,7 @@ dev-news-aggregator/
 | `app/controllers/` | HTTP layer — articles, bookmarks, read/dismissed lists |
 | `app/models/` | ActiveRecord models |
 | `app/services/` | Business logic — news aggregation orchestration |
+| `app/services/error_reporting/` | Rails.error subscriber + optional webhook alerts |
 | `app/services/news_fetchers/` | Per-source API fetchers (HN, Dev.to, Reddit) |
 | `app/jobs/` | Background jobs (e.g. permanent dismissal) |
 | `app/helpers/` | View helpers (categories, formatting) |

--- a/test/services/error_reporting/subscriber_test.rb
+++ b/test/services/error_reporting/subscriber_test.rb
@@ -4,11 +4,13 @@ class ErrorReporting::SubscriberTest < ActiveSupport::TestCase
   setup do
     @previous_url = ENV["ERROR_WEBHOOK_URL"]
     ENV.delete("ERROR_WEBHOOK_URL")
-    Rails.cache.clear
+    @previous_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
     @subscriber = ErrorReporting::Subscriber.new
   end
 
   teardown do
+    Rails.cache = @previous_cache
     if @previous_url
       ENV["ERROR_WEBHOOK_URL"] = @previous_url
     else

--- a/test/services/error_reporting/subscriber_test.rb
+++ b/test/services/error_reporting/subscriber_test.rb
@@ -1,0 +1,87 @@
+require "test_helper"
+
+class ErrorReporting::SubscriberTest < ActiveSupport::TestCase
+  setup do
+    @previous_url = ENV["ERROR_WEBHOOK_URL"]
+    ENV.delete("ERROR_WEBHOOK_URL")
+    Rails.cache.clear
+    @subscriber = ErrorReporting::Subscriber.new
+  end
+
+  teardown do
+    if @previous_url
+      ENV["ERROR_WEBHOOK_URL"] = @previous_url
+    else
+      ENV.delete("ERROR_WEBHOOK_URL")
+    end
+  end
+
+  test "should log structured error payload" do
+    error = StandardError.new("boom")
+
+    assert_logs_match(/"event":"error.reported"/) do
+      @subscriber.report(error, handled: true, severity: :error, context: { source_key: "hn" }, source: "news_fetch")
+    end
+  end
+
+  test "should post webhook when ERROR_WEBHOOK_URL is set" do
+    ENV["ERROR_WEBHOOK_URL"] = "https://example.com/hooks/errors"
+    stub_request(:post, "https://example.com/hooks/errors")
+      .to_return(status: 200, body: "ok")
+
+    @subscriber.report(
+      StandardError.new("API is down"),
+      handled: true,
+      severity: :error,
+      context: { source_key: "hacker_news" },
+      source: "news_fetch"
+    )
+
+    assert_requested :post, "https://example.com/hooks/errors", times: 1
+  end
+
+  test "should dedupe webhook alerts for the same source error" do
+    ENV["ERROR_WEBHOOK_URL"] = "https://example.com/hooks/errors"
+    stub_request(:post, "https://example.com/hooks/errors")
+      .to_return(status: 200, body: "ok")
+
+    2.times do
+      @subscriber.report(
+        StandardError.new("API is down"),
+        handled: true,
+        severity: :error,
+        context: { source_key: "hacker_news" },
+        source: "news_fetch"
+      )
+    end
+
+    assert_requested :post, "https://example.com/hooks/errors", times: 1
+  end
+
+  test "should not raise when webhook delivery fails" do
+    ENV["ERROR_WEBHOOK_URL"] = "https://example.com/hooks/errors"
+    stub_request(:post, "https://example.com/hooks/errors").to_timeout
+
+    assert_nothing_raised do
+      @subscriber.report(
+        StandardError.new("API is down"),
+        handled: true,
+        severity: :error,
+        context: {},
+        source: "news_fetch"
+      )
+    end
+  end
+
+  private
+
+  def assert_logs_match(pattern)
+    io = StringIO.new
+    previous = Rails.logger
+    Rails.logger = ActiveSupport::Logger.new(io)
+    yield
+    assert_match pattern, io.string
+  ensure
+    Rails.logger = previous
+  end
+end

--- a/test/services/news_aggregator_service_test.rb
+++ b/test/services/news_aggregator_service_test.rb
@@ -99,6 +99,47 @@ class NewsAggregatorServiceTest < ActiveSupport::TestCase
     assert_equal "failure", FetchRun.find_by(source_key: "test_failing_fetcher").status
   end
 
+  test "fetch_all_news reports handled fetch failures to Rails.error" do
+    failing_fetcher = Object.new
+    def failing_fetcher.fetch_articles
+      raise StandardError, "API is down"
+    end
+    def failing_fetcher.source_key
+      "test_report_fetcher"
+    end
+    def failing_fetcher.class
+      OpenStruct.new(name: "TestReportFetcher")
+    end
+
+    @service.instance_variable_set(:@fetchers, [ failing_fetcher ])
+
+    recorder = Class.new do
+      attr_reader :reports
+
+      def initialize
+        @reports = []
+      end
+
+      def report(error, handled:, severity:, context:, source: nil)
+        @reports << { error: error, handled: handled, severity: severity, context: context, source: source }
+      end
+    end.new
+
+    Rails.error.subscribe(recorder)
+    begin
+      @service.fetch_all_news
+    ensure
+      Rails.error.unsubscribe(recorder)
+    end
+
+    assert_equal 1, recorder.reports.size
+    report = recorder.reports.first
+    assert_equal "news_fetch", report[:source]
+    assert_equal true, report[:handled]
+    assert_equal "test_report_fetcher", report[:context][:source_key]
+    assert_equal "API is down", report[:error].message
+  end
+
   test "class method fetch_all_news should work without live API calls" do
     mock_fetcher = Object.new
     def mock_fetcher.fetch_articles; []; end


### PR DESCRIPTION
## Summary
- Add `ErrorReporting::Subscriber` on `Rails.error`: structured stdout JSON + optional `ERROR_WEBHOOK_URL` (30m dedupe)
- Report rescued news-fetch failures with `source: news_fetch` so alerts work without failing the job
- Document Kamal/ENV setup; Sources page `FetchRun` status remains the in-app view

Closes #255

## Test plan
- [ ] Failing fetcher creates `FetchRun` failure and triggers `Rails.error.report`
- [ ] With `ERROR_WEBHOOK_URL`, webhook receives JSON (and is deduped within 30 minutes)
- [ ] Unhandled exceptions still flow through the subscriber in production
- [ ] CI green