### PR TITLE
feat(api): filter feed by content type and video duration (#385)

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -153,10 +153,35 @@ class ArticlesController < ApplicationController
     scope = apply_score_filter(scope)
     scope = scope.search(params[:q])
     scope = apply_keyword_filter(scope)
+    scope = apply_content_type_filter(scope)
+    scope = apply_max_duration_filter(scope)
     scope = scope.with_topic_tag(params[:tag])
     scope = helpers.apply_category_filter(scope, params[:category]) if apply_category
     scope = ArticleClusterer.primaries(scope)
     apply_sort(scope.includes(:bookmark, :read_article, :dismissed_article, :tags))
+  end
+
+  def apply_content_type_filter(scope)
+    case params[:content_type].to_s
+    when "video" then scope.videos
+    when "article" then scope.articles_only
+    else scope
+    end
+  end
+
+  # max_duration is in minutes. Text articles are untouched; videos with unknown duration
+  # stay included so Atom-only items remain visible before enrichment.
+  def apply_max_duration_filter(scope)
+    return scope if params[:max_duration].blank?
+
+    seconds = params[:max_duration].to_i * 60
+    return scope if seconds <= 0
+
+    scope.where(
+      "content_type != ? OR duration_seconds IS NULL OR duration_seconds <= ?",
+      "video",
+      seconds
+    )
   end
 
   # `interests=<slug,slug>` (or singular `interest`) expands to the presets' saved terms, unioned

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -27,6 +27,10 @@ class Article < ApplicationRecord
   scope :pending_dismissal, -> { joins(:dismissed_article).where(dismissed_articles: { permanent: false }) }
   scope :videos, -> { where(content_type: "video") }
   scope :articles_only, -> { where(content_type: "article") }
+  # Unknown durations are included so Atom-only videos are not hidden before enrichment.
+  scope :shorter_than_or_unknown, ->(seconds) {
+    where("duration_seconds IS NULL OR duration_seconds <= ?", seconds.to_i)
+  }
   scope :search, ->(query) {
     q = query.to_s.strip
     if q.blank?

--- a/app/models/news_aggregator_config.rb
+++ b/app/models/news_aggregator_config.rb
@@ -101,5 +101,9 @@ module NewsAggregatorConfig
       max = config.dig(:apis, :youtube, :enrich_max_per_run) || 100
       [ max.to_i, 0 ].max
     end
+
+    def youtube_max_duration_seconds
+      config.dig(:apis, :youtube, :max_duration_seconds) || 1200
+    end
   end
 end

--- a/app/services/youtube_video_enricher.rb
+++ b/app/services/youtube_video_enricher.rb
@@ -61,10 +61,23 @@ class YoutubeVideoEnricher
 
       article.update!(attributes)
       updated += 1
+      discard_if_too_long!(article)
     rescue StandardError => e
       Rails.logger.error "Failed to enrich YouTube video #{article.external_id}: #{e.message}"
     end
     updated
+  end
+
+  def discard_if_too_long!(article)
+    max = NewsAggregatorConfig.youtube_max_duration_seconds.to_i
+    return if max <= 0
+    return if article.duration_seconds.blank? || article.duration_seconds <= max
+    return if article.bookmarked? || article.read?
+
+    Rails.logger.info(
+      "Discarding YouTube video #{article.external_id} (#{article.duration_seconds}s > #{max}s cap)"
+    )
+    article.destroy!
   end
 
   def fetch_videos(ids)

--- a/config/news_aggregator.yml
+++ b/config/news_aggregator.yml
@@ -78,6 +78,8 @@ development: &default
       enrich_with_api: true
       enrich_batch_size: 50
       enrich_max_per_run: 100
+      # After enrichment, drop videos longer than this (seconds). 0 disables.
+      max_duration_seconds: 1200
       channels:
         - channel_id: "UCWnPjmqvljcafA0QXblOU1A"
           name: "Confreaks"

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -321,6 +321,82 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
     assert_not article.key?("matched_keywords")
   end
 
+  test "index JSON filters by content_type video" do
+    video = Article.create!(
+      title: "Short Ruby tip",
+      url: "https://www.youtube.com/watch?v=vid1",
+      external_id: "vid1",
+      source_type: "youtube_UCtest",
+      published_at: Time.current,
+      content_type: "video",
+      duration_seconds: 90
+    )
+
+    get articles_url(content_type: "video"), as: :json
+    assert_response :success
+
+    ids = JSON.parse(response.body)["articles"].map { |item| item["id"] }
+    assert_includes ids, video.id
+    assert_not_includes ids, @article.id
+  end
+
+  test "index JSON filters by content_type article" do
+    Article.create!(
+      title: "Short Ruby tip",
+      url: "https://www.youtube.com/watch?v=vid2",
+      external_id: "vid2",
+      source_type: "youtube_UCtest",
+      published_at: Time.current,
+      content_type: "video",
+      duration_seconds: 90
+    )
+
+    get articles_url(content_type: "article"), as: :json
+    assert_response :success
+
+    types = JSON.parse(response.body)["articles"].map { |item| item["content_type"] }.uniq
+    assert_equal [ "article" ], types
+  end
+
+  test "index JSON max_duration keeps text articles and short or unknown videos" do
+    short = Article.create!(
+      title: "Short tip",
+      url: "https://www.youtube.com/watch?v=short1",
+      external_id: "short1",
+      source_type: "youtube_UCtest",
+      published_at: Time.current,
+      content_type: "video",
+      duration_seconds: 60
+    )
+    long = Article.create!(
+      title: "Long talk",
+      url: "https://www.youtube.com/watch?v=long1",
+      external_id: "long1",
+      source_type: "youtube_UCtest",
+      published_at: Time.current,
+      content_type: "video",
+      duration_seconds: 3600
+    )
+    unknown = Article.create!(
+      title: "Unknown length",
+      url: "https://www.youtube.com/watch?v=unk1",
+      external_id: "unk1",
+      source_type: "youtube_UCtest",
+      published_at: Time.current,
+      content_type: "video",
+      duration_seconds: nil
+    )
+
+    get articles_url(max_duration: 20), as: :json
+    assert_response :success
+
+    ids = JSON.parse(response.body)["articles"].map { |item| item["id"] }
+    assert_includes ids, @article.id
+    assert_includes ids, short.id
+    assert_includes ids, unknown.id
+    assert_not_includes ids, long.id
+  end
+
   test "index JSON unions terms from several interest slugs" do
     get articles_url(interests: "ruby,rust"), as: :json
     assert_response :success

--- a/test/services/youtube_video_enricher_test.rb
+++ b/test/services/youtube_video_enricher_test.rb
@@ -102,6 +102,23 @@ class YoutubeVideoEnricherTest < ActiveSupport::TestCase
     assert_equal 1, @video.comment_count
   end
 
+  test "enrich! discards videos longer than the configured ingest cap" do
+    stub_videos_list(
+      items: [
+        {
+          "id" => "abc123XYZ",
+          "contentDetails" => { "duration" => "PT45M" },
+          "statistics" => { "viewCount" => "9", "commentCount" => "0" }
+        }
+      ]
+    )
+
+    result = YoutubeVideoEnricher.enrich!
+
+    assert_equal 1, result[:enriched]
+    assert_nil Article.find_by(id: @video.id)
+  end
+
   private
 
   def stub_videos_list(items:)


### PR DESCRIPTION
## Summary
- Add `content_type=video|article` and `max_duration` (minutes) filters on `GET /articles` (HTML/JSON/Atom share the same scope)
- Videos with unknown duration stay included; text articles are untouched by duration filter
- After enrichment, discard non-bookmarked/non-read videos over `apis.youtube.max_duration_seconds` (default 1200)

Closes #385

## Test plan
- [ ] `GET /articles?content_type=video` and `?content_type=article` return only matching items
- [ ] `GET /articles?max_duration=20` excludes longer videos; keeps text + unknown-duration videos
- [ ] Enricher destroys over-cap videos that are not bookmarked/read
- [ ] Category counts / pagination still make sense with these filters
- [ ] CI green
