### PR TITLE
feat(youtube): ingest channel uploads via atom feeds (#382)

### DIFF
--- a/app/controllers/sources_controller.rb
+++ b/app/controllers/sources_controller.rb
@@ -80,6 +80,7 @@ class SourcesController < ApplicationController
       name: source.name,
       source_type: source.source_type,
       subreddit: source.subreddit,
+      channel_id: source.channel_id,
       active: source.active,
       last_fetch: last_fetch_json(fetch_run, last_article_at)
     }

--- a/app/frontend/api/sources.ts
+++ b/app/frontend/api/sources.ts
@@ -20,8 +20,9 @@ export interface SourceLastFetch {
 export interface NewsSource {
   id: number
   name: string
-  source_type: 'hacker_news' | 'dev_to' | 'reddit'
+  source_type: 'hacker_news' | 'dev_to' | 'reddit' | 'youtube'
   subreddit: string | null
+  channel_id?: string | null
   active: boolean
   last_fetch: SourceLastFetch | null
 }

--- a/app/frontend/pages/SourcesIndexPage.tsx
+++ b/app/frontend/pages/SourcesIndexPage.tsx
@@ -22,6 +22,9 @@ function sourceLabel(source: NewsSource): string {
   if (source.source_type === 'reddit') {
     return `r/${source.subreddit ?? source.name}`
   }
+  if (source.source_type === 'youtube') {
+    return source.name
+  }
   return source.name
 }
 
@@ -145,8 +148,11 @@ export default function SourcesIndexPage() {
     }
   }
 
-  const fixedSources = sources.filter((source) => source.source_type !== 'reddit')
+  const fixedSources = sources.filter(
+    (source) => source.source_type !== 'reddit' && source.source_type !== 'youtube'
+  )
   const redditSources = sources.filter((source) => source.source_type === 'reddit')
+  const youtubeSources = sources.filter((source) => source.source_type === 'youtube')
 
   if (loading) {
     return (
@@ -244,6 +250,35 @@ export default function SourcesIndexPage() {
           )}
         </div>
       </Card>
+
+      {youtubeSources.length > 0 && (
+        <Card as="section" className="mt-8">
+          <h2 className="text-h3 text-gray-200 mb-4">YouTube channels</h2>
+          <div className="space-y-3">
+            {youtubeSources.map((source) => (
+              <div key={source.id} className="flex items-center justify-between gap-4 py-3 border-b border-dark-700 last:border-0">
+                <div className="min-w-0">
+                  <span className="text-gray-200 font-medium">{source.name}</span>
+                  {source.channel_id && (
+                    <p className="text-caption text-gray-500 mt-1">{source.channel_id}</p>
+                  )}
+                  <SourceFetchStatus lastFetch={source.last_fetch} />
+                </div>
+                <label className="flex items-center gap-2 text-sm text-gray-400 cursor-pointer shrink-0">
+                  <input
+                    type="checkbox"
+                    className="rounded border-dark-600 bg-dark-800 text-primary-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+                    checked={source.active}
+                    onChange={() => handleToggle(source)}
+                    data-testid={`source-toggle-youtube-${source.channel_id ?? source.id}`}
+                  />
+                  {source.active ? 'Enabled' : 'Disabled'}
+                </label>
+              </div>
+            ))}
+          </div>
+        </Card>
+      )}
       {dialog}
     </PageContainer>
   )

--- a/app/frontend/test/fixtures.ts
+++ b/app/frontend/test/fixtures.ts
@@ -151,6 +151,7 @@ export function buildNewsSource(overrides: Partial<NewsSource> = {}): NewsSource
     name: 'Hacker News',
     source_type: 'hacker_news',
     subreddit: null,
+    channel_id: null,
     active: true,
     last_fetch: null,
     ...overrides,

--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -8,6 +8,7 @@ module ArticlesHelper
   }.freeze
 
   KNOWN_SOURCE_TYPES = CATEGORIES.values.flatten.freeze
+  YOUTUBE_SOURCE_PREFIX = "youtube_".freeze
 
   def group_sources_by_category(articles_by_source)
     grouped = {}
@@ -20,8 +21,13 @@ module ArticlesHelper
       grouped[category_name] = category_articles if category_articles.any?
     end
 
-    # Add any sources not in predefined categories
-    other_sources = articles_by_source.keys - KNOWN_SOURCE_TYPES
+    video_keys = youtube_source_types(articles_by_source.keys)
+    if video_keys.any?
+      grouped["Videos"] = video_keys.flat_map { |source_type| articles_by_source[source_type] || [] }
+    end
+
+    # Add any sources not in predefined categories (and not YouTube).
+    other_sources = articles_by_source.keys - KNOWN_SOURCE_TYPES - video_keys
     if other_sources.any?
       other_articles = []
       other_sources.each do |source_type|
@@ -40,6 +46,7 @@ module ArticlesHelper
       "Security" => "🔒",
       "AI & Machine Learning" => "🤖",
       "General Tech" => "💻",
+      "Videos" => "▶️",
       "Other" => "📰"
     }
     icons[category_name] || "📄"
@@ -57,6 +64,7 @@ module ArticlesHelper
       return source_types if category_slug(name) == slug
     end
 
+    return :videos if category_slug("Videos") == slug
     return :other if category_slug("Other") == slug
 
     nil
@@ -67,8 +75,12 @@ module ArticlesHelper
     return scope if source_types.nil? && (slug.blank? || slug == "all")
     return scope.none if source_types.nil?
 
-    if source_types == :other
+    case source_types
+    when :videos
+      scope.where("source_type LIKE ?", "#{YOUTUBE_SOURCE_PREFIX}%")
+    when :other
       scope.where.not(source_type: KNOWN_SOURCE_TYPES)
+           .where.not("source_type LIKE ?", "#{YOUTUBE_SOURCE_PREFIX}%")
     else
       scope.where(source_type: source_types)
     end
@@ -87,9 +99,17 @@ module ArticlesHelper
       grouped[category_name] = count if count.positive?
     end
 
-    other_count = counts_by_source.except(*KNOWN_SOURCE_TYPES).values.sum
+    video_keys = youtube_source_types(counts_by_source.keys)
+    video_count = video_keys.sum { |key| counts_by_source[key] || 0 }
+    grouped["Videos"] = video_count if video_count.positive?
+
+    other_count = counts_by_source.except(*KNOWN_SOURCE_TYPES, *video_keys).values.sum
     grouped["Other"] = other_count if other_count.positive?
 
     grouped
+  end
+
+  def youtube_source_types(source_types)
+    Array(source_types).select { |source_type| source_type.to_s.start_with?(YOUTUBE_SOURCE_PREFIX) }
   end
 end

--- a/app/models/news_aggregator_config.rb
+++ b/app/models/news_aggregator_config.rb
@@ -59,5 +59,32 @@ module NewsAggregatorConfig
     def reddit_base_url
       config.dig(:apis, :reddit, :base_url)
     end
+
+    def youtube_channels
+      Array(config.dig(:apis, :youtube, :channels)).filter_map { |entry|
+        next if entry.blank?
+
+        channel = entry.is_a?(Hash) ? entry : { channel_id: entry }
+        channel_id = channel[:channel_id].presence || channel["channel_id"].presence
+        next if channel_id.blank?
+
+        {
+          channel_id: channel_id.to_s,
+          name: (channel[:name] || channel["name"]).presence || channel_id.to_s
+        }
+      }
+    end
+
+    def youtube_min_request_interval_seconds
+      config.dig(:apis, :youtube, :min_request_interval_seconds) || 2.0
+    end
+
+    def youtube_rate_limit_max_retries
+      config.dig(:apis, :youtube, :rate_limit_max_retries) || 4
+    end
+
+    def youtube_feed_base_url
+      config.dig(:apis, :youtube, :feed_base_url) || "https://www.youtube.com/feeds/videos.xml"
+    end
   end
 end

--- a/app/models/news_source.rb
+++ b/app/models/news_source.rb
@@ -1,11 +1,12 @@
 # Database-backed source registry. When any enabled records exist,
 # NewsAggregatorService uses them instead of config/news_aggregator.yml defaults.
 class NewsSource < ApplicationRecord
-  SOURCE_TYPES = %w[hacker_news dev_to reddit].freeze
+  SOURCE_TYPES = %w[hacker_news dev_to reddit youtube].freeze
 
   validates :name, presence: true, uniqueness: { scope: :source_type }
   validates :source_type, inclusion: { in: SOURCE_TYPES }
   validate :reddit_subreddit_present, if: -> { source_type == "reddit" }
+  validate :youtube_channel_id_present, if: -> { source_type == "youtube" }
 
   scope :enabled, -> { where(active: true) }
 
@@ -26,15 +27,37 @@ class NewsSource < ApplicationRecord
         source.config = { "subreddit" => subreddit }
       end
     end
+
+    NewsAggregatorConfig.youtube_channels.each do |channel|
+      find_or_create_by!(source_type: "youtube", name: channel[:name]) do |source|
+        source.active = true
+        source.config = {
+          "channel_id" => channel[:channel_id],
+          "channel_name" => channel[:name]
+        }
+      end
+    end
   end
 
   def subreddit
     config["subreddit"]
   end
 
+  def channel_id
+    config["channel_id"]
+  end
+
+  def channel_name
+    config["channel_name"].presence || name
+  end
+
   # Matches NewsFetchers::*#source_key used by FetchRun rows.
   def source_key
-    source_type == "reddit" ? "reddit_#{subreddit}" : source_type
+    case source_type
+    when "reddit" then "reddit_#{subreddit}"
+    when "youtube" then "youtube_#{channel_id}"
+    else source_type
+    end
   end
 
   def build_fetcher
@@ -45,6 +68,8 @@ class NewsSource < ApplicationRecord
       NewsFetchers::DevToFetcher.new
     when "reddit"
       NewsFetchers::RedditFetcher.new(subreddit: subreddit)
+    when "youtube"
+      NewsFetchers::YoutubeFetcher.new(channel_id: channel_id, channel_name: channel_name)
     end
   end
 
@@ -52,5 +77,9 @@ class NewsSource < ApplicationRecord
 
   def reddit_subreddit_present
     errors.add(:config, "must include subreddit") if subreddit.blank?
+  end
+
+  def youtube_channel_id_present
+    errors.add(:config, "must include channel_id") if channel_id.blank?
   end
 end

--- a/app/services/news_aggregator_service.rb
+++ b/app/services/news_aggregator_service.rb
@@ -26,6 +26,13 @@ class NewsAggregatorService
       fetchers << NewsFetchers::RedditFetcher.new(subreddit: subreddit)
     end
 
+    NewsAggregatorConfig.youtube_channels.each do |channel|
+      fetchers << NewsFetchers::YoutubeFetcher.new(
+        channel_id: channel[:channel_id],
+        channel_name: channel[:name]
+      )
+    end
+
     fetchers
   end
 

--- a/app/services/news_fetchers/youtube_fetcher.rb
+++ b/app/services/news_fetchers/youtube_fetcher.rb
@@ -1,0 +1,167 @@
+class NewsFetchers::YoutubeFetcher < NewsFetchers::BaseFetcher
+  USER_AGENT = "dev-news-aggregator/1.0 (+https://github.com/MarcosLorejan/dev-news-aggregator)"
+  FEED_HOST = "https://www.youtube.com"
+
+  base_uri FEED_HOST
+  headers "User-Agent" => USER_AGENT
+
+  class << self
+    attr_writer :min_request_interval_seconds, :rate_limit_backoff_seconds
+
+    def min_request_interval_seconds
+      @min_request_interval_seconds || NewsAggregatorConfig.youtube_min_request_interval_seconds
+    end
+
+    def rate_limit_backoff_seconds(attempt)
+      if @rate_limit_backoff_seconds
+        return @rate_limit_backoff_seconds.respond_to?(:call) ? @rate_limit_backoff_seconds.call(attempt) : @rate_limit_backoff_seconds
+      end
+
+      [ 5 * (3**(attempt - 1)), 120 ].min
+    end
+
+    def reset_throttle!
+      @last_request_at = nil
+    end
+
+    def throttle!
+      @throttle_mutex ||= Mutex.new
+      @throttle_mutex.synchronize do
+        now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        if @last_request_at
+          wait = min_request_interval_seconds - (now - @last_request_at)
+          sleep(wait) if wait.positive?
+        end
+        @last_request_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+    end
+  end
+
+  def initialize(channel_id:, channel_name: nil)
+    super()
+    @channel_id = channel_id.to_s.strip
+    @channel_name = channel_name.presence
+    raise ArgumentError, "channel_id is required" if @channel_id.blank?
+  end
+
+  def source_key
+    "youtube_#{@channel_id}"
+  end
+
+  def fetch_articles
+    Rails.logger.info "Fetching YouTube channel #{@channel_id}..."
+
+    feed_body = fetch_with_rate_limit_retry { fetch_feed_body }
+    entries = parse_atom_entries(feed_body)
+    raise FetchError, "YouTube channel #{@channel_id} feed contained no entries" if entries.empty?
+
+    entries.first(NewsAggregatorConfig.max_articles_per_source).each do |entry|
+      create_article_from_atom_entry(entry)
+    end
+
+    Rails.logger.info "Fetched #{@articles.length} videos from YouTube channel #{@channel_id}"
+    @articles
+  end
+
+  private
+
+  def fetch_feed_body
+    response = self.class.get(
+      "/feeds/videos.xml",
+      query: { channel_id: @channel_id },
+      format: :plain,
+      headers: { "User-Agent" => USER_AGENT }
+    )
+
+    body = response.to_s
+    raise FetchError, "Empty YouTube channel #{@channel_id} Atom feed" if body.blank?
+
+    body
+  end
+
+  def fetch_with_rate_limit_retry
+    attempt = 0
+    max_attempts = NewsAggregatorConfig.youtube_rate_limit_max_retries + 1
+
+    begin
+      self.class.throttle!
+      yield
+    rescue FetchError => e
+      raise unless rate_limited_error?(e)
+
+      attempt += 1
+      raise if attempt >= max_attempts
+
+      wait = self.class.rate_limit_backoff_seconds(attempt)
+      Rails.logger.warn(
+        "YouTube channel #{@channel_id} rate limited (attempt #{attempt}/#{max_attempts - 1}); sleeping #{wait}s"
+      )
+      sleep(wait)
+      retry
+    end
+  end
+
+  def rate_limited_error?(error)
+    error.message.match?(/HTTP 429\b/)
+  end
+
+  def parse_atom_entries(feed_body)
+    document = Nokogiri::XML(feed_body)
+    document.remove_namespaces!
+
+    document.xpath("//entry").filter_map do |entry|
+      video_id = entry.at_xpath("./videoId")&.text&.strip.presence ||
+                 entry.at_xpath("./id")&.text&.to_s&.delete_prefix("yt:video:")&.strip
+      title = entry.at_xpath("./title")&.text&.strip
+      url = entry.at_xpath("./link/@href")&.value&.strip
+      published = entry.at_xpath("./published")&.text.presence ||
+                  entry.at_xpath("./updated")&.text
+      description = entry.at_xpath("./group/description")&.text.to_s.strip
+      thumbnail_url = entry.at_xpath("./group/thumbnail/@url")&.value&.strip
+      author = entry.at_xpath("./author/name")&.text&.strip.presence || @channel_name
+      views = entry.at_xpath("./group/community/statistics/@views")&.value
+
+      next if video_id.blank? || title.blank? || url.blank?
+
+      {
+        video_id: video_id,
+        title: title,
+        url: url,
+        published_at: published,
+        description: description,
+        thumbnail_url: thumbnail_url,
+        author: author,
+        views: views
+      }
+    end
+  end
+
+  def create_article_from_atom_entry(entry)
+    published_at = Time.iso8601(entry[:published_at])
+    source_type = source_key
+
+    article_attributes = {
+      title: entry[:title],
+      url: entry[:url],
+      published_at: published_at,
+      description: entry[:description].presence,
+      external_id: entry[:video_id],
+      source_type: source_type,
+      content_type: "video",
+      thumbnail_url: entry[:thumbnail_url],
+      author: entry[:author],
+      comment_count: 0
+    }
+
+    if entry[:views].present?
+      article_attributes[:score] = entry[:views].to_i
+    elsif !Article.exists?(external_id: entry[:video_id], source_type: source_type)
+      article_attributes[:score] = 0
+    end
+
+    article = create_or_update_article(article_attributes)
+    @articles << article if article.persisted?
+  rescue StandardError => e
+    Rails.logger.error "Error creating YouTube video #{entry[:video_id]}: #{e.message}"
+  end
+end

--- a/config/news_aggregator.yml
+++ b/config/news_aggregator.yml
@@ -69,6 +69,21 @@ development: &default
         - artificial
         - LocalLLaMA
 
+    youtube:
+      # Public channel Atom feeds — no API key / quota. Prefer channel_id (UC...).
+      feed_base_url: "https://www.youtube.com/feeds/videos.xml"
+      min_request_interval_seconds: 2.0
+      rate_limit_max_retries: 4
+      channels:
+        - channel_id: "UCWnPjmqvljcafA0QXblOU1A"
+          name: "Confreaks"
+        - channel_id: "UCsBjURrPoezykLs9EqgamOA"
+          name: "Fireship"
+        - channel_id: "UC_x5XG1OV2P6uZZ5FSM9Ttw"
+          name: "Google for Developers"
+        - channel_id: "UCUyeluBRhGPCW4rPe7MhPUA"
+          name: "ThePrimeagen"
+
 test:
   <<: *default
   fetching:

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -55,7 +55,7 @@ dev-news-aggregator/
 | `app/models/` | ActiveRecord models |
 | `app/services/` | Business logic — news aggregation orchestration |
 | `app/services/error_reporting/` | Rails.error subscriber + optional webhook alerts |
-| `app/services/news_fetchers/` | Per-source API fetchers (HN, Dev.to, Reddit) |
+| `app/services/news_fetchers/` | Per-source API fetchers (HN, Dev.to, Reddit, YouTube) |
 | `app/jobs/` | Background jobs (e.g. permanent dismissal) |
 | `app/helpers/` | View helpers (categories, formatting) |
 | `app/views/` | ERB templates |
@@ -101,6 +101,7 @@ dev-news-aggregator/
 | `news_fetchers/hacker_news_fetcher.rb` | Hacker News Firebase API |
 | `news_fetchers/dev_to_fetcher.rb` | Dev.to REST API |
 | `news_fetchers/reddit_fetcher.rb` | Reddit API (one instance per subreddit) |
+| `news_fetchers/youtube_fetcher.rb` | YouTube channel Atom feeds (no API key) |
 | `personal_feed_ranker.rb` | For you sort — source affinity from bookmarks/dismissals |
 | `article_topic_classifier.rb` | Schema-validated topic tagging (keyword heuristics) |
 | `feed_noise_classifier.rb` | Heuristics to flag low-signal / meme feed items |

--- a/test/models/news_source_test.rb
+++ b/test/models/news_source_test.rb
@@ -14,6 +14,12 @@ class NewsSourceTest < ActiveSupport::TestCase
     assert_includes source.errors[:config], "must include subreddit"
   end
 
+  test "youtube source requires channel_id in config" do
+    source = NewsSource.new(name: "Confreaks", source_type: "youtube", config: {})
+    assert_not source.valid?
+    assert_includes source.errors[:config], "must include channel_id"
+  end
+
   test "build_fetcher returns correct fetcher class" do
     source = news_sources(:hacker_news)
     assert_instance_of NewsFetchers::HackerNewsFetcher, source.build_fetcher
@@ -22,12 +28,28 @@ class NewsSourceTest < ActiveSupport::TestCase
     fetcher = reddit.build_fetcher
     assert_instance_of NewsFetchers::RedditFetcher, fetcher
     assert_equal "rust", fetcher.instance_variable_get(:@subreddit)
+
+    youtube = NewsSource.create!(
+      name: "Confreaks",
+      source_type: "youtube",
+      active: true,
+      config: { "channel_id" => "UCWnPjmqvljcafA0QXblOU1A", "channel_name" => "Confreaks" }
+    )
+    yt_fetcher = youtube.build_fetcher
+    assert_instance_of NewsFetchers::YoutubeFetcher, yt_fetcher
+    assert_equal "UCWnPjmqvljcafA0QXblOU1A", yt_fetcher.instance_variable_get(:@channel_id)
   end
 
   test "source_key matches fetcher keys" do
     assert_equal "hacker_news", news_sources(:hacker_news).source_key
     assert_equal "dev_to", news_sources(:dev_to).source_key
     assert_equal "reddit_rust", news_sources(:reddit_rust).source_key
+
+    youtube = NewsSource.new(
+      source_type: "youtube",
+      config: { "channel_id" => "UCWnPjmqvljcafA0QXblOU1A" }
+    )
+    assert_equal "youtube_UCWnPjmqvljcafA0QXblOU1A", youtube.source_key
   end
 
   test "bootstrap_defaults creates default sources" do
@@ -38,5 +60,7 @@ class NewsSourceTest < ActiveSupport::TestCase
     assert NewsSource.exists?(source_type: "dev_to")
     assert_equal NewsAggregatorConfig.reddit_subreddits.length,
                  NewsSource.where(source_type: "reddit").count
+    assert_equal NewsAggregatorConfig.youtube_channels.length,
+                 NewsSource.where(source_type: "youtube").count
   end
 end

--- a/test/services/news_aggregator_service_test.rb
+++ b/test/services/news_aggregator_service_test.rb
@@ -23,6 +23,8 @@ class NewsAggregatorServiceTest < ActiveSupport::TestCase
     assert fetchers.any? { |f| f.is_a?(NewsFetchers::DevToFetcher) }
     reddit_fetchers = fetchers.select { |f| f.is_a?(NewsFetchers::RedditFetcher) }
     assert_equal NewsAggregatorConfig.reddit_subreddits.length, reddit_fetchers.length
+    youtube_fetchers = fetchers.select { |f| f.is_a?(NewsFetchers::YoutubeFetcher) }
+    assert_equal NewsAggregatorConfig.youtube_channels.length, youtube_fetchers.length
   end
 
   test "uses enabled database sources when present" do

--- a/test/services/news_fetchers/youtube_fetcher_test.rb
+++ b/test/services/news_fetchers/youtube_fetcher_test.rb
@@ -1,0 +1,174 @@
+require "test_helper"
+
+class NewsFetchers::YoutubeFetcherTest < ActiveSupport::TestCase
+  setup do
+    NewsFetchers::YoutubeFetcher.reset_throttle!
+    NewsFetchers::YoutubeFetcher.min_request_interval_seconds = 0
+    NewsFetchers::YoutubeFetcher.rate_limit_backoff_seconds = 0
+    @channel_id = "UCWnPjmqvljcafA0QXblOU1A"
+    @fetcher = NewsFetchers::YoutubeFetcher.new(channel_id: @channel_id, channel_name: "Confreaks")
+  end
+
+  teardown do
+    NewsFetchers::YoutubeFetcher.min_request_interval_seconds = nil
+    NewsFetchers::YoutubeFetcher.rate_limit_backoff_seconds = nil
+    NewsFetchers::YoutubeFetcher.reset_throttle!
+  end
+
+  test "source_key includes the channel id" do
+    assert_equal "youtube_#{@channel_id}", @fetcher.source_key
+  end
+
+  test "fetch_articles creates video articles from the Atom feed" do
+    stub_youtube_feed(<<~ATOM)
+      <feed xmlns:yt="http://www.youtube.com/xml/schemas/2015"
+            xmlns:media="http://search.yahoo.com/mrss/"
+            xmlns="http://www.w3.org/2005/Atom">
+        <entry>
+          <id>yt:video:abc123XYZ</id>
+          <yt:videoId>abc123XYZ</yt:videoId>
+          <title>Rails performance tips</title>
+          <link rel="alternate" href="https://www.youtube.com/watch?v=abc123XYZ"/>
+          <author><name>Confreaks</name></author>
+          <published>2024-06-01T12:00:00+00:00</published>
+          <media:group>
+            <media:description>A talk about Rails performance.</media:description>
+            <media:thumbnail url="https://i.ytimg.com/vi/abc123XYZ/hqdefault.jpg"/>
+            <media:community>
+              <media:statistics views="1234"/>
+            </media:community>
+          </media:group>
+        </entry>
+      </feed>
+    ATOM
+
+    assert_difference "Article.count", 1 do
+      articles = @fetcher.fetch_articles
+      assert_equal 1, articles.length
+    end
+
+    article = Article.find_by!(external_id: "abc123XYZ", source_type: "youtube_#{@channel_id}")
+    assert_equal "Rails performance tips", article.title
+    assert_equal "https://www.youtube.com/watch?v=abc123XYZ", article.url
+    assert_equal "video", article.content_type
+    assert_equal "Confreaks", article.author
+    assert_equal "https://i.ytimg.com/vi/abc123XYZ/hqdefault.jpg", article.thumbnail_url
+    assert_equal 1234, article.score
+    assert_equal 0, article.comment_count
+    assert_equal "A talk about Rails performance.", article.description
+  end
+
+  test "fetch_articles updates existing videos without wiping a higher score when views are missing" do
+    existing = Article.create!(
+      title: "Old title",
+      url: "https://www.youtube.com/watch?v=abc123XYZ",
+      external_id: "abc123XYZ",
+      source_type: "youtube_#{@channel_id}",
+      published_at: 1.day.ago,
+      content_type: "video",
+      score: 9999,
+      comment_count: 0
+    )
+
+    stub_youtube_feed(<<~ATOM)
+      <feed xmlns:yt="http://www.youtube.com/xml/schemas/2015"
+            xmlns:media="http://search.yahoo.com/mrss/"
+            xmlns="http://www.w3.org/2005/Atom">
+        <entry>
+          <yt:videoId>abc123XYZ</yt:videoId>
+          <title>Updated title</title>
+          <link rel="alternate" href="https://www.youtube.com/watch?v=abc123XYZ"/>
+          <published>2024-06-02T12:00:00+00:00</published>
+          <media:group>
+            <media:description>Updated</media:description>
+            <media:thumbnail url="https://i.ytimg.com/vi/abc123XYZ/hqdefault.jpg"/>
+          </media:group>
+        </entry>
+      </feed>
+    ATOM
+
+    assert_no_difference "Article.count" do
+      @fetcher.fetch_articles
+    end
+
+    existing.reload
+    assert_equal "Updated title", existing.title
+    assert_equal 9999, existing.score
+  end
+
+  test "fetch_articles raises on HTTP 404" do
+    stub_request(:get, feed_url)
+      .to_return(status: 404, body: "Not Found", headers: { "Content-Type" => "text/plain" })
+
+    error = assert_raises(NewsFetchers::BaseFetcher::FetchError) { @fetcher.fetch_articles }
+    assert_match(/HTTP 404/, error.message)
+  end
+
+  test "fetch_articles raises on HTTP 5xx" do
+    stub_request(:get, feed_url)
+      .to_return(status: 503, body: "Unavailable", headers: { "Content-Type" => "text/plain" })
+
+    error = assert_raises(NewsFetchers::BaseFetcher::FetchError) { @fetcher.fetch_articles }
+    assert_match(/HTTP 503/, error.message)
+  end
+
+  test "fetch_articles raises when the feed has no entries" do
+    stub_youtube_feed(<<~ATOM)
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <title>Empty channel</title>
+      </feed>
+    ATOM
+
+    error = assert_raises(NewsFetchers::BaseFetcher::FetchError) { @fetcher.fetch_articles }
+    assert_match(/no entries/, error.message)
+  end
+
+  test "fetch_articles raises on an empty body" do
+    stub_request(:get, feed_url)
+      .to_return(status: 200, body: "", headers: { "Content-Type" => "application/atom+xml" })
+
+    error = assert_raises(NewsFetchers::BaseFetcher::FetchError) { @fetcher.fetch_articles }
+    assert_match(/Empty YouTube/, error.message)
+  end
+
+  test "fetch_articles retries after HTTP 429" do
+    stub_request(:get, feed_url)
+      .to_return(
+        { status: 429, body: "rate limited", headers: { "Content-Type" => "text/plain" } },
+        { status: 200, body: single_entry_atom, headers: { "Content-Type" => "application/atom+xml" } }
+      )
+
+    articles = @fetcher.fetch_articles
+    assert_equal 1, articles.length
+  end
+
+  private
+
+  def feed_url
+    "https://www.youtube.com/feeds/videos.xml?channel_id=#{@channel_id}"
+  end
+
+  def stub_youtube_feed(body)
+    stub_request(:get, feed_url)
+      .to_return(status: 200, body: body, headers: { "Content-Type" => "application/atom+xml" })
+  end
+
+  def single_entry_atom
+    <<~ATOM
+      <feed xmlns:yt="http://www.youtube.com/xml/schemas/2015"
+            xmlns:media="http://search.yahoo.com/mrss/"
+            xmlns="http://www.w3.org/2005/Atom">
+        <entry>
+          <yt:videoId>retryVid1</yt:videoId>
+          <title>After retry</title>
+          <link rel="alternate" href="https://www.youtube.com/watch?v=retryVid1"/>
+          <published>2024-06-01T12:00:00+00:00</published>
+          <media:group>
+            <media:description>ok</media:description>
+            <media:thumbnail url="https://i.ytimg.com/vi/retryVid1/hqdefault.jpg"/>
+          </media:group>
+        </entry>
+      </feed>
+    ATOM
+  end
+end


### PR DESCRIPTION
Closes #382.

## Summary

- Adds `NewsFetchers::YoutubeFetcher` to ingest channel uploads from public Atom feeds (`/feeds/videos.xml?channel_id=UC...`) with zero API quota: title, url, description, published_at, thumbnail, author, view count → `score`, `content_type: video`, `source_type: youtube_<channel_id>`.
- Wires `youtube` into `NewsSource` (bootstrap, build_fetcher, validations), `NewsAggregatorService.default_fetchers`, and `apis.youtube` starter channels in `config/news_aggregator.yml`.
- Groups YouTube sources under a **Videos** category; Sources page lists YouTube channels with enable/disable (add/remove UI stays for #387).
- Throttling + 429 retries mirror Reddit; 404/5xx/empty feeds raise `FetchError` so `FetchRun` records per-channel failures without breaking other sources.

## Test plan

- [x] `youtube_fetcher_test` — create from Atom, preserve score without views, 404/5xx/empty/no-entries, 429 retry
- [x] `news_source_test` / `news_aggregator_service_test` extended
- [x] RuboCop + Typecheck
