### PR TITLE
feat(api): filter articles by multiple keywords on the index endpoint (#373)

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -150,6 +150,7 @@ class ArticlesController < ApplicationController
 
     scope = apply_score_filter(scope)
     scope = scope.search(params[:q])
+    scope = scope.matching_keywords(params[:keywords], match: params[:match])
     scope = scope.with_topic_tag(params[:tag])
     scope = helpers.apply_category_filter(scope, params[:category]) if apply_category
     scope = ArticleClusterer.primaries(scope)

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,4 +1,7 @@
 class Article < ApplicationRecord
+  # Keeps keyword queries bounded no matter how long a saved interest preset grows.
+  MAX_KEYWORDS = 20
+
   validates :title, :url, :external_id, :source_type, presence: true
   validates :external_id, uniqueness: { scope: :source_type }
   validates :url, format: { with: URI::DEFAULT_PARSER.make_regexp(%w[http https]) }
@@ -39,6 +42,26 @@ class Article < ApplicationRecord
 
     joins(:tags).where(tags: { slug: slug }).distinct
   }
+  scope :matching_keywords, ->(terms, match: :any) {
+    keywords = Article.normalize_keywords(terms)
+    return all if keywords.empty?
+
+    joiner = match.to_s == "all" ? " AND " : " OR "
+    clause = keywords.map { "(title ILIKE ? OR COALESCE(description, '') ILIKE ?)" }.join(joiner)
+    patterns = keywords.flat_map { |keyword| [ "%#{sanitize_sql_like(keyword)}%" ] * 2 }
+
+    where(clause, *patterns)
+  }
+
+  # Accepts a comma-separated string or an array; multi-word terms stay whole phrases.
+  def self.normalize_keywords(terms)
+    list = terms.is_a?(String) ? terms.split(",") : Array(terms)
+
+    list.map { |term| term.to_s.strip }
+        .reject(&:blank?)
+        .uniq { |term| term.downcase }
+        .first(MAX_KEYWORDS)
+  end
 
   def self.similar_to(article, limit: 5)
     title = article.title.to_s.strip

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -223,6 +223,72 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
     assert_equal published_ats, published_ats.sort.reverse
   end
 
+  test "index JSON filters by any of the given keywords" do
+    get articles_url(keywords: "ruby,rust"), as: :json
+    assert_response :success
+
+    ids = JSON.parse(response.body)["articles"].map { |article| article["id"] }
+    assert_includes ids, @dev_to_article.id
+    assert_includes ids, @rust_article.id
+    assert_not_includes ids, @article.id
+  end
+
+  test "index JSON requires every keyword when match is all" do
+    both = articles(:reddit_ruby_article)
+    both.update!(description: "Exploring the latest Rails features and their performance impact")
+
+    get articles_url(keywords: "rails,performance", match: "all"), as: :json
+    assert_response :success
+
+    ids = JSON.parse(response.body)["articles"].map { |article| article["id"] }
+    assert_includes ids, both.id
+    assert_not_includes ids, @rust_article.id
+  end
+
+  test "index JSON matches multi-word keywords as phrases" do
+    phrase = Article.create!(
+      title: "A pragmatic take on software architecture",
+      url: "https://example.com/architecture-index",
+      external_id: "architecture-index",
+      source_type: "hacker_news",
+      published_at: Time.current,
+      description: "Layering trade-offs"
+    )
+
+    get articles_url(keywords: "software architecture"), as: :json
+    assert_response :success
+
+    ids = JSON.parse(response.body)["articles"].map { |article| article["id"] }
+    assert_equal [ phrase.id ], ids
+  end
+
+  test "index JSON composes keywords with q, category and min_score" do
+    get articles_url(keywords: "ruby,rust", q: "Rust", category: "programming-languages", min_score: 100), as: :json
+    assert_response :success
+
+    ids = JSON.parse(response.body)["articles"].map { |article| article["id"] }
+    assert_includes ids, @rust_article.id
+    assert_not_includes ids, @dev_to_article.id
+  end
+
+  test "index JSON ignores blank keywords" do
+    get articles_url(keywords: " , "), as: :json
+    assert_response :success
+
+    unfiltered = JSON.parse(response.body)["pagination"]["total_count"]
+
+    get articles_url, as: :json
+    assert_equal JSON.parse(response.body)["pagination"]["total_count"], unfiltered
+  end
+
+  test "index JSON keeps category counts consistent with keyword filter" do
+    get articles_url(keywords: "rust"), as: :json
+    assert_response :success
+
+    body = JSON.parse(response.body)
+    assert_equal 1, body["category_counts"].values.sum
+  end
+
   test "index JSON filters by topic tag" do
     article = articles(:reddit_rust_article)
     ArticleTopicClassifier.apply!(article)

--- a/test/models/article_test.rb
+++ b/test/models/article_test.rb
@@ -368,6 +368,82 @@ class ArticleTest < ActiveSupport::TestCase
     assert_includes results, @article
   end
 
+  test "matching_keywords returns all articles when no usable term is given" do
+    assert_equal Article.count, Article.matching_keywords(nil).count
+    assert_equal Article.count, Article.matching_keywords("").count
+    assert_equal Article.count, Article.matching_keywords(" , ,  ").count
+    assert_equal Article.count, Article.matching_keywords([]).count
+  end
+
+  test "matching_keywords with any match returns articles hitting either term" do
+    results = Article.matching_keywords("ruby,rust")
+
+    assert_includes results, articles(:dev_to_article)
+    assert_includes results, articles(:reddit_rust_article)
+    assert_not_includes results, articles(:hacker_news_article)
+  end
+
+  test "matching_keywords with all match requires every term" do
+    both = articles(:reddit_ruby_article)
+    both.update!(description: "Exploring the latest Rails features and their performance impact")
+
+    results = Article.matching_keywords("rails,performance", match: :all)
+
+    assert_includes results, both
+    assert_not_includes results, articles(:reddit_rust_article)
+  end
+
+  test "matching_keywords treats multi-word terms as phrases" do
+    architecture = Article.create!(
+      title: "Notes on software architecture reviews",
+      url: "https://example.com/architecture",
+      external_id: "architecture-1",
+      source_type: "hacker_news",
+      published_at: Time.current,
+      description: "Trade-offs in layered designs"
+    )
+    Article.create!(
+      title: "Software testing without architecture talk",
+      url: "https://example.com/testing",
+      external_id: "testing-1",
+      source_type: "hacker_news",
+      published_at: Time.current,
+      description: "Only the two words apart"
+    )
+
+    results = Article.matching_keywords("software architecture")
+
+    assert_equal [ architecture ], results.to_a
+  end
+
+  test "matching_keywords ignores duplicate terms regardless of case" do
+    assert_equal(
+      Article.matching_keywords("ruby").pluck(:id).sort,
+      Article.matching_keywords("ruby,Ruby, RUBY ").pluck(:id).sort
+    )
+  end
+
+  test "matching_keywords caps the number of terms" do
+    filler = (1..Article::MAX_KEYWORDS).map { |index| "no-match-#{index}" }
+
+    results = Article.matching_keywords(filler + [ "rust" ])
+
+    assert_not_includes results, articles(:reddit_rust_article)
+  end
+
+  test "matching_keywords escapes LIKE wildcards" do
+    literal = Article.create!(
+      title: "Ship 100% typed Ruby",
+      url: "https://example.com/typed",
+      external_id: "typed-1",
+      source_type: "dev_to",
+      published_at: Time.current,
+      description: "literal percent"
+    )
+
+    assert_equal [ literal ], Article.matching_keywords("100%").to_a
+  end
+
   test "similar_to returns title-similar articles" do
     related = articles(:dev_to_article)
     @article.update!(title: "Rails performance tips for production")


### PR DESCRIPTION
## Summary

Closes #373.

- Adds `Article.matching_keywords(terms, match:)` next to `search`: `match: :any` (default) ORs the terms, `match: :all` requires all of them, both over `title` and `description`
- `GET /articles` accepts `keywords` (comma-separated) and `match` (`any` / `all`); it composes with `q`, `category`, `tag`, and the score filters, and category counts stay computed on the keyword-filtered scope
- Multi-word terms stay whole phrases (`software architecture` does not match "software testing without architecture talk")
- Blank and case-duplicate terms are dropped, `LIKE` wildcards are escaped, and the term count is capped by `Article::MAX_KEYWORDS` (20) so a long saved preset cannot blow up the query
- The Atom feed inherits the filter, since it renders the same scope

Frontend wiring, saved presets, and docs are intentionally out of scope (#376, #374, #380).

## Test plan

- [x] `bin/rails test test/models/article_test.rb` (50 runs) — any/all, phrases, blank input, case-duplicates, term cap, wildcard escaping
- [x] `bin/rails test test/controllers/articles_controller_test.rb` (63 runs) — any/all, phrase, composition with `q` + `category` + `min_score`, blank keywords, category counts
- [x] `bin/rails test` (318 runs, 0 failures)
- [x] `bundle exec rubocop` (138 files, no offenses)

## Notes

The OR-of-`ILIKE` shape reuses the GIN trigram indexes added in #371, so no new migration is needed here.
