### PR TITLE
docs: document keyword interest filters and API params (#380)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ A Rails application that aggregates developer news from Hacker News, Dev.to, and
 
 - **Multi-source aggregation**: Fetches from 12+ sources including Hacker News, Dev.to, and programming subreddits
 - **Article bookmarking**: Save articles for later reading with category filtering  
-- **Atom feeds**: Subscribe to `/articles.atom` (main feed) and `/bookmarks.atom` (reading list)
+- **Keyword interests**: Filter the feed by saved topic presets (ruby, rails, rust, architecture, …) — see [docs/KEYWORD_FILTERS.md](docs/KEYWORD_FILTERS.md)
+- **Atom feeds**: Subscribe to `/articles.atom` (main feed; supports `q`, keyword interests, category, score) and `/bookmarks.atom` (reading list)
 - **Automated updates**: Hourly fetching during business hours via cron jobs
-- **Responsive interface**: React SPA with source-based filtering and Vite HMR in development
+- **Responsive interface**: React SPA with source- and interest-based filtering and Vite HMR in development
 
 ## Quick Start
 
@@ -106,7 +107,7 @@ Production deploys use Kamal via the **Deploy** GitHub Actions workflow (manual)
 
 ## Development
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the contributor entry point, [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) for development guidelines, and [docs/REPO_STRUCTURE.md](docs/REPO_STRUCTURE.md) for the repository map (keep it updated when structure changes).
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the contributor entry point, [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) for development guidelines, [docs/KEYWORD_FILTERS.md](docs/KEYWORD_FILTERS.md) for interest/keyword filtering, and [docs/REPO_STRUCTURE.md](docs/REPO_STRUCTURE.md) for the repository map (keep it updated when structure changes).
 
 ### Pre-commit Hooks
 

--- a/docs/AGENT_API.md
+++ b/docs/AGENT_API.md
@@ -32,6 +32,8 @@ Query params:
 | `show_read` | `true` to include read articles |
 | `page`, `per_page` | Pagination (`per_page` max 100) |
 
+For the richer HTML/JSON feed (`GET /articles.json` / `.atom`) — including `keywords`, `match`, `interest` / `interests`, categories, and tags — see [KEYWORD_FILTERS.md](KEYWORD_FILTERS.md). Those params are not yet mirrored on `/api/v1/articles`.
+
 Response:
 
 ```json

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -260,6 +260,8 @@ Copy `.env.example` to `.env` before starting the stack. Docker Compose reads it
 
 **Category filtering**: Articles are grouped into logical categories (Programming Languages, Web Development, Security, AI & Machine Learning, General Tech) for easier browsing.
 
+**Keyword interests**: Saved topic presets (`KeywordFilter`) filter the feed by title/description terms (`keywords`, `interest` / `interests`). Manage them at `/interests`; see [KEYWORD_FILTERS.md](KEYWORD_FILTERS.md).
+
 **Multi-source aggregation**: Default sources are defined in `config/news_aggregator.yml` — Hacker News, Dev.to, and 11 Reddit subreddits (programming, webdev, javascript, ruby, rust, netsec, cybersecurity, technology, MachineLearning, artificial, LocalLLaMA). Override via enabled `NewsSource` records.
 
 ### Adding new news sources

--- a/docs/KEYWORD_FILTERS.md
+++ b/docs/KEYWORD_FILTERS.md
@@ -1,0 +1,98 @@
+# Keyword interests & filtering
+
+Drive the feed from personal topics (ruby, rails, rust, software architecture, AI performance) in addition to source categories and free-text search.
+
+## Concepts
+
+| Mechanism | What it is | Where it lives |
+|-----------|------------|----------------|
+| **Interests** (`KeywordFilter`) | Saved presets: a name + list of terms | `keyword_filters` table; UI at `/interests` |
+| **Source categories** | UI groupings of `source_type` (HN, Dev.to, Reddit, …) | `ArticlesHelper::CATEGORIES` |
+| **Topic tags** | Per-article tags from heuristics | `tags` / `article_tags` (`?tag=` filter) |
+| **Free-text search** | Single `q` string (trigram + ILIKE) | `Article.search` |
+
+Interests filter by matching terms against **title + description**. They are orthogonal to category and tag filters: all active filters AND together.
+
+## API (articles index)
+
+`GET /articles.json` and `GET /articles.atom` share the same filter scope.
+
+| Param | Description |
+|-------|-------------|
+| `keywords` | Comma-separated terms (or repeated values). Multi-word tokens stay phrases (`software architecture`). |
+| `match` | `any` (default, OR) or `all` (AND every term). |
+| `interest` | Single interest slug (e.g. `ruby`). Expands to that preset’s terms. |
+| `interests` | Comma-separated slugs. Union of those presets’ terms. Unknown slug → empty result. |
+| `q` | Free-text search (trigram similarity when available). |
+| `category` | Source-category slug. |
+| `tag` | Topic tag slug. |
+| `min_score` / `top_percent` / `sort` / `show_read` / `page` | Unchanged score/sort/pagination params. |
+
+### Combining filters
+
+1. Explicit `keywords` and expanded `interest` / `interests` terms are **unioned**, then `match` applies to that combined list.
+2. The keyword filter is then AND-ed with `q`, `category`, `tag`, and score filters.
+
+Examples:
+
+```bash
+# Any of these terms
+curl "http://localhost:3000/articles.json?keywords=ruby,rust"
+
+# Every term must match
+curl "http://localhost:3000/articles.json?keywords=rails,performance&match=all"
+
+# Saved interest preset
+curl "http://localhost:3000/articles.json?interest=software-architecture"
+
+# Several interests + an extra ad-hoc term
+curl "http://localhost:3000/articles.json?interests=ruby,rust&keywords=wasm"
+
+# Atom consumers get the same filters
+curl "http://localhost:3000/articles.atom?interests=ai-performance&min_score=50"
+```
+
+### Matched keywords in the JSON payload
+
+When a keyword/interest filter is active, each article includes `matched_keywords`: the subset of the requested terms that appear in that article’s title or description. The field is omitted when no keyword filter is applied. The feed UI shows up to three badges plus a `+N` overflow.
+
+## Matching semantics
+
+- Case-insensitive substring match on `title` and `description` (`ILIKE`).
+- Terms are trimmed; blank tokens dropped; duplicates collapsed (case-insensitive).
+- Multi-word terms stay whole phrases (no split on spaces).
+- Cap: `Article::MAX_KEYWORDS` (20) after normalization.
+- LIKE metacharacters (`%`, `_`) in terms are escaped.
+
+## Managing interests
+
+### UI
+
+`/interests` lists presets with match counts, create/edit terms (chip input), toggle `active`, reorder (up/down), and delete (confirm). Writes use the same mutating HTTP Basic auth as Sources when configured.
+
+Feed chips: `InterestFilter` on the articles index reads `?interests=` and multi-selects slugs.
+
+### API
+
+```
+GET    /keyword_filters.json
+POST   /keyword_filters.json      { "keyword_filter": { "name", "terms" } }
+PATCH  /keyword_filters/:id.json  { "keyword_filter": { "name", "terms", "active", "position" } }
+DELETE /keyword_filters/:id.json
+```
+
+`terms` may be an array or a comma-separated string. Index responses include `article_count` (kept, non-dismissed articles inside the retention window) computed in one query via `Article.keyword_match_counts`.
+
+### Defaults & seeding
+
+Starter presets live under `interests:` in `config/news_aggregator.yml`. `KeywordFilter.bootstrap_defaults!` (also called from `db/seeds.rb` and on an empty `GET /keyword_filters`) creates missing slugs only — local edits are not overwritten.
+
+## Performance
+
+Trigram indexes on `articles.title` and `articles.description` (`pg_trgm`) keep leading-wildcard `ILIKE` usable. Prefer saved interests or a short `keywords` list over very long OR chains. Listing interests uses a single conditional-count query, not N separate `COUNT(*)`s.
+
+## Related code
+
+- Model: `app/models/keyword_filter.rb`, `Article.matching_keywords` / `matched_keywords_for`
+- Controllers: `KeywordFiltersController`, `ArticlesController#apply_keyword_filter`
+- Frontend: `InterestFilter`, `InterestsIndexPage`, `api/keywordFilters.ts`

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -247,16 +247,19 @@ Agents should start here, then use this file as the navigation map:
 1. [AGENTS.md](../AGENTS.md) — work rules and verification (`bin/validate`)
 2. [CONTRIBUTING.md](../CONTRIBUTING.md) — PR workflow
 3. [DEVELOPMENT.md](DEVELOPMENT.md) — setup, commands, conventions
-4. This file — directory and entry-point map
+4. [KEYWORD_FILTERS.md](KEYWORD_FILTERS.md) — interest/keyword feed filters
+5. This file — directory and entry-point map
 
 ## Routes (summary)
 
 | Path | Controller#action |
 |------|-------------------|
 | `/` | `articles#index` |
-| `/articles.atom` | `articles#index` (Atom feed; honors `q`, `category`, `sort`, score filters) |
+| `/articles.atom` | `articles#index` (Atom feed; honors `q`, `keywords`, `match`, `interest`/`interests`, `category`, `tag`, `sort`, score filters — see [KEYWORD_FILTERS.md](KEYWORD_FILTERS.md)) |
 | `/articles/:id` | `articles#show` |
 | `/articles/:id/summarize` | `articles#summarize` (POST; optional AI/heuristic summary) |
+| `/keyword_filters` | `keyword_filters#index` (CRUD JSON for interest presets) |
+| `/interests` | SPA interests management page |
 | `/bookmarks` | `bookmarks#index` |
 | `/bookmarks.atom` | `bookmarks#index` (Atom feed) |
 | `/read` | `read_articles#index` |


### PR DESCRIPTION
Closes #380.

## Summary

- Adds `docs/KEYWORD_FILTERS.md` covering interests vs categories vs tags, API params (`keywords`, `match`, `interest`/`interests`), matching rules, `/interests` management, seeding, and trigram performance notes.
- Links the doc from README, DEVELOPMENT, REPO_STRUCTURE (routes + agent onboarding), and AGENT_API (points feed consumers at the richer `/articles` filters).

## Test plan

- [x] Doc review against acceptance criteria
- [ ] CI (docs-only; quality_gate should pass)
