### PR TITLE
feat(api): add CRUD endpoints for keyword filters (#375)

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -150,11 +150,27 @@ class ArticlesController < ApplicationController
 
     scope = apply_score_filter(scope)
     scope = scope.search(params[:q])
-    scope = scope.matching_keywords(params[:keywords], match: params[:match])
+    scope = apply_keyword_filter(scope)
     scope = scope.with_topic_tag(params[:tag])
     scope = helpers.apply_category_filter(scope, params[:category]) if apply_category
     scope = ArticleClusterer.primaries(scope)
     apply_sort(scope.includes(:bookmark, :read_article, :dismissed_article, :tags))
+  end
+
+  # `interest=<slug>` expands to that preset's saved terms and is unioned with any explicit
+  # `keywords`; `match` then applies to the combined list. An unknown slug filters everything
+  # out, mirroring how an unknown category behaves.
+  def apply_keyword_filter(scope)
+    terms = Article.normalize_keywords(params[:keywords])
+
+    if params[:interest].present?
+      interest = KeywordFilter.find_by(slug: params[:interest])
+      return scope.none if interest.nil?
+
+      terms += interest.terms
+    end
+
+    scope.matching_keywords(terms, match: params[:match])
   end
 
   def apply_sort(scope)

--- a/app/controllers/keyword_filters_controller.rb
+++ b/app/controllers/keyword_filters_controller.rb
@@ -1,0 +1,67 @@
+class KeywordFiltersController < ApplicationController
+  include MutatingAuthentication
+
+  before_action :authenticate_mutation!, only: %i[create update destroy]
+  before_action :set_keyword_filter, only: %i[update destroy]
+
+  def index
+    KeywordFilter.bootstrap_defaults! if KeywordFilter.none?
+
+    filters = KeywordFilter.ordered.to_a
+    counts = Article.keyword_match_counts(filters.map(&:terms), scope: match_count_scope)
+
+    render json: {
+      keyword_filters: filters.each_with_index.map { |filter, index|
+        KeywordFilterSerializer.as_json(filter, article_count: counts[index])
+      }
+    }
+  end
+
+  def create
+    keyword_filter = KeywordFilter.new(keyword_filter_params)
+
+    unless keyword_filter.save
+      return render json: { errors: keyword_filter.errors.full_messages }, status: :unprocessable_entity
+    end
+
+    render json: KeywordFilterSerializer.as_json(keyword_filter), status: :created
+  end
+
+  def update
+    unless @keyword_filter.update(keyword_filter_params)
+      return render json: { errors: @keyword_filter.errors.full_messages }, status: :unprocessable_entity
+    end
+
+    render json: KeywordFilterSerializer.as_json(@keyword_filter)
+  end
+
+  def destroy
+    @keyword_filter.destroy!
+    head :no_content
+  end
+
+  private
+
+  def set_keyword_filter
+    @keyword_filter = KeywordFilter.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: "Keyword filter not found" }, status: :not_found
+  end
+
+  def keyword_filter_params
+    raw = params.require(:keyword_filter)
+    attributes = raw.permit(:name, :active, :position).to_h
+    attributes[:terms] = terms_from(raw[:terms]) if raw.key?(:terms)
+    attributes
+  end
+
+  # Accepts both ["ruby", "rails"] and "ruby, rails" so the UI and curl can use either.
+  def terms_from(value)
+    value.is_a?(String) ? value.split(",") : Array(value).map(&:to_s)
+  end
+
+  # Counts only what the feed can currently show: kept articles inside the retention window.
+  def match_count_scope
+    Article.not_dismissed.where(published_at: NewsAggregatorConfig.retention_days.days.ago..)
+  end
+end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -43,14 +43,8 @@ class Article < ApplicationRecord
     joins(:tags).where(tags: { slug: slug }).distinct
   }
   scope :matching_keywords, ->(terms, match: :any) {
-    keywords = Article.normalize_keywords(terms)
-    return all if keywords.empty?
-
-    joiner = match.to_s == "all" ? " AND " : " OR "
-    clause = keywords.map { "(title ILIKE ? OR COALESCE(description, '') ILIKE ?)" }.join(joiner)
-    patterns = keywords.flat_map { |keyword| [ "%#{sanitize_sql_like(keyword)}%" ] * 2 }
-
-    where(clause, *patterns)
+    clause = Article.keyword_clause(terms, match: match)
+    clause ? where(clause) : all
   }
 
   # Accepts a comma-separated string or an array; multi-word terms stay whole phrases.
@@ -61,6 +55,31 @@ class Article < ApplicationRecord
         .reject(&:blank?)
         .uniq { |term| term.downcase }
         .first(MAX_KEYWORDS)
+  end
+
+  # Sanitized SQL fragment for the given terms, or nil when there is nothing to match.
+  def self.keyword_clause(terms, match: :any)
+    keywords = normalize_keywords(terms)
+    return nil if keywords.empty?
+
+    joiner = match.to_s == "all" ? " AND " : " OR "
+    keywords.map { |keyword|
+      pattern = "%#{sanitize_sql_like(keyword)}%"
+      sanitize_sql_array([ "(title ILIKE ? OR COALESCE(description, '') ILIKE ?)", pattern, pattern ])
+    }.join(joiner)
+  end
+
+  # Conditional counts in one query, so listing N keyword presets stays a single round trip.
+  def self.keyword_match_counts(term_groups, scope: all)
+    return [] if term_groups.empty?
+
+    projections = term_groups.each_with_index.map { |terms, index|
+      "COUNT(CASE WHEN #{keyword_clause(terms) || 'FALSE'} THEN 1 END) AS keyword_count_#{index}"
+    }
+
+    row = scope.unscope(:includes, :order, :select, :limit, :offset).select(projections.join(", ")).take
+
+    term_groups.each_index.map { |index| row.public_send("keyword_count_#{index}").to_i }
   end
 
   def self.similar_to(article, limit: 5)

--- a/app/serializers/keyword_filter_serializer.rb
+++ b/app/serializers/keyword_filter_serializer.rb
@@ -1,0 +1,13 @@
+class KeywordFilterSerializer
+  def self.as_json(keyword_filter, article_count: nil)
+    {
+      id: keyword_filter.id,
+      name: keyword_filter.name,
+      slug: keyword_filter.slug,
+      terms: keyword_filter.terms,
+      active: keyword_filter.active,
+      position: keyword_filter.position,
+      article_count: article_count
+    }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,8 @@ Rails.application.routes.draw do
 
   resources :sources, only: [ :index, :create, :update, :destroy ]
 
+  resources :keyword_filters, only: [ :index, :create, :update, :destroy ]
+
   # Bookmarks routes
   resources :bookmarks, only: [ :index ]
 

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -73,6 +73,7 @@ dev-news-aggregator/
 | `bookmarks_controller.rb` | Saved articles index |
 | `read_articles_controller.rb` | Mark articles as read |
 | `dismissed_articles_controller.rb` | Dismissed and recently dismissed lists |
+| `keyword_filters_controller.rb` | CRUD for saved keyword interests (presets) |
 
 ### Models
 

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -281,6 +281,33 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
     assert_equal JSON.parse(response.body)["pagination"]["total_count"], unfiltered
   end
 
+  test "index JSON filters by a saved interest slug" do
+    get articles_url(interest: "ruby"), as: :json
+    assert_response :success
+
+    ids = JSON.parse(response.body)["articles"].map { |article| article["id"] }
+    assert_includes ids, @dev_to_article.id
+    assert_not_includes ids, @rust_article.id
+  end
+
+  test "index JSON unions interest terms with explicit keywords" do
+    get articles_url(interest: "ruby", keywords: "rust"), as: :json
+    assert_response :success
+
+    ids = JSON.parse(response.body)["articles"].map { |article| article["id"] }
+    assert_includes ids, @dev_to_article.id
+    assert_includes ids, @rust_article.id
+  end
+
+  test "index JSON returns nothing for an unknown interest" do
+    get articles_url(interest: "does-not-exist"), as: :json
+    assert_response :success
+
+    body = JSON.parse(response.body)
+    assert_empty body["articles"]
+    assert_equal 0, body["pagination"]["total_count"]
+  end
+
   test "index JSON keeps category counts consistent with keyword filter" do
     get articles_url(keywords: "rust"), as: :json
     assert_response :success

--- a/test/controllers/keyword_filters_controller_test.rb
+++ b/test/controllers/keyword_filters_controller_test.rb
@@ -1,0 +1,137 @@
+require "test_helper"
+
+class KeywordFiltersControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @ruby_interest = keyword_filters(:ruby_interest)
+  end
+
+  test "index returns filters with terms and match counts" do
+    get keyword_filters_url, as: :json
+    assert_response :success
+
+    body = JSON.parse(response.body)
+    names = body["keyword_filters"].map { |filter| filter["name"] }
+    assert_includes names, "Ruby"
+    assert_includes names, "Elixir"
+
+    ruby = body["keyword_filters"].find { |filter| filter["slug"] == "ruby" }
+    assert_equal [ "ruby", "rubygems" ], ruby["terms"]
+    assert_equal 1, ruby["article_count"]
+
+    elixir = body["keyword_filters"].find { |filter| filter["slug"] == "elixir" }
+    assert_equal 0, elixir["article_count"]
+  end
+
+  test "index seeds default interests when none exist" do
+    KeywordFilter.delete_all
+
+    get keyword_filters_url, as: :json
+    assert_response :success
+
+    slugs = JSON.parse(response.body)["keyword_filters"].map { |filter| filter["slug"] }
+    assert_includes slugs, "software-architecture"
+  end
+
+  test "index counts matches in a single query per request" do
+    queries = 0
+    subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |_name, _start, _finish, _id, payload|
+      queries += 1 if payload[:sql].to_s.include?("keyword_count_0")
+    end
+
+    get keyword_filters_url, as: :json
+
+    assert_equal 1, queries
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber)
+  end
+
+  test "create adds a filter from an array of terms" do
+    assert_difference -> { KeywordFilter.count }, 1 do
+      post keyword_filters_url, params: { keyword_filter: { name: "Observability", terms: [ "tracing", " OpenTelemetry " ] } }, as: :json
+    end
+
+    assert_response :created
+    body = JSON.parse(response.body)
+    assert_equal "observability", body["slug"]
+    assert_equal [ "tracing", "opentelemetry" ], body["terms"]
+  end
+
+  test "create accepts comma-separated terms" do
+    post keyword_filters_url, params: { keyword_filter: { name: "Databases", terms: "postgres, sqlite" } }, as: :json
+
+    assert_response :created
+    assert_equal [ "postgres", "sqlite" ], JSON.parse(response.body)["terms"]
+  end
+
+  test "create returns 422 with messages for invalid payloads" do
+    assert_no_difference -> { KeywordFilter.count } do
+      post keyword_filters_url, params: { keyword_filter: { name: "", terms: [] } }, as: :json
+    end
+
+    assert_response :unprocessable_entity
+    errors = JSON.parse(response.body)["errors"]
+    assert_includes errors, "Name can't be blank"
+    assert_includes errors, "Terms must include at least one keyword"
+  end
+
+  test "update replaces terms and toggles active" do
+    patch keyword_filter_url(@ruby_interest), params: { keyword_filter: { terms: [ "ruby", "hotwire" ], active: false } }, as: :json
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_equal [ "ruby", "hotwire" ], body["terms"]
+    assert_equal false, body["active"]
+  end
+
+  test "update returns 422 when terms become empty" do
+    patch keyword_filter_url(@ruby_interest), params: { keyword_filter: { terms: [ "  " ] } }, as: :json
+
+    assert_response :unprocessable_entity
+    assert_equal [ "ruby", "rubygems" ], @ruby_interest.reload.terms
+  end
+
+  test "destroy removes the filter" do
+    assert_difference -> { KeywordFilter.count }, -1 do
+      delete keyword_filter_url(@ruby_interest)
+    end
+
+    assert_response :no_content
+  end
+
+  test "update returns 404 for unknown filters" do
+    patch keyword_filter_url(id: 0), params: { keyword_filter: { name: "Nope" } }, as: :json
+
+    assert_response :not_found
+  end
+
+  test "writes require mutating auth when configured" do
+    previous_username = ENV["MUTATING_AUTH_USERNAME"]
+    previous_password = ENV["MUTATING_AUTH_PASSWORD"]
+    ENV["MUTATING_AUTH_USERNAME"] = "admin"
+    ENV["MUTATING_AUTH_PASSWORD"] = "secret"
+
+    post keyword_filters_url, params: { keyword_filter: { name: "Blocked", terms: [ "nope" ] } }, as: :json
+    assert_response :unauthorized
+
+    get keyword_filters_url, as: :json
+    assert_response :success
+
+    post keyword_filters_url,
+         params: { keyword_filter: { name: "Allowed", terms: [ "yes" ] } },
+         headers: { "Authorization" => ActionController::HttpAuthentication::Basic.encode_credentials("admin", "secret") },
+         as: :json
+    assert_response :created
+  ensure
+    if previous_username
+      ENV["MUTATING_AUTH_USERNAME"] = previous_username
+    else
+      ENV.delete("MUTATING_AUTH_USERNAME")
+    end
+
+    if previous_password
+      ENV["MUTATING_AUTH_PASSWORD"] = previous_password
+    else
+      ENV.delete("MUTATING_AUTH_PASSWORD")
+    end
+  end
+end


### PR DESCRIPTION
Closes #375.

## Summary

- Adds `KeywordFiltersController` with `index`, `create`, `update` and `destroy` for the saved interest presets introduced in #374. Writes go through `MutatingAuthentication`; `index` stays public like the rest of the read endpoints.
- Adds `KeywordFilterSerializer` exposing `id`, `name`, `slug`, `terms`, `active`, `position` and `article_count`. The count reflects what the feed can actually show (not dismissed, inside the retention window).
- `Article.keyword_match_counts` computes every preset's count with conditional aggregates in a single query, so listing N interests never turns into N `COUNT(*)` round trips. `Article.keyword_clause` was extracted from `matching_keywords` to build the shared sanitized SQL fragment.
- `ArticlesController#index` now accepts `interest=<slug>`, which expands to that preset's terms and is unioned with any explicit `keywords` before `match` is applied. An unknown slug returns an empty result set, mirroring the existing unknown-category behavior.
- `GET /keyword_filters` bootstraps the defaults from `config/news_aggregator.yml` when the table is empty, so a fresh install returns the curated interests without a manual seed step.

## API

```
GET    /keyword_filters
POST   /keyword_filters      { keyword_filter: { name:, terms: [...] | "a, b" } }
PATCH  /keyword_filters/:id  { keyword_filter: { name:, terms:, active:, position: } }
DELETE /keyword_filters/:id

GET    /articles?interest=ruby
GET    /articles?interest=ruby&keywords=rust&match=any
```

`terms` accepts both an array and a comma-separated string so the UI and `curl` can use either form.

## Test plan

- [x] `bin/rails test test/controllers/keyword_filters_controller_test.rb` — 11 runs covering index payload/counts, default bootstrap, single-query counting, create from array and from a comma string, 422s with full messages, update replacing terms and toggling `active`, destroy, 404 on unknown id, and the mutating-auth gate.
- [x] `bin/rails test test/controllers/articles_controller_test.rb` — 66 runs, including the new `interest` slug filter, the union of `interest` with explicit `keywords`, and the empty result for an unknown slug.
- [x] `bin/rails test test/models/article_test.rb test/models/keyword_filter_test.rb` — 62 runs.
- [x] `bin/rubocop` on the touched files.
