### PR TITLE
feat(frontend): add interests management page (#377)

### DIFF
--- a/app/frontend/api/client.test.ts
+++ b/app/frontend/api/client.test.ts
@@ -77,6 +77,19 @@ describe('apiRequest', () => {
     expect(retryHeaders.get('Authorization')).toBe(`Basic ${btoa('admin:secret')}`)
   })
 
+  it('joins plural errors from unprocessable responses', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 422,
+      json: async () => ({ errors: ["Name can't be blank", 'Terms must include at least one keyword'] }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(apiRequest('/keyword_filters.json', { method: 'POST', body: '{}' })).rejects.toThrow(
+      "Name can't be blank, Terms must include at least one keyword"
+    )
+  })
+
   it('isAbortError detects AbortError', () => {
     expect(isAbortError(new DOMException('Aborted', 'AbortError'))).toBe(true)
     expect(isAbortError(Object.assign(new Error('Aborted'), { name: 'AbortError' }))).toBe(true)

--- a/app/frontend/api/client.ts
+++ b/app/frontend/api/client.ts
@@ -77,7 +77,11 @@ export async function apiRequest<T>(
     let message = `Request failed: ${response.status}`
     try {
       const body = await response.json()
-      if (body?.error) message = body.error
+      if (typeof body?.error === 'string' && body.error) {
+        message = body.error
+      } else if (Array.isArray(body?.errors) && body.errors.length > 0) {
+        message = body.errors.join(', ')
+      }
     } catch {
       // ignore JSON parse errors
     }

--- a/app/frontend/api/keywordFilters.ts
+++ b/app/frontend/api/keywordFilters.ts
@@ -1,10 +1,35 @@
 import { apiRequest } from './client'
-import type { KeywordFiltersIndexResponse } from '../types/keywordFilter'
+import type { KeywordFilter, KeywordFiltersIndexResponse } from '../types/keywordFilter'
+
+export type KeywordFilterInput = {
+  name?: string
+  terms?: string[]
+  active?: boolean
+  position?: number
+}
 
 export function fetchKeywordFilters(params?: { signal?: AbortSignal }) {
   return apiRequest<KeywordFiltersIndexResponse>('/keyword_filters.json', {
     signal: params?.signal,
   })
+}
+
+export function createKeywordFilter(attributes: KeywordFilterInput) {
+  return apiRequest<KeywordFilter>('/keyword_filters.json', {
+    method: 'POST',
+    body: JSON.stringify({ keyword_filter: attributes }),
+  })
+}
+
+export function updateKeywordFilter(id: number, attributes: KeywordFilterInput) {
+  return apiRequest<KeywordFilter>(`/keyword_filters/${id}.json`, {
+    method: 'PATCH',
+    body: JSON.stringify({ keyword_filter: attributes }),
+  })
+}
+
+export function deleteKeywordFilter(id: number) {
+  return apiRequest<void>(`/keyword_filters/${id}.json`, { method: 'DELETE' })
 }
 
 export type { KeywordFilter, KeywordFiltersIndexResponse } from '../types/keywordFilter'

--- a/app/frontend/components/App.tsx
+++ b/app/frontend/components/App.tsx
@@ -10,6 +10,7 @@ const DismissedArticlesIndexPage = lazy(() => import('../pages/DismissedArticles
 const ReadArticlesIndexPage = lazy(() => import('../pages/ReadArticlesIndexPage'))
 const RecentlyDismissedPage = lazy(() => import('../pages/RecentlyDismissedPage'))
 const SourcesIndexPage = lazy(() => import('../pages/SourcesIndexPage'))
+const InterestsIndexPage = lazy(() => import('../pages/InterestsIndexPage'))
 const DigestsIndexPage = lazy(() => import('../pages/DigestsIndexPage'))
 const DigestsShowPage = lazy(() => import('../pages/DigestsShowPage'))
 
@@ -27,6 +28,7 @@ export default function App() {
             <Route path="/dismissed" element={<DismissedArticlesIndexPage />} />
             <Route path="/recently_dismissed" element={<RecentlyDismissedPage />} />
             <Route path="/sources" element={<SourcesIndexPage />} />
+            <Route path="/interests" element={<InterestsIndexPage />} />
             <Route path="/digests" element={<DigestsIndexPage />} />
             <Route path="/digests/:id" element={<DigestsShowPage />} />
           </Route>

--- a/app/frontend/components/PageHeader.tsx
+++ b/app/frontend/components/PageHeader.tsx
@@ -61,6 +61,9 @@ export default function PageHeader({
           <NavLink to="/sources" className={navLinkClassName('purple')}>
             Sources
           </NavLink>
+          <NavLink to="/interests" className={navLinkClassName('blue')}>
+            Interests
+          </NavLink>
           {onShowReadChange && (
             <label className="flex items-center gap-2 text-sm text-gray-300 cursor-pointer">
               <input

--- a/app/frontend/components/TermChipInput.test.tsx
+++ b/app/frontend/components/TermChipInput.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import TermChipInput, { addTerm } from '../components/TermChipInput'
+
+describe('addTerm', () => {
+  it('trims, downcases and dedupes', () => {
+    expect(addTerm(['ruby'], ' Ruby ')).toEqual(['ruby'])
+    expect(addTerm(['ruby'], 'Rails')).toEqual(['ruby', 'rails'])
+  })
+
+  it('ignores blank values', () => {
+    expect(addTerm(['ruby'], '   ')).toEqual(['ruby'])
+  })
+})
+
+describe('TermChipInput', () => {
+  it('adds a term on Enter and clears the draft', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<TermChipInput terms={[]} onChange={onChange} />)
+
+    await user.type(screen.getByTestId('term-chip-input-field'), 'rust{Enter}')
+
+    expect(onChange).toHaveBeenCalledWith(['rust'])
+  })
+
+  it('removes the last term on Backspace when the draft is empty', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<TermChipInput terms={['ruby', 'rails']} onChange={onChange} />)
+
+    await user.click(screen.getByTestId('term-chip-input-field'))
+    await user.keyboard('{Backspace}')
+
+    expect(onChange).toHaveBeenCalledWith(['ruby'])
+  })
+
+  it('removes a specific term via its button', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<TermChipInput terms={['ruby', 'rails']} onChange={onChange} />)
+
+    await user.click(screen.getByRole('button', { name: 'Remove rails' }))
+
+    expect(onChange).toHaveBeenCalledWith(['ruby'])
+  })
+})

--- a/app/frontend/components/TermChipInput.tsx
+++ b/app/frontend/components/TermChipInput.tsx
@@ -1,0 +1,82 @@
+import { useState, type KeyboardEvent } from 'react'
+import Badge from './ui/Badge'
+
+interface TermChipInputProps {
+  terms: string[]
+  onChange: (terms: string[]) => void
+  disabled?: boolean
+  placeholder?: string
+  'data-testid'?: string
+}
+
+function normalizeTerm(value: string): string {
+  return value.trim().toLowerCase()
+}
+
+export function addTerm(terms: string[], raw: string): string[] {
+  const term = normalizeTerm(raw)
+  if (!term || terms.includes(term)) return terms
+  return [...terms, term]
+}
+
+export default function TermChipInput({
+  terms,
+  onChange,
+  disabled = false,
+  placeholder = 'Add a keyword and press Enter',
+  'data-testid': testId = 'term-chip-input',
+}: TermChipInputProps) {
+  const [draft, setDraft] = useState('')
+
+  const commitDraft = () => {
+    const next = addTerm(terms, draft)
+    if (next !== terms) onChange(next)
+    setDraft('')
+  }
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter' || event.key === ',') {
+      event.preventDefault()
+      commitDraft()
+      return
+    }
+
+    if (event.key === 'Backspace' && draft === '' && terms.length > 0) {
+      event.preventDefault()
+      onChange(terms.slice(0, -1))
+    }
+  }
+
+  return (
+    <div
+      className="flex flex-wrap items-center gap-2 px-3 py-2 bg-dark-800 border border-dark-700 rounded-xl focus-within:border-primary-500 focus-within:ring-2 focus-within:ring-primary-500"
+      data-testid={testId}
+    >
+      {terms.map((term) => (
+        <Badge key={term} variant="primary" size="sm" className="inline-flex items-center gap-1">
+          <span>{term}</span>
+          <button
+            type="button"
+            className="text-primary-100 hover:text-white"
+            aria-label={`Remove ${term}`}
+            disabled={disabled}
+            onClick={() => onChange(terms.filter((current) => current !== term))}
+          >
+            ×
+          </button>
+        </Badge>
+      ))}
+      <input
+        type="text"
+        value={draft}
+        disabled={disabled}
+        placeholder={terms.length === 0 ? placeholder : undefined}
+        className="flex-1 min-w-[10rem] bg-transparent text-gray-200 placeholder-gray-500 focus-visible:outline-none"
+        data-testid={`${testId}-field`}
+        onChange={(event) => setDraft(event.target.value)}
+        onKeyDown={handleKeyDown}
+        onBlur={commitDraft}
+      />
+    </div>
+  )
+}

--- a/app/frontend/components/breadcrumbTrails.ts
+++ b/app/frontend/components/breadcrumbTrails.ts
@@ -28,6 +28,11 @@ export const sourcesBreadcrumbs: BreadcrumbItem[] = [
   { label: 'News Sources' },
 ]
 
+export const interestsBreadcrumbs: BreadcrumbItem[] = [
+  feedBreadcrumb,
+  { label: 'Interests' },
+]
+
 export function articleBreadcrumbs(title: string): BreadcrumbItem[] {
   return [feedBreadcrumb, { label: title }]
 }

--- a/app/frontend/pages/InterestsIndexPage.test.tsx
+++ b/app/frontend/pages/InterestsIndexPage.test.tsx
@@ -1,0 +1,157 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import InterestsIndexPage from '../pages/InterestsIndexPage'
+import * as keywordFiltersApi from '../api/keywordFilters'
+import { buildKeywordFilter, buildKeywordFiltersResponse } from '../test/fixtures'
+
+vi.mock('../api/keywordFilters', () => ({
+  fetchKeywordFilters: vi.fn(),
+  createKeywordFilter: vi.fn(),
+  updateKeywordFilter: vi.fn(),
+  deleteKeywordFilter: vi.fn(),
+}))
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/interests']}>
+      <InterestsIndexPage />
+    </MemoryRouter>
+  )
+}
+
+async function waitForInterestsPage() {
+  await screen.findByTestId('interests-page')
+  await screen.findByRole('heading', { name: 'Interests' })
+}
+
+describe('InterestsIndexPage', () => {
+  beforeEach(() => {
+    vi.mocked(keywordFiltersApi.fetchKeywordFilters).mockResolvedValue(buildKeywordFiltersResponse())
+    vi.mocked(keywordFiltersApi.createKeywordFilter).mockResolvedValue(
+      buildKeywordFilter({
+        id: 3,
+        name: 'Architecture',
+        slug: 'architecture',
+        terms: ['software architecture'],
+        position: 2,
+        article_count: null,
+      })
+    )
+    vi.mocked(keywordFiltersApi.updateKeywordFilter).mockImplementation(async (id, attributes) =>
+      buildKeywordFilter({
+        id,
+        name: id === 1 ? 'Ruby' : 'Rust',
+        slug: id === 1 ? 'ruby' : 'rust',
+        terms: attributes.terms ?? (id === 1 ? ['ruby', 'rubygems'] : ['rust']),
+        active: attributes.active ?? true,
+        position: attributes.position ?? (id === 1 ? 0 : 1),
+        article_count: id === 1 ? 3 : 5,
+      })
+    )
+    vi.mocked(keywordFiltersApi.deleteKeywordFilter).mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('loads and displays interests with terms and counts', async () => {
+    renderPage()
+    await waitForInterestsPage()
+
+    expect(screen.getByText('Ruby')).toBeInTheDocument()
+    expect(screen.getByText('Rust')).toBeInTheDocument()
+    expect(screen.getByText('3 matching')).toBeInTheDocument()
+    expect(screen.getByText('rubygems')).toBeInTheDocument()
+  })
+
+  it('creates an interest from the form', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await waitForInterestsPage()
+
+    await user.type(screen.getByTestId('interest-name-input'), 'Architecture')
+    await user.type(screen.getByTestId('term-chip-input-field'), 'software architecture{Enter}')
+    await user.click(screen.getByTestId('add-interest-button'))
+
+    await waitFor(() => {
+      expect(keywordFiltersApi.createKeywordFilter).toHaveBeenCalledWith({
+        name: 'Architecture',
+        terms: ['software architecture'],
+        position: 2,
+      })
+    })
+    expect(await screen.findByText('Architecture')).toBeInTheDocument()
+  })
+
+  it('surfaces API validation errors when create fails', async () => {
+    vi.mocked(keywordFiltersApi.createKeywordFilter).mockRejectedValue(
+      new Error("Name can't be blank, Terms must include at least one keyword")
+    )
+    const user = userEvent.setup()
+    renderPage()
+    await waitForInterestsPage()
+
+    await user.type(screen.getByTestId('interest-name-input'), 'Broken')
+    await user.type(screen.getByTestId('term-chip-input-field'), 'x{Enter}')
+    await user.click(screen.getByTestId('add-interest-button'))
+
+    expect(await screen.findByTestId('interest-validation-error')).toHaveTextContent(
+      "Name can't be blank"
+    )
+  })
+
+  it('edits terms inline and saves them', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await waitForInterestsPage()
+
+    await user.click(screen.getByTestId('edit-interest-ruby'))
+    await user.click(screen.getByRole('button', { name: 'Remove rubygems' }))
+    await user.type(screen.getByTestId('edit-terms-ruby-field'), 'hotwire{Enter}')
+    await user.click(screen.getByTestId('save-terms-ruby'))
+
+    await waitFor(() => {
+      expect(keywordFiltersApi.updateKeywordFilter).toHaveBeenCalledWith(1, {
+        terms: ['ruby', 'hotwire'],
+      })
+    })
+  })
+
+  it('toggles active state', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await waitForInterestsPage()
+
+    await user.click(screen.getByTestId('interest-toggle-ruby'))
+
+    await waitFor(() => {
+      expect(keywordFiltersApi.updateKeywordFilter).toHaveBeenCalledWith(1, { active: false })
+    })
+  })
+
+  it('deletes an interest after confirmation', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await waitForInterestsPage()
+
+    await user.click(screen.getByTestId('delete-interest-ruby'))
+    expect(await screen.findByTestId('confirm-dialog')).toBeInTheDocument()
+    await user.click(screen.getByTestId('confirm-dialog-confirm'))
+
+    await waitFor(() => {
+      expect(keywordFiltersApi.deleteKeywordFilter).toHaveBeenCalledWith(1)
+    })
+    expect(screen.queryByText('Ruby')).not.toBeInTheDocument()
+  })
+
+  it('shows an error when interests fail to load', async () => {
+    vi.mocked(keywordFiltersApi.fetchKeywordFilters).mockRejectedValue(new Error('network'))
+
+    renderPage()
+
+    expect(await screen.findByText('Failed to load interests.')).toBeInTheDocument()
+  })
+})

--- a/app/frontend/pages/InterestsIndexPage.tsx
+++ b/app/frontend/pages/InterestsIndexPage.tsx
@@ -1,0 +1,336 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+  createKeywordFilter,
+  deleteKeywordFilter,
+  fetchKeywordFilters,
+  updateKeywordFilter,
+  type KeywordFilter,
+} from '../api/keywordFilters'
+import { useConfirmDialog } from '../hooks/useConfirmDialog'
+import Badge from '../components/ui/Badge'
+import Button from '../components/ui/Button'
+import Card from '../components/ui/Card'
+import PageContainer from '../components/ui/PageContainer'
+import PageHeading from '../components/ui/PageHeading'
+import Breadcrumbs from '../components/Breadcrumbs'
+import { interestsBreadcrumbs } from '../components/breadcrumbTrails'
+import TermChipInput, { addTerm } from '../components/TermChipInput'
+import SourcesIndexSkeleton from '../components/SourcesIndexSkeleton'
+
+function sortInterests(items: KeywordFilter[]): KeywordFilter[] {
+  return [...items].sort((a, b) => a.position - b.position || a.name.localeCompare(b.name))
+}
+
+export default function InterestsIndexPage() {
+  const [interests, setInterests] = useState<KeywordFilter[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [nameInput, setNameInput] = useState('')
+  const [createTerms, setCreateTerms] = useState<string[]>([])
+  const [creating, setCreating] = useState(false)
+  const [validationError, setValidationError] = useState<string | null>(null)
+  const [editingId, setEditingId] = useState<number | null>(null)
+  const [editTerms, setEditTerms] = useState<string[]>([])
+  const [savingId, setSavingId] = useState<number | null>(null)
+  const { confirm, dialog } = useConfirmDialog()
+
+  const loadInterests = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const response = await fetchKeywordFilters()
+      setInterests(sortInterests(response.keyword_filters))
+    } catch {
+      setError('Failed to load interests.')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadInterests()
+  }, [loadInterests])
+
+  const handleCreate = async (event: React.FormEvent) => {
+    event.preventDefault()
+    const name = nameInput.trim()
+    const terms = createTerms.reduce((acc, term) => addTerm(acc, term), [] as string[])
+    if (!name || terms.length === 0) {
+      setValidationError('Name and at least one keyword are required.')
+      return
+    }
+
+    setCreating(true)
+    setValidationError(null)
+    try {
+      const created = await createKeywordFilter({
+        name,
+        terms,
+        position: interests.length,
+      })
+      setInterests((current) => sortInterests([...current, created]))
+      setNameInput('')
+      setCreateTerms([])
+    } catch (err) {
+      setValidationError(err instanceof Error ? err.message : 'Failed to create interest.')
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  const handleToggle = async (interest: KeywordFilter) => {
+    setSavingId(interest.id)
+    setError(null)
+    try {
+      const updated = await updateKeywordFilter(interest.id, { active: !interest.active })
+      setInterests((current) => current.map((item) => (item.id === updated.id ? updated : item)))
+    } catch {
+      setError('Failed to update interest.')
+    } finally {
+      setSavingId(null)
+    }
+  }
+
+  const startEditing = (interest: KeywordFilter) => {
+    setEditingId(interest.id)
+    setEditTerms([...interest.terms])
+    setValidationError(null)
+  }
+
+  const handleSaveTerms = async (interest: KeywordFilter) => {
+    const terms = editTerms.reduce((acc, term) => addTerm(acc, term), [] as string[])
+    if (terms.length === 0) {
+      setValidationError('At least one keyword is required.')
+      return
+    }
+
+    setSavingId(interest.id)
+    setValidationError(null)
+    try {
+      const updated = await updateKeywordFilter(interest.id, { terms })
+      setInterests((current) => current.map((item) => (item.id === updated.id ? updated : item)))
+      setEditingId(null)
+    } catch (err) {
+      setValidationError(err instanceof Error ? err.message : 'Failed to update terms.')
+    } finally {
+      setSavingId(null)
+    }
+  }
+
+  const handleMove = async (interest: KeywordFilter, direction: -1 | 1) => {
+    const index = interests.findIndex((item) => item.id === interest.id)
+    const swapWith = interests[index + direction]
+    if (!swapWith) return
+
+    setSavingId(interest.id)
+    setError(null)
+    try {
+      const [updated, swapped] = await Promise.all([
+        updateKeywordFilter(interest.id, { position: swapWith.position }),
+        updateKeywordFilter(swapWith.id, { position: interest.position }),
+      ])
+      setInterests((current) =>
+        sortInterests(
+          current.map((item) => {
+            if (item.id === updated.id) return updated
+            if (item.id === swapped.id) return swapped
+            return item
+          })
+        )
+      )
+    } catch {
+      setError('Failed to reorder interests.')
+    } finally {
+      setSavingId(null)
+    }
+  }
+
+  const handleDelete = async (interest: KeywordFilter) => {
+    const confirmed = await confirm({
+      message: `Delete the “${interest.name}” interest?`,
+      confirmLabel: 'Delete',
+    })
+    if (!confirmed) return
+
+    try {
+      await deleteKeywordFilter(interest.id)
+      setInterests((current) => current.filter((item) => item.id !== interest.id))
+      if (editingId === interest.id) setEditingId(null)
+    } catch {
+      setError('Failed to delete interest.')
+    }
+  }
+
+  if (loading) {
+    return (
+      <PageContainer width="4xl" testId="interests-page" role="status" aria-live="polite" aria-busy>
+        <SourcesIndexSkeleton />
+      </PageContainer>
+    )
+  }
+
+  return (
+    <PageContainer width="4xl" testId="interests-page">
+      <Breadcrumbs items={interestsBreadcrumbs} />
+      <PageHeading
+        title="Interests"
+        subtitle="Saved keyword presets used to filter the feed by topic."
+        titleClassName="text-gray-100"
+      />
+
+      {error && <div className="mb-4 text-sm text-red-400">{error}</div>}
+
+      <Card as="section" className="mb-8">
+        <h2 className="text-h3 text-gray-200 mb-4">Add interest</h2>
+        <form onSubmit={handleCreate} className="space-y-4">
+          <input
+            type="text"
+            value={nameInput}
+            onChange={(event) => setNameInput(event.target.value)}
+            placeholder="Name, e.g. Software architecture"
+            className="w-full px-4 py-2 bg-dark-800 border border-dark-700 rounded-xl text-gray-200 placeholder-gray-500 focus-visible:outline-none focus-visible:border-primary-500 focus-visible:ring-2 focus-visible:ring-primary-500"
+            data-testid="interest-name-input"
+          />
+          <TermChipInput terms={createTerms} onChange={setCreateTerms} />
+          <Button
+            type="submit"
+            disabled={creating || !nameInput.trim() || createTerms.length === 0}
+            data-testid="add-interest-button"
+          >
+            {creating ? 'Saving...' : 'Add interest'}
+          </Button>
+        </form>
+        {validationError && editingId === null && (
+          <p className="text-sm text-red-400 mt-4" data-testid="interest-validation-error">
+            {validationError}
+          </p>
+        )}
+      </Card>
+
+      <Card as="section">
+        <h2 className="text-h3 text-gray-200 mb-4">Saved interests</h2>
+        <div className="space-y-4">
+          {interests.map((interest, index) => {
+            const editing = editingId === interest.id
+            return (
+              <div
+                key={interest.id}
+                className="py-3 border-b border-dark-700 last:border-0"
+                data-testid={`interest-row-${interest.slug}`}
+              >
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="min-w-0 space-y-2">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-gray-100 font-medium">{interest.name}</span>
+                      <Badge variant={interest.active ? 'green' : 'orange'} size="sm">
+                        {interest.active ? 'Active' : 'Inactive'}
+                      </Badge>
+                      {interest.article_count !== null && (
+                        <span className="text-caption text-gray-500">
+                          {interest.article_count} matching
+                        </span>
+                      )}
+                    </div>
+                    {editing ? (
+                      <TermChipInput
+                        terms={editTerms}
+                        onChange={setEditTerms}
+                        disabled={savingId === interest.id}
+                        data-testid={`edit-terms-${interest.slug}`}
+                      />
+                    ) : (
+                      <div className="flex flex-wrap gap-2">
+                        {interest.terms.map((term) => (
+                          <Badge key={term} variant="primary" size="sm">
+                            {term}
+                          </Badge>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="flex flex-wrap items-center gap-3 shrink-0">
+                    <button
+                      type="button"
+                      className="text-sm text-gray-400 hover:text-white disabled:opacity-40"
+                      disabled={index === 0 || savingId === interest.id}
+                      aria-label={`Move ${interest.name} up`}
+                      onClick={() => handleMove(interest, -1)}
+                    >
+                      Up
+                    </button>
+                    <button
+                      type="button"
+                      className="text-sm text-gray-400 hover:text-white disabled:opacity-40"
+                      disabled={index === interests.length - 1 || savingId === interest.id}
+                      aria-label={`Move ${interest.name} down`}
+                      onClick={() => handleMove(interest, 1)}
+                    >
+                      Down
+                    </button>
+                    <label className="flex items-center gap-2 text-sm text-gray-400 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        className="rounded border-dark-600 bg-dark-800 text-primary-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+                        checked={interest.active}
+                        disabled={savingId === interest.id}
+                        onChange={() => handleToggle(interest)}
+                        data-testid={`interest-toggle-${interest.slug}`}
+                      />
+                      {interest.active ? 'Enabled' : 'Disabled'}
+                    </label>
+                    {editing ? (
+                      <>
+                        <Button
+                          size="sm"
+                          disabled={savingId === interest.id || editTerms.length === 0}
+                          data-testid={`save-terms-${interest.slug}`}
+                          onClick={() => handleSaveTerms(interest)}
+                        >
+                          Save
+                        </Button>
+                        <button
+                          type="button"
+                          className="text-sm text-gray-400 hover:text-white"
+                          onClick={() => setEditingId(null)}
+                        >
+                          Cancel
+                        </button>
+                      </>
+                    ) : (
+                      <button
+                        type="button"
+                        className="text-sm text-primary-300 hover:text-primary-200"
+                        data-testid={`edit-interest-${interest.slug}`}
+                        onClick={() => startEditing(interest)}
+                      >
+                        Edit terms
+                      </button>
+                    )}
+                    <button
+                      type="button"
+                      className="text-sm text-red-400 hover:text-red-300"
+                      data-testid={`delete-interest-${interest.slug}`}
+                      onClick={() => handleDelete(interest)}
+                    >
+                      Delete
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )
+          })}
+          {interests.length === 0 && (
+            <p className="text-gray-500 text-sm">No interests configured yet.</p>
+          )}
+        </div>
+        {validationError && editingId !== null && (
+          <p className="text-sm text-red-400 mt-4" data-testid="interest-validation-error">
+            {validationError}
+          </p>
+        )}
+      </Card>
+      {dialog}
+    </PageContainer>
+  )
+}

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -123,6 +123,11 @@ dev-news-aggregator/
 |------|---------|
 | `app/frontend/entrypoints/application.tsx` | Vite/React mount point |
 | `app/frontend/components/App.tsx` | Root React component |
+| `app/frontend/pages/InterestsIndexPage.tsx` | Manage saved keyword interest presets |
+| `app/frontend/api/keywordFilters.ts` | Keyword filter CRUD client |
+| `app/frontend/types/keywordFilter.ts` | Keyword filter TypeScript types |
+| `app/frontend/components/InterestFilter.tsx` | Interest chip filters on the articles index |
+| `app/frontend/components/TermChipInput.tsx` | Chip input for interest keyword terms |
 
 ## `config/`
 


### PR DESCRIPTION
Closes #377.

## Summary

- Adds `/interests` (`InterestsIndexPage`) to list, create, edit terms, toggle active, reorder, and delete keyword filter presets.
- Extends `keywordFilters` API client with create/update/delete; `TermChipInput` handles Enter/comma/backspace chip editing with trim+dedupe.
- Surfaces Rails `errors[]` 422 payloads in `apiRequest` so validation messages reach the form.
- Nav link next to Sources, breadcrumbs, and `docs/REPO_STRUCTURE.md` updates.

## Test plan

- [x] Vitest: `InterestsIndexPage` (load, create, validation error, edit terms, toggle, delete)
- [x] Vitest: `TermChipInput` helpers + keyboard behavior
- [x] Vitest: `apiRequest` joins plural `errors`
- [x] Typecheck
