### PR TITLE
feat(db): add keyword filters model for saved interest presets (#374)

### DIFF
--- a/app/models/keyword_filter.rb
+++ b/app/models/keyword_filter.rb
@@ -1,0 +1,55 @@
+# Saved keyword presets ("interests") used to filter the feed by topic instead of source.
+# Defaults come from config/news_aggregator.yml and are seeded once, like NewsSource.
+class KeywordFilter < ApplicationRecord
+  MAX_TERM_LENGTH = 60
+
+  before_validation :assign_slug
+  before_validation :normalize_terms
+
+  validates :name, presence: true, uniqueness: { case_sensitive: false }
+  validates :slug, presence: true, uniqueness: true
+  validate :terms_present
+  validate :terms_within_length
+
+  scope :enabled, -> { where(active: true) }
+  scope :ordered, -> { order(:position, :name) }
+
+  def self.slug_for(name)
+    name.to_s.strip.downcase.gsub(/[^a-z0-9]+/, "-").gsub(/\A-+|-+\z/, "")
+  end
+
+  # Idempotent: existing interests are left untouched so local edits survive re-seeding.
+  def self.bootstrap_defaults!
+    NewsAggregatorConfig.interests.each_with_index do |interest, index|
+      next if exists?(slug: slug_for(interest[:name]))
+
+      create!(
+        name: interest[:name],
+        terms: Array(interest[:terms]),
+        active: true,
+        position: index
+      )
+    end
+  end
+
+  private
+
+  def assign_slug
+    self.slug = self.class.slug_for(name) if name.present?
+  end
+
+  # Same normalization as the keywords index filter: trim, downcase, dedupe, cap.
+  def normalize_terms
+    self.terms = Article.normalize_keywords(Array(terms).map { |term| term.to_s.downcase })
+  end
+
+  def terms_present
+    errors.add(:terms, "must include at least one keyword") if terms.empty?
+  end
+
+  def terms_within_length
+    return if terms.all? { |term| term.length <= MAX_TERM_LENGTH }
+
+    errors.add(:terms, "must be #{MAX_TERM_LENGTH} characters or fewer each")
+  end
+end

--- a/app/models/news_aggregator_config.rb
+++ b/app/models/news_aggregator_config.rb
@@ -36,6 +36,10 @@ module NewsAggregatorConfig
       Array(config.dig(:apis, :reddit, :subreddits))
     end
 
+    def interests
+      Array(config[:interests])
+    end
+
     def reddit_min_request_interval_seconds
       config.dig(:apis, :reddit, :min_request_interval_seconds) || 2.5
     end

--- a/config/news_aggregator.yml
+++ b/config/news_aggregator.yml
@@ -21,6 +21,20 @@ development: &default
     # Clean old articles automatically
     auto_cleanup: true
   
+  # Starter keyword interests, seeded into keyword_filters when the table is empty.
+  # Terms are matched as phrases against article title + description.
+  interests:
+    - name: "Ruby"
+      terms: [ "ruby", "rubygems", "sorbet" ]
+    - name: "Rails"
+      terms: [ "rails", "activerecord", "hotwire", "turbo" ]
+    - name: "Rust"
+      terms: [ "rust", "cargo", "tokio" ]
+    - name: "Software architecture"
+      terms: [ "software architecture", "system design", "domain-driven", "ddd", "event sourcing" ]
+    - name: "AI performance"
+      terms: [ "inference", "quantization", "prompt optimization", "llm latency", "context window" ]
+
   # API endpoints
   apis:
     hacker_news:

--- a/db/migrate/20260802090000_create_keyword_filters.rb
+++ b/db/migrate/20260802090000_create_keyword_filters.rb
@@ -1,0 +1,15 @@
+class CreateKeywordFilters < ActiveRecord::Migration[8.1]
+  def change
+    create_table :keyword_filters do |t|
+      t.string :name, null: false
+      t.string :slug, null: false
+      t.string :terms, array: true, null: false, default: []
+      t.boolean :active, null: false, default: true
+      t.integer :position, null: false, default: 0
+      t.timestamps
+    end
+
+    add_index :keyword_filters, :slug, unique: true
+    add_index :keyword_filters, [ :active, :position ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_01_150000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_02_090000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -88,6 +88,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_01_150000) do
     t.index ["finished_at"], name: "index_fetch_runs_on_finished_at"
     t.index ["source_key"], name: "index_fetch_runs_on_source_key", unique: true
     t.index ["status"], name: "index_fetch_runs_on_status"
+  end
+
+  create_table "keyword_filters", force: :cascade do |t|
+    t.boolean "active", default: true, null: false
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.integer "position", default: 0, null: false
+    t.string "slug", null: false
+    t.string "terms", default: [], null: false, array: true
+    t.datetime "updated_at", null: false
+    t.index ["active", "position"], name: "index_keyword_filters_on_active_and_position"
+    t.index ["slug"], name: "index_keyword_filters_on_slug", unique: true
   end
 
   create_table "news_digests", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,1 +1,2 @@
 NewsSource.bootstrap_defaults! if NewsSource.none?
+KeywordFilter.bootstrap_defaults! if KeywordFilter.none?

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -83,7 +83,8 @@ dev-news-aggregator/
 | `read_article.rb` | `read_articles` | Article marked as read |
 | `dismissed_article.rb` | `dismissed_articles` | Article hidden from feed |
 | `news_source.rb` | `news_sources` | Optional DB-backed source registry; overrides YAML defaults when enabled |
-| `news_aggregator_config.rb` | — | Loads `config/news_aggregator.yml` (limits, retention, subreddits) |
+| `news_aggregator_config.rb` | — | Loads `config/news_aggregator.yml` (limits, retention, subreddits, interests) |
+| `keyword_filter.rb` | `keyword_filters` | Saved keyword interests (presets) for filtering the feed by topic |
 | `tag.rb` | `tags` | Topic tag vocabulary for articles |
 | `article_tag.rb` | `article_tags` | Join table for article topic tags |
 | `news_digest.rb` | `news_digests` | Generated unread digests (daily/weekly payloads) |
@@ -164,6 +165,7 @@ dev-news-aggregator/
 | `create_news_digests` | `news_digests` |
 | `enable_pg_trgm_and_article_similarity_indexes` | `pg_trgm` + trigram indexes on `articles` |
 | `add_summary_to_articles` | `articles.summary`, `summary_provider`, `summarized_at` |
+| `create_keyword_filters` | `keyword_filters` |
 
 ## `lib/`
 

--- a/test/fixtures/keyword_filters.yml
+++ b/test/fixtures/keyword_filters.yml
@@ -1,0 +1,20 @@
+ruby_interest:
+  name: "Ruby"
+  slug: "ruby"
+  terms: [ "ruby", "rubygems" ]
+  active: true
+  position: 0
+
+rust_interest:
+  name: "Rust"
+  slug: "rust"
+  terms: [ "rust", "cargo" ]
+  active: true
+  position: 1
+
+archived_interest:
+  name: "Elixir"
+  slug: "elixir"
+  terms: [ "elixir", "phoenix" ]
+  active: false
+  position: 2

--- a/test/models/keyword_filter_test.rb
+++ b/test/models/keyword_filter_test.rb
@@ -1,0 +1,99 @@
+require "test_helper"
+
+class KeywordFilterTest < ActiveSupport::TestCase
+  test "requires a name" do
+    filter = KeywordFilter.new(terms: [ "ruby" ])
+
+    assert_not filter.valid?
+    assert_includes filter.errors[:name], "can't be blank"
+  end
+
+  test "requires a unique name regardless of case" do
+    filter = KeywordFilter.new(name: "ruby", terms: [ "ruby" ])
+
+    assert_not filter.valid?
+    assert_includes filter.errors[:name], "has already been taken"
+  end
+
+  test "derives a slug from the name" do
+    filter = KeywordFilter.create!(name: "Software Architecture & Design", terms: [ "system design" ])
+
+    assert_equal "software-architecture-design", filter.slug
+  end
+
+  test "keeps slugs unique" do
+    KeywordFilter.create!(name: "AI performance", terms: [ "inference" ])
+    duplicate = KeywordFilter.new(name: "ai  performance", terms: [ "latency" ])
+
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:slug], "has already been taken"
+  end
+
+  test "normalizes terms on save" do
+    filter = KeywordFilter.create!(
+      name: "Mixed input",
+      terms: [ "  Rust ", "rust", "RUST", "", "  ", "Software Architecture" ]
+    )
+
+    assert_equal [ "rust", "software architecture" ], filter.terms
+  end
+
+  test "rejects filters without any usable term" do
+    filter = KeywordFilter.new(name: "Empty", terms: [ " ", "" ])
+
+    assert_not filter.valid?
+    assert_includes filter.errors[:terms], "must include at least one keyword"
+  end
+
+  test "caps the number of stored terms" do
+    filter = KeywordFilter.create!(
+      name: "Long list",
+      terms: (1..Article::MAX_KEYWORDS + 5).map { |index| "term-#{index}" }
+    )
+
+    assert_equal Article::MAX_KEYWORDS, filter.terms.size
+  end
+
+  test "rejects overly long terms" do
+    filter = KeywordFilter.new(name: "Too long", terms: [ "a" * (KeywordFilter::MAX_TERM_LENGTH + 1) ])
+
+    assert_not filter.valid?
+    assert_includes filter.errors[:terms], "must be #{KeywordFilter::MAX_TERM_LENGTH} characters or fewer each"
+  end
+
+  test "enabled scope skips inactive filters" do
+    enabled = KeywordFilter.enabled
+
+    assert_includes enabled, keyword_filters(:ruby_interest)
+    assert_not_includes enabled, keyword_filters(:archived_interest)
+  end
+
+  test "ordered scope sorts by position then name" do
+    KeywordFilter.update_all(position: 0)
+
+    assert_equal KeywordFilter.pluck(:name).sort, KeywordFilter.ordered.pluck(:name)
+  end
+
+  test "bootstrap_defaults! seeds configured interests and is idempotent" do
+    KeywordFilter.delete_all
+
+    KeywordFilter.bootstrap_defaults!
+    seeded = KeywordFilter.ordered.pluck(:name)
+
+    assert_equal NewsAggregatorConfig.interests.map { |interest| interest[:name] }, seeded
+    assert KeywordFilter.find_by(slug: "software-architecture").terms.include?("system design")
+
+    assert_no_difference -> { KeywordFilter.count } do
+      KeywordFilter.bootstrap_defaults!
+    end
+  end
+
+  test "bootstrap_defaults! leaves existing interests untouched" do
+    KeywordFilter.delete_all
+    custom = KeywordFilter.create!(name: "Ruby", terms: [ "my own term" ])
+
+    KeywordFilter.bootstrap_defaults!
+
+    assert_equal [ "my own term" ], custom.reload.terms
+  end
+end


### PR DESCRIPTION
## Summary

Closes #374.

- Adds the `keyword_filters` table (`name`, unique `slug`, `terms` string array, `active`, `position`) and the `KeywordFilter` model, following the `NewsSource` precedent of DB-backed config with YAML defaults
- Slugs are derived from the name; terms are normalized with the same rules as the `keywords` index filter from #373 (trim, downcase, dedupe, capped at `Article::MAX_KEYWORDS`), so a preset can never produce an unbounded query
- Validates name presence and case-insensitive uniqueness, slug uniqueness, at least one usable term, and a 60-character limit per term
- Starter interests (Ruby, Rails, Rust, Software architecture, AI performance) live under a new `interests:` key in `config/news_aggregator.yml` and are seeded by `KeywordFilter.bootstrap_defaults!` from `db/seeds.rb`
- Seeding is idempotent and never overwrites an existing interest, so local edits survive re-seeding

## Test plan

- [x] `bin/rails test test/models/keyword_filter_test.rb` (12 runs) — validations, slug derivation, term normalization, term cap, scopes, and both seeding behaviors
- [x] `bin/rails test` (330 runs, 0 failures)
- [x] `bundle exec rubocop` (141 files, no offenses)

## Notes

- No controller or UI yet: CRUD endpoints are #375 and the chip UI is #376
- `docs/REPO_STRUCTURE.md` lists the new model and migration
