### PR TITLE
feat(youtube): enrich videos with duration and stats via videos.list (#383)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,10 @@ SECRET_KEY_BASE=your_secret_key_base_here
 # REDDIT_CLIENT_ID=
 # REDDIT_CLIENT_SECRET=
 
+# Optional YouTube Data API key for videos.list duration/stats enrichment
+# (1 quota unit per call, up to 50 IDs). Channel Atom feeds work without this.
+# YOUTUBE_API_KEY=
+
 # Optional article summarizer (default: none — app works without it).
 # Providers: none | heuristic | openai | ollama
 # ARTICLE_SUMMARIZER_PROVIDER=none

--- a/app/jobs/fetch_news_job.rb
+++ b/app/jobs/fetch_news_job.rb
@@ -2,6 +2,8 @@ class FetchNewsJob < ApplicationJob
   queue_as :default
 
   def perform
-    NewsAggregatorService.fetch_all_news
+    result = NewsAggregatorService.fetch_all_news
+    YoutubeVideoEnricher.enrich!
+    result
   end
 end

--- a/app/models/news_aggregator_config.rb
+++ b/app/models/news_aggregator_config.rb
@@ -86,5 +86,20 @@ module NewsAggregatorConfig
     def youtube_feed_base_url
       config.dig(:apis, :youtube, :feed_base_url) || "https://www.youtube.com/feeds/videos.xml"
     end
+
+    def youtube_enrich_with_api?
+      flag = config.dig(:apis, :youtube, :enrich_with_api)
+      flag.nil? ? true : ActiveModel::Type::Boolean.new.cast(flag)
+    end
+
+    def youtube_enrich_batch_size
+      size = config.dig(:apis, :youtube, :enrich_batch_size) || 50
+      [ size.to_i, 1 ].max.clamp(1, 50)
+    end
+
+    def youtube_enrich_max_per_run
+      max = config.dig(:apis, :youtube, :enrich_max_per_run) || 100
+      [ max.to_i, 0 ].max
+    end
   end
 end

--- a/app/services/youtube_video_enricher.rb
+++ b/app/services/youtube_video_enricher.rb
@@ -1,0 +1,114 @@
+# Fills in duration/stats for YouTube videos using videos.list (1 quota unit per
+# call, up to 50 IDs). No-ops when YOUTUBE_API_KEY is unset so Atom-only works.
+class YoutubeVideoEnricher
+  include HTTParty
+
+  API_URL = "https://www.googleapis.com/youtube/v3/videos"
+  DEFAULT_BATCH_SIZE = 50
+
+  class << self
+    def enrich!(limit: nil)
+      new.enrich!(limit: limit)
+    end
+
+    def api_key
+      ENV["YOUTUBE_API_KEY"].presence
+    end
+
+    def enabled?
+      NewsAggregatorConfig.youtube_enrich_with_api? && api_key.present?
+    end
+  end
+
+  def enrich!(limit: nil)
+    unless self.class.enabled?
+      Rails.logger.info "YouTube video enrichment skipped (no API key or enrich_with_api disabled)"
+      return { enriched: 0, skipped: true }
+    end
+
+    scope = Article.videos.where(duration_seconds: nil).order(published_at: :desc)
+    max = limit || NewsAggregatorConfig.youtube_enrich_max_per_run
+    candidates = scope.limit(max).to_a
+    return { enriched: 0, skipped: false } if candidates.empty?
+
+    enriched = 0
+    candidates.each_slice(NewsAggregatorConfig.youtube_enrich_batch_size) do |batch|
+      enriched += enrich_batch(batch)
+    end
+
+    { enriched: enriched, skipped: false }
+  rescue StandardError => e
+    Rails.error.report(e, handled: true, context: { service: "YoutubeVideoEnricher" })
+    Rails.logger.error "YouTube video enrichment failed: #{e.class}: #{e.message}"
+    { enriched: 0, skipped: false, error: e.message }
+  end
+
+  private
+
+  def enrich_batch(articles)
+    ids = articles.map(&:external_id)
+    payload = fetch_videos(ids)
+    items = payload.is_a?(Hash) ? Array(payload["items"]) : []
+    by_id = items.index_by { |item| item["id"].to_s }
+
+    updated = 0
+    articles.each do |article|
+      item = by_id[article.external_id.to_s]
+      next unless item
+
+      attributes = attributes_from_item(item)
+      next if attributes.empty?
+
+      article.update!(attributes)
+      updated += 1
+    rescue StandardError => e
+      Rails.logger.error "Failed to enrich YouTube video #{article.external_id}: #{e.message}"
+    end
+    updated
+  end
+
+  def fetch_videos(ids)
+    response = HTTParty.get(
+      API_URL,
+      query: {
+        part: "contentDetails,statistics",
+        id: ids.join(","),
+        key: self.class.api_key
+      },
+      timeout: NewsAggregatorConfig.request_timeout
+    )
+
+    unless response.success?
+      body_preview = response.body.to_s.gsub(/\s+/, " ").strip[0, 200]
+      raise NewsFetchers::BaseFetcher::FetchError,
+            "HTTP #{response.code} for videos.list: #{body_preview.presence || '(empty body)'}"
+    end
+
+    response.parsed_response
+  end
+
+  def attributes_from_item(item)
+    attributes = {}
+
+    duration = item.dig("contentDetails", "duration")
+    seconds = parse_duration_seconds(duration)
+    attributes[:duration_seconds] = seconds if seconds
+
+    stats = item["statistics"]
+    if stats.is_a?(Hash)
+      attributes[:score] = stats["viewCount"].to_i if stats.key?("viewCount")
+      attributes[:comment_count] = stats["commentCount"].to_i if stats.key?("commentCount")
+    end
+
+    attributes
+  end
+
+  # PT1H2M3S / PT7M32S / PT45S → integer seconds. Returns nil when unparseable.
+  def parse_duration_seconds(value)
+    return nil if value.blank?
+
+    ActiveSupport::Duration.parse(value).to_i
+  rescue ArgumentError, TypeError
+    nil
+  end
+end

--- a/config/news_aggregator.yml
+++ b/config/news_aggregator.yml
@@ -74,6 +74,10 @@ development: &default
       feed_base_url: "https://www.youtube.com/feeds/videos.xml"
       min_request_interval_seconds: 2.0
       rate_limit_max_retries: 4
+      # Optional videos.list enrichment (1 unit / call, up to 50 IDs). Needs YOUTUBE_API_KEY.
+      enrich_with_api: true
+      enrich_batch_size: 50
+      enrich_max_per_run: 100
       channels:
         - channel_id: "UCWnPjmqvljcafA0QXblOU1A"
           name: "Confreaks"

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -110,6 +110,7 @@ dev-news-aggregator/
 | `digest_builder.rb` | Builds schema-validated unread digests (title-only without LLM) |
 | `article_summarizer.rb` | Pluggable article summarizer facade (`none` / `heuristic` / `openai` / `ollama`) |
 | `summarizers/` | Provider implementations for `ArticleSummarizer` |
+| `youtube_video_enricher.rb` | Optional YouTube `videos.list` duration/stats enrichment |
 
 ### Jobs
 

--- a/test/jobs/fetch_news_job_test.rb
+++ b/test/jobs/fetch_news_job_test.rb
@@ -10,12 +10,15 @@ class FetchNewsJobTest < ActiveJob::TestCase
     }
 
     original = NewsAggregatorService.method(:fetch_all_news)
+    enrich_original = YoutubeVideoEnricher.method(:enrich!)
     NewsAggregatorService.define_singleton_method(:fetch_all_news) { expected }
+    YoutubeVideoEnricher.define_singleton_method(:enrich!) { { enriched: 0, skipped: true } }
     begin
       result = FetchNewsJob.perform_now
       assert_equal expected, result
     ensure
       NewsAggregatorService.define_singleton_method(:fetch_all_news, original)
+      YoutubeVideoEnricher.define_singleton_method(:enrich!, enrich_original)
     end
   end
 end

--- a/test/services/youtube_video_enricher_test.rb
+++ b/test/services/youtube_video_enricher_test.rb
@@ -1,0 +1,116 @@
+require "test_helper"
+
+class YoutubeVideoEnricherTest < ActiveSupport::TestCase
+  setup do
+    @previous_key = ENV["YOUTUBE_API_KEY"]
+    ENV["YOUTUBE_API_KEY"] = "test-key"
+
+    @video = Article.create!(
+      title: "Short tip",
+      url: "https://www.youtube.com/watch?v=abc123XYZ",
+      external_id: "abc123XYZ",
+      source_type: "youtube_UCWnPjmqvljcafA0QXblOU1A",
+      published_at: Time.current,
+      content_type: "video",
+      score: 10,
+      comment_count: 0,
+      duration_seconds: nil
+    )
+  end
+
+  teardown do
+    if @previous_key
+      ENV["YOUTUBE_API_KEY"] = @previous_key
+    else
+      ENV.delete("YOUTUBE_API_KEY")
+    end
+  end
+
+  test "enrich! fills duration and stats from videos.list" do
+    stub_videos_list(
+      items: [
+        {
+          "id" => "abc123XYZ",
+          "contentDetails" => { "duration" => "PT7M32S" },
+          "statistics" => { "viewCount" => "1500", "commentCount" => "12" }
+        }
+      ]
+    )
+
+    result = YoutubeVideoEnricher.enrich!
+
+    assert_equal 1, result[:enriched]
+    @video.reload
+    assert_equal 452, @video.duration_seconds
+    assert_equal 1500, @video.score
+    assert_equal 12, @video.comment_count
+  end
+
+  test "parse_duration_seconds handles hours and seconds-only forms" do
+    enricher = YoutubeVideoEnricher.new
+
+    assert_equal 452, enricher.send(:parse_duration_seconds, "PT7M32S")
+    assert_equal 3723, enricher.send(:parse_duration_seconds, "PT1H2M3S")
+    assert_equal 45, enricher.send(:parse_duration_seconds, "PT45S")
+    assert_nil enricher.send(:parse_duration_seconds, "not-a-duration")
+    assert_nil enricher.send(:parse_duration_seconds, nil)
+  end
+
+  test "enrich! is a no-op without an API key" do
+    ENV.delete("YOUTUBE_API_KEY")
+
+    result = YoutubeVideoEnricher.enrich!
+
+    assert result[:skipped]
+    assert_equal 0, result[:enriched]
+    assert_nil @video.reload.duration_seconds
+  end
+
+  test "enrich! reports quota errors without crashing or writing partial junk" do
+    stub_request(:get, %r{https://www\.googleapis\.com/youtube/v3/videos})
+      .to_return(
+        status: 403,
+        body: { error: { message: "quotaExceeded" } }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+
+    result = YoutubeVideoEnricher.enrich!
+
+    assert_equal 0, result[:enriched]
+    assert_match(/HTTP 403/, result[:error])
+    assert_nil @video.reload.duration_seconds
+    assert_equal 10, @video.score
+  end
+
+  test "enrich! skips unparseable durations but still updates stats" do
+    stub_videos_list(
+      items: [
+        {
+          "id" => "abc123XYZ",
+          "contentDetails" => { "duration" => "bogus" },
+          "statistics" => { "viewCount" => "42", "commentCount" => "1" }
+        }
+      ]
+    )
+
+    result = YoutubeVideoEnricher.enrich!
+
+    assert_equal 1, result[:enriched]
+    @video.reload
+    assert_nil @video.duration_seconds
+    assert_equal 42, @video.score
+    assert_equal 1, @video.comment_count
+  end
+
+  private
+
+  def stub_videos_list(items:)
+    stub_request(:get, %r{https://www\.googleapis\.com/youtube/v3/videos})
+      .with(query: hash_including("part" => "contentDetails,statistics", "key" => "test-key"))
+      .to_return(
+        status: 200,
+        body: { items: items }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+  end
+end


### PR DESCRIPTION
Closes #383.

## Summary

- Adds `YoutubeVideoEnricher` to fill `duration_seconds`, view `score`, and `comment_count` via `videos.list` (1 quota unit / up to 50 IDs).
- Runs after each `FetchNewsJob` fetch; no-ops without `YOUTUBE_API_KEY` or when `enrich_with_api` is false so Atom-only stays working.
- Config knobs under `apis.youtube` (`enrich_with_api`, `enrich_batch_size`, `enrich_max_per_run`); key documented in `.env.example`.
- Quota/HTTP errors are reported and leave rows unchanged; unparseable durations skip only that field.

## Test plan

- [x] Success path with PT7M32S → 452s + stats
- [x] Hours / seconds-only duration parsing
- [x] Missing API key no-op
- [x] HTTP 403 quota error without partial writes
- [x] Unparseable duration still updates stats
- [x] FetchNewsJob still returns aggregator result
