### PR TITLE
feat(frontend): add interest chip filters on articles index (#376)

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -157,20 +157,29 @@ class ArticlesController < ApplicationController
     apply_sort(scope.includes(:bookmark, :read_article, :dismissed_article, :tags))
   end
 
-  # `interest=<slug>` expands to that preset's saved terms and is unioned with any explicit
-  # `keywords`; `match` then applies to the combined list. An unknown slug filters everything
-  # out, mirroring how an unknown category behaves.
+  # `interests=<slug,slug>` (or singular `interest`) expands to the presets' saved terms, unioned
+  # with any explicit `keywords`; `match` then applies to the combined list. An unknown slug
+  # filters everything out, mirroring how an unknown category behaves.
   def apply_keyword_filter(scope)
     terms = Article.normalize_keywords(params[:keywords])
+    slugs = interest_slugs
 
-    if params[:interest].present?
-      interest = KeywordFilter.find_by(slug: params[:interest])
-      return scope.none if interest.nil?
+    if slugs.any?
+      interests = KeywordFilter.where(slug: slugs).to_a
+      return scope.none if interests.size < slugs.size
 
-      terms += interest.terms
+      terms += interests.flat_map(&:terms)
     end
 
     scope.matching_keywords(terms, match: params[:match])
+  end
+
+  def interest_slugs
+    [ params[:interests], params[:interest] ]
+      .flat_map { |value| value.to_s.split(",") }
+      .map { |slug| slug.strip.downcase }
+      .reject(&:empty?)
+      .uniq
   end
 
   def apply_sort(scope)

--- a/app/frontend/api/articles.ts
+++ b/app/frontend/api/articles.ts
@@ -7,6 +7,7 @@ export function fetchArticles(params?: {
   show_read?: boolean
   category?: string
   tag?: string
+  interests?: string[]
   q?: string
   sort?: string
   min_score?: number
@@ -19,6 +20,7 @@ export function fetchArticles(params?: {
   if (params?.show_read) search.set('show_read', 'true')
   if (params?.category && params.category !== 'all') search.set('category', params.category)
   if (params?.tag && params.tag !== 'all') search.set('tag', params.tag)
+  if (params?.interests?.length) search.set('interests', params.interests.join(','))
   if (params?.q?.trim()) search.set('q', params.q.trim())
   if (params?.sort && params.sort !== 'published_at') search.set('sort', params.sort)
   if (params?.min_score) search.set('min_score', String(params.min_score))

--- a/app/frontend/api/keywordFilters.ts
+++ b/app/frontend/api/keywordFilters.ts
@@ -1,0 +1,10 @@
+import { apiRequest } from './client'
+import type { KeywordFiltersIndexResponse } from '../types/keywordFilter'
+
+export function fetchKeywordFilters(params?: { signal?: AbortSignal }) {
+  return apiRequest<KeywordFiltersIndexResponse>('/keyword_filters.json', {
+    signal: params?.signal,
+  })
+}
+
+export type { KeywordFilter, KeywordFiltersIndexResponse } from '../types/keywordFilter'

--- a/app/frontend/components/InterestFilter.test.tsx
+++ b/app/frontend/components/InterestFilter.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import InterestFilter, { parseInterests, toggleInterest } from '../components/InterestFilter'
+import { buildKeywordFilter } from '../test/fixtures'
+
+const interests = [
+  buildKeywordFilter(),
+  buildKeywordFilter({ id: 2, name: 'Rust', slug: 'rust', terms: ['rust'], article_count: 5 }),
+]
+
+describe('InterestFilter', () => {
+  it('renders one chip per interest with its article count', () => {
+    render(
+      <InterestFilter interests={interests} selectedSlugs={[]} onToggle={vi.fn()} onClear={vi.fn()} />
+    )
+
+    expect(screen.getByRole('button', { name: 'Ruby (3)' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Rust (5)' })).toBeInTheDocument()
+  })
+
+  it('omits the count when the API does not provide one', () => {
+    render(
+      <InterestFilter
+        interests={[buildKeywordFilter({ article_count: null })]}
+        selectedSlugs={[]}
+        onToggle={vi.fn()}
+        onClear={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Ruby' })).toBeInTheDocument()
+  })
+
+  it('marks selected interests with aria-pressed', () => {
+    render(
+      <InterestFilter
+        interests={interests}
+        selectedSlugs={['rust']}
+        onToggle={vi.fn()}
+        onClear={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Ruby (3)' })).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.getByRole('button', { name: 'Rust (5)' })).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('calls onToggle with the chip slug', async () => {
+    const user = userEvent.setup()
+    const onToggle = vi.fn()
+    render(
+      <InterestFilter interests={interests} selectedSlugs={[]} onToggle={onToggle} onClear={vi.fn()} />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Rust (5)' }))
+
+    expect(onToggle).toHaveBeenCalledWith('rust')
+  })
+
+  it('shows the clear affordance only while something is selected', async () => {
+    const user = userEvent.setup()
+    const onClear = vi.fn()
+    const { rerender } = render(
+      <InterestFilter interests={interests} selectedSlugs={[]} onToggle={vi.fn()} onClear={onClear} />
+    )
+
+    expect(screen.queryByTestId('clear-interests')).not.toBeInTheDocument()
+
+    rerender(
+      <InterestFilter
+        interests={interests}
+        selectedSlugs={['ruby']}
+        onToggle={vi.fn()}
+        onClear={onClear}
+      />
+    )
+
+    await user.click(screen.getByTestId('clear-interests'))
+    expect(onClear).toHaveBeenCalled()
+  })
+
+  it('renders nothing when there are no interests', () => {
+    const { container } = render(
+      <InterestFilter interests={[]} selectedSlugs={[]} onToggle={vi.fn()} onClear={vi.fn()} />
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+})
+
+describe('parseInterests', () => {
+  it('splits, trims, downcases and dedupes slugs', () => {
+    expect(parseInterests(' Ruby, rust ,ruby')).toEqual(['ruby', 'rust'])
+  })
+
+  it('returns an empty list for missing or blank values', () => {
+    expect(parseInterests(null)).toEqual([])
+    expect(parseInterests(' , ')).toEqual([])
+  })
+})
+
+describe('toggleInterest', () => {
+  it('adds a slug that is not selected yet', () => {
+    expect(toggleInterest(['ruby'], 'rust')).toEqual(['ruby', 'rust'])
+  })
+
+  it('removes a slug that is already selected', () => {
+    expect(toggleInterest(['ruby', 'rust'], 'ruby')).toEqual(['rust'])
+  })
+})

--- a/app/frontend/components/InterestFilter.tsx
+++ b/app/frontend/components/InterestFilter.tsx
@@ -1,0 +1,69 @@
+import type { KeywordFilter } from '../types/keywordFilter'
+import Button from './ui/Button'
+import Card from './ui/Card'
+
+interface InterestFilterProps {
+  interests: KeywordFilter[]
+  selectedSlugs: string[]
+  onToggle: (slug: string) => void
+  onClear: () => void
+}
+
+export default function InterestFilter({
+  interests,
+  selectedSlugs,
+  onToggle,
+  onClear,
+}: InterestFilterProps) {
+  if (interests.length === 0) return null
+
+  return (
+    <div className="mb-8">
+      <Card tone="subtle">
+        <div className="flex items-center justify-between gap-4 mb-4">
+          <h2 className="text-h3 text-gray-100">Filter by interest</h2>
+          {selectedSlugs.length > 0 && (
+            <button
+              type="button"
+              className="text-sm text-gray-300 underline hover:text-white"
+              data-testid="clear-interests"
+              onClick={onClear}
+            >
+              Clear interests
+            </button>
+          )}
+        </div>
+        <div className="flex flex-wrap gap-3">
+          {interests.map((interest) => {
+            const selected = selectedSlugs.includes(interest.slug)
+            return (
+              <Button
+                key={interest.slug}
+                variant="filter"
+                active={selected}
+                data-filter-type="interest"
+                data-filter-value={interest.slug}
+                aria-pressed={selected}
+                onClick={() => onToggle(interest.slug)}
+              >
+                {interest.article_count === null
+                  ? interest.name
+                  : `${interest.name} (${interest.article_count})`}
+              </Button>
+            )
+          })}
+        </div>
+      </Card>
+    </div>
+  )
+}
+
+export function parseInterests(value: string | null): string[] {
+  if (!value) return []
+
+  return [...new Set(value.split(',').map((slug) => slug.trim().toLowerCase()).filter(Boolean))]
+}
+
+export function toggleInterest(slugs: string[], slug: string): string[] {
+  return slugs.includes(slug) ? slugs.filter((current) => current !== slug) : [...slugs, slug]
+}

--- a/app/frontend/components/a11y.test.tsx
+++ b/app/frontend/components/a11y.test.tsx
@@ -6,7 +6,9 @@ import { axe } from 'vitest-axe'
 import ArticleCard from './ArticleCard'
 import CategoryFilter from './CategoryFilter'
 import ConfirmDialog from './ConfirmDialog'
+import InterestFilter from './InterestFilter'
 import PageHeading from './ui/PageHeading'
+import { buildKeywordFilter } from '../test/fixtures'
 
 const baseArticle = {
   id: 1,
@@ -38,6 +40,27 @@ describe('accessibility audits', () => {
         totalCount={4}
         activeFilter="all"
         onFilterChange={vi.fn()}
+      />
+    )
+
+    const results = await axe(container, {
+      rules: {
+        'color-contrast': { enabled: true },
+      },
+    })
+    expect(results).toHaveNoViolations()
+  })
+
+  it('InterestFilter has no critical accessibility violations', async () => {
+    const { container } = render(
+      <InterestFilter
+        interests={[
+          buildKeywordFilter(),
+          buildKeywordFilter({ id: 2, name: 'Rust', slug: 'rust', terms: ['rust'], article_count: 5 }),
+        ]}
+        selectedSlugs={['ruby']}
+        onToggle={vi.fn()}
+        onClear={vi.fn()}
       />
     )
 

--- a/app/frontend/pages/ArticlesIndexPage.test.tsx
+++ b/app/frontend/pages/ArticlesIndexPage.test.tsx
@@ -4,7 +4,12 @@ import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import ArticlesIndexPage from '../pages/ArticlesIndexPage'
 import * as articlesApi from '../api/articles'
-import { buildArticle, buildArticlesIndexResponse } from '../test/fixtures'
+import * as keywordFiltersApi from '../api/keywordFilters'
+import {
+  buildArticle,
+  buildArticlesIndexResponse,
+  buildKeywordFiltersResponse,
+} from '../test/fixtures'
 
 vi.mock('../api/articles', () => ({
   fetchArticles: vi.fn(),
@@ -15,6 +20,10 @@ vi.mock('../api/articles', () => ({
   markArticleAsRead: vi.fn(),
   unmarkArticleAsRead: vi.fn(),
   fetchNews: vi.fn(),
+}))
+
+vi.mock('../api/keywordFilters', () => ({
+  fetchKeywordFilters: vi.fn(),
 }))
 
 function renderPage(initialEntries = ['/articles']) {
@@ -37,6 +46,7 @@ describe('ArticlesIndexPage dismiss flow', () => {
     vi.mocked(articlesApi.fetchArticles).mockResolvedValue(buildArticlesIndexResponse())
     vi.mocked(articlesApi.dismissArticle).mockResolvedValue({ status: 'dismissed', timeout: 15 })
     vi.mocked(articlesApi.undismissArticle).mockResolvedValue({ status: 'restored' })
+    vi.mocked(keywordFiltersApi.fetchKeywordFilters).mockResolvedValue(buildKeywordFiltersResponse())
   })
 
   afterEach(() => {
@@ -197,6 +207,91 @@ describe('ArticlesIndexPage dismiss flow', () => {
     expect(screen.getByText('No articles match your search')).toBeInTheDocument()
     expect(screen.queryByText('Your feed is empty')).not.toBeInTheDocument()
     expect(screen.getByTestId('article-search-input')).toHaveValue('zzzz-no-match')
+  })
+
+  it('renders interest chips and reflects the interests URL param', async () => {
+    renderPage(['/articles?interests=rust'])
+
+    await waitForArticlesFeed()
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Rust (5)' })).toHaveAttribute('aria-pressed', 'true')
+    })
+    expect(screen.getByRole('button', { name: 'Ruby (3)' })).toHaveAttribute('aria-pressed', 'false')
+    expect(articlesApi.fetchArticles).toHaveBeenCalledWith(
+      expect.objectContaining({ interests: ['rust'] })
+    )
+  })
+
+  it('adds and removes interests from the request as chips are toggled', async () => {
+    const user = userEvent.setup()
+    renderPage(['/articles?interests=rust'])
+
+    await waitForArticlesFeed()
+    await user.click(await screen.findByRole('button', { name: 'Ruby (3)' }))
+
+    await waitFor(() => {
+      expect(articlesApi.fetchArticles).toHaveBeenCalledWith(
+        expect.objectContaining({ interests: ['rust', 'ruby'] })
+      )
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Rust (5)' }))
+
+    await waitFor(() => {
+      expect(articlesApi.fetchArticles).toHaveBeenCalledWith(
+        expect.objectContaining({ interests: ['ruby'] })
+      )
+    })
+  })
+
+  it('clears interests and resets pagination', async () => {
+    const user = userEvent.setup()
+    renderPage(['/articles?interests=ruby,rust&page=3'])
+
+    await waitForArticlesFeed()
+    await user.click(await screen.findByTestId('clear-interests'))
+
+    await waitFor(() => {
+      expect(articlesApi.fetchArticles).toHaveBeenCalledWith(
+        expect.objectContaining({ interests: undefined, page: 1 })
+      )
+    })
+    expect(screen.queryByTestId('clear-interests')).not.toBeInTheDocument()
+  })
+
+  it('shows an interest-specific empty state when nothing matches', async () => {
+    vi.mocked(articlesApi.fetchArticles).mockResolvedValue(
+      buildArticlesIndexResponse({
+        articles: [],
+        articles_by_category: {},
+        category_counts: {},
+        pagination: {
+          current_page: 1,
+          per_page: 20,
+          total_count: 0,
+          total_pages: 0,
+        },
+      })
+    )
+
+    renderPage(['/articles?interests=rust'])
+
+    await screen.findByTestId('articles-page')
+    expect(await screen.findByText('No articles match these interests')).toBeInTheDocument()
+    expect(screen.queryByText('Your feed is empty')).not.toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Rust (5)' })).toBeInTheDocument()
+    })
+  })
+
+  it('keeps the feed usable when interests fail to load', async () => {
+    vi.mocked(keywordFiltersApi.fetchKeywordFilters).mockRejectedValue(new Error('boom'))
+
+    renderPage()
+
+    await waitForArticlesFeed()
+    expect(screen.queryByText('Filter by interest')).not.toBeInTheDocument()
+    expect(screen.getByText('Rust 2024 Edition Highlights')).toBeInTheDocument()
   })
 
   it('counts down dismiss toast and removes article after timeout', async () => {

--- a/app/frontend/pages/ArticlesIndexPage.tsx
+++ b/app/frontend/pages/ArticlesIndexPage.tsx
@@ -12,7 +12,9 @@ import {
   type Article,
 } from '../api/articles'
 import { isAbortError } from '../api/client'
+import { fetchKeywordFilters } from '../api/keywordFilters'
 import type { ArticlesIndexResponse } from '../types/article'
+import type { KeywordFilter } from '../types/keywordFilter'
 import { parameterize, truncate } from '../utils/format'
 import ArticleList from '../components/ArticleList'
 import ArticleListSkeleton from '../components/ArticleListSkeleton'
@@ -20,6 +22,7 @@ import ArticleSearch from '../components/ArticleSearch'
 import CategoryFilter from '../components/CategoryFilter'
 import DismissToast from '../components/DismissToast'
 import EmptyState from '../components/EmptyState'
+import InterestFilter, { parseInterests, toggleInterest } from '../components/InterestFilter'
 import PageHeader from '../components/PageHeader'
 import PageHeaderSkeleton from '../components/PageHeaderSkeleton'
 import PageContainer from '../components/ui/PageContainer'
@@ -59,8 +62,11 @@ export default function ArticlesIndexPage() {
   const activeSort = parseSort(searchParams.get('sort'))
   const showRead = searchParams.get('show_read') === 'true'
   const searchQuery = (searchParams.get('q') ?? '').trim()
+  const interestsParam = searchParams.get('interests') ?? ''
+  const activeInterests = useMemo(() => parseInterests(interestsParam), [interestsParam])
 
   const [searchInput, setSearchInput] = useState(searchQuery)
+  const [interests, setInterests] = useState<KeywordFilter[]>([])
   const [data, setData] = useState<ArticlesIndexResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -113,6 +119,7 @@ export default function ArticlesIndexPage() {
         show_read: showRead,
         category: activeFilter !== 'all' ? activeFilter : undefined,
         tag: activeTag !== 'all' ? activeTag : undefined,
+        interests: activeInterests.length > 0 ? activeInterests : undefined,
         q: searchQuery || undefined,
         sort: activeSort,
         ...scoreFilterParams(activeScoreFilter),
@@ -133,7 +140,7 @@ export default function ArticlesIndexPage() {
     } finally {
       if (!signal.aborted) setLoading(false)
     }
-  }, [showRead, activeScoreFilter, activeFilter, activeTag, activeSort, searchQuery, currentPage, patchSearchParams])
+  }, [showRead, activeScoreFilter, activeFilter, activeTag, activeInterests, activeSort, searchQuery, currentPage, patchSearchParams])
 
   useEffect(() => {
     void loadArticles()
@@ -141,6 +148,20 @@ export default function ArticlesIndexPage() {
       abortRef.current?.abort()
     }
   }, [loadArticles])
+
+  // Interest presets are an enhancement over the rest of the filters: if they fail to load the
+  // chips stay hidden instead of blocking the feed.
+  useEffect(() => {
+    const controller = new AbortController()
+
+    fetchKeywordFilters({ signal: controller.signal })
+      .then((response) => {
+        if (!controller.signal.aborted) setInterests(response.keyword_filters)
+      })
+      .catch(() => {})
+
+    return () => controller.abort()
+  }, [])
 
   const articleCategories = useMemo(
     () => (data ? buildArticleCategories(data) : {}),
@@ -157,6 +178,14 @@ export default function ArticlesIndexPage() {
   const articles = useMemo(
     () => data?.articles.filter((article) => !removedIds.has(article.id)) ?? [],
     [data, removedIds]
+  )
+
+  const interestLabels = useMemo(
+    () =>
+      activeInterests
+        .map((slug) => interests.find((interest) => interest.slug === slug)?.name ?? slug)
+        .join(', '),
+    [activeInterests, interests]
   )
 
   const clearDismissTimer = () => {
@@ -274,6 +303,22 @@ export default function ArticlesIndexPage() {
     })
   }
 
+  const handleInterestToggle = (slug: string) => {
+    patchSearchParams((params) => {
+      const next = toggleInterest(parseInterests(params.get('interests')), slug)
+      if (next.length === 0) params.delete('interests')
+      else params.set('interests', next.join(','))
+      params.delete('page')
+    })
+  }
+
+  const handleInterestsClear = () => {
+    patchSearchParams((params) => {
+      params.delete('interests')
+      params.delete('page')
+    })
+  }
+
   const handlePageChange = (page: number) => {
     patchSearchParams((params) => {
       if (page <= 1) params.delete('page')
@@ -381,9 +426,25 @@ export default function ArticlesIndexPage() {
     )
   }
 
-  const showEmptyFeed = !data || (!searchQuery && allArticlesCount === 0 && articles.length === 0)
-  const showNoSearchResults =
-    Boolean(searchQuery) && articles.length === 0 && (data?.pagination.total_count ?? 0) === 0
+  const hasInterestFilter = activeInterests.length > 0
+  const noResults = articles.length === 0 && (data?.pagination.total_count ?? 0) === 0
+  const showEmptyFeed =
+    !data || (!searchQuery && !hasInterestFilter && allArticlesCount === 0 && articles.length === 0)
+  const showNoSearchResults = Boolean(searchQuery) && noResults
+  const showNoInterestResults = !searchQuery && hasInterestFilter && noResults
+
+  let emptyResults: { title: string; description: string } | null = null
+  if (showNoSearchResults) {
+    emptyResults = {
+      title: 'No articles match your search',
+      description: `Nothing matched “${searchQuery}”. Try a different term or clear the search.`,
+    }
+  } else if (showNoInterestResults) {
+    emptyResults = {
+      title: 'No articles match these interests',
+      description: `Nothing in the feed mentions ${interestLabels}. Try picking fewer interests or clearing them.`,
+    }
+  }
 
   if (showEmptyFeed) {
     return (
@@ -439,6 +500,13 @@ export default function ArticlesIndexPage() {
 
       <ArticleSearch value={searchInput} onChange={setSearchInput} />
 
+      <InterestFilter
+        interests={interests}
+        selectedSlugs={activeInterests}
+        onToggle={handleInterestToggle}
+        onClear={handleInterestsClear}
+      />
+
       <ScoreFilter
         activeScoreFilter={activeScoreFilter}
         onScoreFilterChange={handleScoreFilterChange}
@@ -463,7 +531,7 @@ export default function ArticlesIndexPage() {
         onTagChange={handleTagChange}
       />
 
-      {showNoSearchResults ? (
+      {emptyResults ? (
         <EmptyState
           icon={
             <svg className="w-10 h-10 text-primary-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -475,8 +543,8 @@ export default function ArticlesIndexPage() {
               />
             </svg>
           }
-          title="No articles match your search"
-          description={`Nothing matched “${searchQuery}”. Try a different term or clear the search.`}
+          title={emptyResults.title}
+          description={emptyResults.description}
         />
       ) : (
         <>

--- a/app/frontend/test/fixtures.ts
+++ b/app/frontend/test/fixtures.ts
@@ -1,6 +1,7 @@
 import type { Article, ArticlesIndexResponse } from '../types/article'
 import type { BookmarkArticle, BookmarksIndexResponse } from '../types/bookmark'
 import type { NewsSource, SourcesIndexResponse } from '../api/sources'
+import type { KeywordFilter, KeywordFiltersIndexResponse } from '../types/keywordFilter'
 
 export function buildArticle(overrides: Partial<Article> = {}): Article {
   return {
@@ -61,6 +62,38 @@ export function buildArticlesIndexResponse(
       total_pages: 1,
     },
     last_updated: '2024-06-01T12:00:00Z',
+    ...overrides,
+  }
+}
+
+export function buildKeywordFilter(overrides: Partial<KeywordFilter> = {}): KeywordFilter {
+  return {
+    id: 1,
+    name: 'Ruby',
+    slug: 'ruby',
+    terms: ['ruby', 'rubygems'],
+    active: true,
+    position: 0,
+    article_count: 3,
+    ...overrides,
+  }
+}
+
+export function buildKeywordFiltersResponse(
+  overrides: Partial<KeywordFiltersIndexResponse> = {}
+): KeywordFiltersIndexResponse {
+  return {
+    keyword_filters: [
+      buildKeywordFilter(),
+      buildKeywordFilter({
+        id: 2,
+        name: 'Rust',
+        slug: 'rust',
+        terms: ['rust'],
+        position: 1,
+        article_count: 5,
+      }),
+    ],
     ...overrides,
   }
 }

--- a/app/frontend/types/keywordFilter.ts
+++ b/app/frontend/types/keywordFilter.ts
@@ -1,0 +1,13 @@
+export interface KeywordFilter {
+  id: number
+  name: string
+  slug: string
+  terms: string[]
+  active: boolean
+  position: number
+  article_count: number | null
+}
+
+export interface KeywordFiltersIndexResponse {
+  keyword_filters: KeywordFilter[]
+}

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -12,7 +12,12 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
 
   def count_queries
     count = 0
-    subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") { count += 1 }
+    subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |_name, _start, _finish, _id, payload|
+      # SCHEMA lookups (and similar) vary by connection cache warmth and are not N+1.
+      next if payload[:name] == "SCHEMA" || payload[:sql].to_s.match?(/\A(BEGIN|COMMIT|SAVEPOINT|RELEASE)/i)
+
+      count += 1
+    end
     yield
     count
   ensure
@@ -297,6 +302,23 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
     ids = JSON.parse(response.body)["articles"].map { |article| article["id"] }
     assert_includes ids, @dev_to_article.id
     assert_includes ids, @rust_article.id
+  end
+
+  test "index JSON unions terms from several interest slugs" do
+    get articles_url(interests: "ruby,rust"), as: :json
+    assert_response :success
+
+    ids = JSON.parse(response.body)["articles"].map { |article| article["id"] }
+    assert_includes ids, @dev_to_article.id
+    assert_includes ids, @rust_article.id
+    assert_not_includes ids, @article.id
+  end
+
+  test "index JSON returns nothing when one of several interests is unknown" do
+    get articles_url(interests: "ruby,nope"), as: :json
+    assert_response :success
+
+    assert_empty JSON.parse(response.body)["articles"]
   end
 
   test "index JSON returns nothing for an unknown interest" do


### PR DESCRIPTION
Closes #376.

## Summary

- Adds `InterestFilter` chips on the articles index, loaded from `GET /keyword_filters`, with match counts and multi-select via the `interests` URL param.
- Extends `ArticlesController` so `interests=ruby,rust` (and the existing singular `interest`) expands to the union of those presets' terms before `match` is applied. Unknown slugs still return an empty feed.
- Wires `fetchArticles({ interests })`, a dedicated `keywordFilters` API client, empty-state copy for "no articles match these interests", and a Clear affordance that resets pagination.
- Interest load failures stay non-fatal: chips hide, the rest of the feed keeps working.

## Test plan

- [x] Vitest: `InterestFilter` unit tests (aria-pressed, toggle, clear, empty render, parse/toggle helpers)
- [x] Vitest: `ArticlesIndexPage` integration (URL → request params, toggle/clear, empty state, graceful API failure)
- [x] Vitest: axe scan for `InterestFilter` in `a11y.test.tsx`
- [x] Rails: multi-interest union + unknown-slug empty result
- [x] RuboCop / Typecheck (pre-commit)
