### PR TITLE
feat(articles): show matched keywords on article cards (#379)

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -29,6 +29,7 @@ class ArticlesController < ApplicationController
     @articles_by_source = @articles.group_by(&:source_type)
     @articles_by_category = helpers.group_sources_by_category(@articles_by_source)
     @last_updated = Article.maximum(:updated_at)
+    filter_terms = active_keyword_terms
 
     respond_to do |format|
       format.html
@@ -37,7 +38,8 @@ class ArticlesController < ApplicationController
           articles: @articles.map { |article|
             ArticleSerializer.as_json(
               article,
-              related_articles: @related_by_article_id[article.id] || []
+              related_articles: @related_by_article_id[article.id] || [],
+              matched_keywords: filter_terms && article.matched_keywords_for(filter_terms)
             )
           },
           articles_by_category: @articles_by_category.transform_values { |articles| articles.map(&:id) },
@@ -161,17 +163,29 @@ class ArticlesController < ApplicationController
   # with any explicit `keywords`; `match` then applies to the combined list. An unknown slug
   # filters everything out, mirroring how an unknown category behaves.
   def apply_keyword_filter(scope)
-    terms = Article.normalize_keywords(params[:keywords])
-    slugs = interest_slugs
-
-    if slugs.any?
-      interests = KeywordFilter.where(slug: slugs).to_a
-      return scope.none if interests.size < slugs.size
-
-      terms += interests.flat_map(&:terms)
-    end
+    terms = resolved_keyword_terms
+    return scope.none if terms == :unknown
 
     scope.matching_keywords(terms, match: params[:match])
+  end
+
+  # Normalized terms currently driving the keyword/interest filter, or nil when none apply.
+  def active_keyword_terms
+    terms = resolved_keyword_terms
+    return nil if terms == :unknown || terms.empty?
+
+    terms
+  end
+
+  def resolved_keyword_terms
+    terms = Article.normalize_keywords(params[:keywords])
+    slugs = interest_slugs
+    return terms if slugs.empty?
+
+    interests = KeywordFilter.where(slug: slugs).to_a
+    return :unknown if interests.size < slugs.size
+
+    Article.normalize_keywords(terms + interests.flat_map(&:terms))
   end
 
   def interest_slugs

--- a/app/frontend/components/ArticleCard.test.tsx
+++ b/app/frontend/components/ArticleCard.test.tsx
@@ -103,6 +103,52 @@ describe('ArticleCard', () => {
     expect(screen.getByRole('link', { name: /Dev To/i })).toHaveAttribute('href', '/articles/9')
   })
 
+  it('renders matched keyword badges with overflow', () => {
+    render(
+      <MemoryRouter>
+        <ArticleCard
+          variant="feed"
+          article={{
+            ...feedArticle,
+            matched_keywords: ['rust', 'cargo', 'wasm', 'tokio'],
+          }}
+          categorySlug="programming"
+          index={0}
+          isDismissing={false}
+          onDismiss={() => {}}
+          onBookmarkToggle={() => {}}
+          onReadToggle={() => {}}
+        />
+      </MemoryRouter>
+    )
+
+    const badges = screen.getByTestId('matched-keywords')
+    expect(badges).toHaveTextContent('rust')
+    expect(badges).toHaveTextContent('cargo')
+    expect(badges).toHaveTextContent('wasm')
+    expect(badges).toHaveTextContent('+1')
+    expect(badges).not.toHaveTextContent('tokio')
+  })
+
+  it('omits matched keyword badges when the field is absent', () => {
+    render(
+      <MemoryRouter>
+        <ArticleCard
+          variant="feed"
+          article={feedArticle}
+          categorySlug="programming"
+          index={0}
+          isDismissing={false}
+          onDismiss={() => {}}
+          onBookmarkToggle={() => {}}
+          onReadToggle={() => {}}
+        />
+      </MemoryRouter>
+    )
+
+    expect(screen.queryByTestId('matched-keywords')).not.toBeInTheDocument()
+  })
+
   it('renders bookmark variant with bookmarked metadata', () => {
     render(
       <MemoryRouter>

--- a/app/frontend/components/articleCard/ArticleCardLayout.tsx
+++ b/app/frontend/components/articleCard/ArticleCardLayout.tsx
@@ -4,7 +4,10 @@ import { cn } from '../../utils/cn'
 import { DetailsLink } from './CardActions'
 import CardMetadata from './CardMetadata'
 import CardTitle from './CardTitle'
+import Badge from '../ui/Badge'
 import { CARD_THEMES, type ArticleCardData, type ArticleCardAccent, type ArticleCardTheme } from './cardThemes'
+
+const MATCHED_KEYWORD_LIMIT = 3
 
 interface ArticleCardLayoutProps {
   article: ArticleCardData
@@ -31,6 +34,26 @@ const ACCENT_BAR_CLASSES: Record<NonNullable<ArticleCardAccent>, string> = {
   red: 'border-l-[3px] border-l-red-500/70',
 }
 
+function MatchedKeywordBadges({ keywords }: { keywords: string[] }) {
+  const visible = keywords.slice(0, MATCHED_KEYWORD_LIMIT)
+  const overflow = keywords.length - visible.length
+
+  return (
+    <div className="mb-5 flex flex-wrap items-center gap-2" data-testid="matched-keywords">
+      {visible.map((keyword) => (
+        <Badge key={keyword} variant="primary" size="sm">
+          {keyword}
+        </Badge>
+      ))}
+      {overflow > 0 && (
+        <Badge variant="orange" size="sm">
+          +{overflow}
+        </Badge>
+      )}
+    </div>
+  )
+}
+
 export default function ArticleCardLayout({
   article,
   index,
@@ -50,6 +73,7 @@ export default function ArticleCardLayout({
 }: ArticleCardLayoutProps) {
   const styles = CARD_THEMES[theme]
   const relatedSources = article.related_sources ?? []
+  const matchedKeywords = article.matched_keywords ?? []
 
   return (
     <article
@@ -83,6 +107,8 @@ export default function ArticleCardLayout({
           {truncate(article.description, 280)}
         </p>
       )}
+
+      {matchedKeywords.length > 0 && <MatchedKeywordBadges keywords={matchedKeywords} />}
 
       {relatedSources.length > 0 && (
         <div className="mb-5 flex flex-wrap items-center gap-2" data-testid="related-sources">

--- a/app/frontend/components/articleCard/cardThemes.ts
+++ b/app/frontend/components/articleCard/cardThemes.ts
@@ -17,6 +17,7 @@ export interface ArticleCardData {
     title: string
     score: number | null
   }>
+  matched_keywords?: string[]
 }
 
 export type ArticleCardTheme = 'primary' | 'green' | 'red' | 'orange'

--- a/app/frontend/types/article.ts
+++ b/app/frontend/types/article.ts
@@ -30,6 +30,7 @@ export interface Article {
   low_signal?: boolean
   topic_tags?: TopicTag[]
   related_sources?: RelatedSource[]
+  matched_keywords?: string[]
   similar_articles?: Article[]
   summary?: string | null
   summary_provider?: string | null

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -82,6 +82,12 @@ class Article < ApplicationRecord
     term_groups.each_index.map { |index| row.public_send("keyword_count_#{index}").to_i }
   end
 
+  # Which of the requested terms appear in this article's title/description (case-insensitive).
+  def matched_keywords_for(terms)
+    haystack = "#{title} #{description}".downcase
+    self.class.normalize_keywords(terms).select { |term| haystack.include?(term.downcase) }
+  end
+
   def self.similar_to(article, limit: 5)
     title = article.title.to_s.strip
     return none if title.blank?

--- a/app/serializers/article_serializer.rb
+++ b/app/serializers/article_serializer.rb
@@ -5,7 +5,7 @@ class ArticleSerializer
 
   SUMMARY_ATTRIBUTES = %i[summary summary_provider summarized_at].freeze
 
-  def self.as_json(article, related_articles: [], include_summary: false)
+  def self.as_json(article, related_articles: [], include_summary: false, matched_keywords: nil)
     payload = base_attributes(article).merge(
       created_at: article.created_at,
       updated_at: article.updated_at,
@@ -17,6 +17,7 @@ class ArticleSerializer
       topic_tags: article.tags.map { |tag| { slug: tag.slug, name: tag.name } },
       related_sources: Array(related_articles).map { |related| related_source_json(related) }
     )
+    payload[:matched_keywords] = matched_keywords unless matched_keywords.nil?
 
     return payload unless include_summary
 

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -304,6 +304,23 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
     assert_includes ids, @rust_article.id
   end
 
+  test "index JSON includes matched_keywords when a keyword filter is active" do
+    get articles_url(keywords: "rust"), as: :json
+    assert_response :success
+
+    article = JSON.parse(response.body)["articles"].find { |item| item["id"] == @rust_article.id }
+    assert_equal [ "rust" ], article["matched_keywords"]
+  end
+
+  test "index JSON omits matched_keywords when no keyword filter is active" do
+    get articles_url, as: :json
+    assert_response :success
+
+    article = JSON.parse(response.body)["articles"].first
+    assert article
+    assert_not article.key?("matched_keywords")
+  end
+
   test "index JSON unions terms from several interest slugs" do
     get articles_url(interests: "ruby,rust"), as: :json
     assert_response :success

--- a/test/models/article_test.rb
+++ b/test/models/article_test.rb
@@ -444,6 +444,13 @@ class ArticleTest < ActiveSupport::TestCase
     assert_equal [ literal ], Article.matching_keywords("100%").to_a
   end
 
+  test "matched_keywords_for returns only terms present in title or description" do
+    article = articles(:reddit_rust_article)
+
+    assert_equal [ "rust" ], article.matched_keywords_for("ruby,rust,wasm")
+    assert_empty article.matched_keywords_for("elixir")
+  end
+
   test "similar_to returns title-similar articles" do
     related = articles(:dev_to_article)
     @article.update!(title: "Rails performance tips for production")

--- a/test/serializers/article_serializer_test.rb
+++ b/test/serializers/article_serializer_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class ArticleSerializerTest < ActiveSupport::TestCase
+  setup do
+    @article = articles(:reddit_rust_article)
+  end
+
+  test "as_json omits matched_keywords when not provided" do
+    payload = ArticleSerializer.as_json(@article)
+
+    assert_not payload.key?(:matched_keywords)
+  end
+
+  test "as_json includes matched_keywords when provided" do
+    payload = ArticleSerializer.as_json(@article, matched_keywords: [ "rust", "cargo" ])
+
+    assert_equal [ "rust", "cargo" ], payload[:matched_keywords]
+  end
+
+  test "as_json includes an empty matched_keywords list when explicitly empty" do
+    payload = ArticleSerializer.as_json(@article, matched_keywords: [])
+
+    assert_equal [], payload[:matched_keywords]
+  end
+end


### PR DESCRIPTION
Closes #379.

## Summary

- When `keywords` / `interest(s)` filter the index, each article payload includes `matched_keywords` (terms that hit title/description). The field is omitted when no keyword filter is active.
- Cards render up to 3 matched-keyword badges with a `+N` overflow chip; layout is unchanged when the field is absent.
- Adds `Article#matched_keywords_for` and serializer support; controller resolves filter terms once for both filtering and annotation.

## Test plan

- [x] Serializer present/absent/empty cases
- [x] Model `matched_keywords_for`
- [x] Controller includes/omits `matched_keywords`
- [x] Vitest ArticleCard badges + overflow + absent
- [x] Typecheck
