### PR TITLE
feat(frontend): video cards with thumbnail, duration and type filter (#386)

### DIFF
--- a/app/frontend/api/articles.ts
+++ b/app/frontend/api/articles.ts
@@ -12,6 +12,8 @@ export function fetchArticles(params?: {
   sort?: string
   min_score?: number
   top_percent?: number
+  content_type?: 'article' | 'video'
+  max_duration?: number
   signal?: AbortSignal
 }) {
   const search = new URLSearchParams()
@@ -25,6 +27,8 @@ export function fetchArticles(params?: {
   if (params?.sort && params.sort !== 'published_at') search.set('sort', params.sort)
   if (params?.min_score) search.set('min_score', String(params.min_score))
   if (params?.top_percent) search.set('top_percent', String(params.top_percent))
+  if (params?.content_type) search.set('content_type', params.content_type)
+  if (params?.max_duration) search.set('max_duration', String(params.max_duration))
 
   const query = search.toString()
   return apiRequest<ArticlesIndexResponse>(`/articles.json${query ? `?${query}` : ''}`, {

--- a/app/frontend/components/ArticleCard.test.tsx
+++ b/app/frontend/components/ArticleCard.test.tsx
@@ -149,6 +149,91 @@ describe('ArticleCard', () => {
     expect(screen.queryByTestId('matched-keywords')).not.toBeInTheDocument()
   })
 
+  it('renders video thumbnail, duration badge, and channel name', () => {
+    render(
+      <MemoryRouter>
+        <ArticleCard
+          variant="feed"
+          article={{
+            ...feedArticle,
+            content_type: 'video',
+            title: 'Hexagonal Architecture in Rails',
+            author: 'Thoughtbot',
+            thumbnail_url: 'https://i.ytimg.com/vi/abc123/hqdefault.jpg',
+            duration_seconds: 372,
+            source_type: 'youtube_thoughtbot',
+          }}
+          categorySlug="videos"
+          index={0}
+          isDismissing={false}
+          onDismiss={() => {}}
+          onBookmarkToggle={() => {}}
+          onReadToggle={() => {}}
+        />
+      </MemoryRouter>
+    )
+
+    const thumb = screen.getByTestId('video-thumbnail')
+    expect(thumb).toHaveAttribute('aria-label', 'Watch Hexagonal Architecture in Rails')
+    expect(thumb.querySelector('img')).toHaveAttribute(
+      'src',
+      'https://i.ytimg.com/vi/abc123/hqdefault.jpg'
+    )
+    expect(screen.getByTestId('video-duration')).toHaveTextContent('6:12')
+    expect(screen.getByTestId('video-channel')).toHaveTextContent('Thoughtbot')
+    expect(screen.getByRole('article')).toHaveAttribute('data-content-type', 'video')
+  })
+
+  it('degrades cleanly when thumbnail and duration are missing', () => {
+    render(
+      <MemoryRouter>
+        <ArticleCard
+          variant="feed"
+          article={{
+            ...feedArticle,
+            content_type: 'video',
+            author: 'Confreaks',
+            thumbnail_url: null,
+            duration_seconds: null,
+            source_type: 'youtube_confreaks',
+          }}
+          categorySlug="videos"
+          index={0}
+          isDismissing={false}
+          onDismiss={() => {}}
+          onBookmarkToggle={() => {}}
+          onReadToggle={() => {}}
+        />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByTestId('video-thumbnail')).toBeInTheDocument()
+    expect(screen.queryByTestId('video-duration')).not.toBeInTheDocument()
+    expect(screen.getByTestId('video-channel')).toHaveTextContent('Confreaks')
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+  })
+
+  it('leaves text articles visually without video chrome', () => {
+    render(
+      <MemoryRouter>
+        <ArticleCard
+          variant="feed"
+          article={{ ...feedArticle, content_type: 'article' }}
+          categorySlug="programming"
+          index={0}
+          isDismissing={false}
+          onDismiss={() => {}}
+          onBookmarkToggle={() => {}}
+          onReadToggle={() => {}}
+        />
+      </MemoryRouter>
+    )
+
+    expect(screen.queryByTestId('video-thumbnail')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('video-channel')).not.toBeInTheDocument()
+    expect(screen.getByRole('article')).toHaveAttribute('data-content-type', 'article')
+  })
+
   it('renders bookmark variant with bookmarked metadata', () => {
     render(
       <MemoryRouter>

--- a/app/frontend/components/ContentTypeFilter.test.tsx
+++ b/app/frontend/components/ContentTypeFilter.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import ContentTypeFilter, {
+  contentTypeFilterParams,
+  maxDurationFilterParams,
+  parseContentTypeFilter,
+  parseMaxDurationFilter,
+} from './ContentTypeFilter'
+
+describe('ContentTypeFilter', () => {
+  it('marks the active type and duration pills with aria-pressed', () => {
+    render(
+      <ContentTypeFilter
+        activeContentType="video"
+        activeMaxDuration="20"
+        onContentTypeChange={vi.fn()}
+        onMaxDurationChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Videos' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: 'All' })).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.getByRole('button', { name: '≤ 20 min' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: 'Any length' })).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('notifies when type or duration pills are clicked', async () => {
+    const user = userEvent.setup()
+    const onContentTypeChange = vi.fn()
+    const onMaxDurationChange = vi.fn()
+
+    render(
+      <ContentTypeFilter
+        activeContentType="all"
+        activeMaxDuration="all"
+        onContentTypeChange={onContentTypeChange}
+        onMaxDurationChange={onMaxDurationChange}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Articles' }))
+    await user.click(screen.getByRole('button', { name: '≤ 10 min' }))
+
+    expect(onContentTypeChange).toHaveBeenCalledWith('article')
+    expect(onMaxDurationChange).toHaveBeenCalledWith('10')
+  })
+})
+
+describe('content type filter helpers', () => {
+  it('maps filter values to request params', () => {
+    expect(contentTypeFilterParams('all')).toEqual({})
+    expect(contentTypeFilterParams('video')).toEqual({ content_type: 'video' })
+    expect(maxDurationFilterParams('all')).toEqual({})
+    expect(maxDurationFilterParams('20')).toEqual({ max_duration: 20 })
+  })
+
+  it('parses URL values with safe defaults', () => {
+    expect(parseContentTypeFilter('video')).toBe('video')
+    expect(parseContentTypeFilter('nope')).toBe('all')
+    expect(parseMaxDurationFilter('10')).toBe('10')
+    expect(parseMaxDurationFilter('99')).toBe('all')
+  })
+})

--- a/app/frontend/components/ContentTypeFilter.tsx
+++ b/app/frontend/components/ContentTypeFilter.tsx
@@ -1,0 +1,98 @@
+import Button from './ui/Button'
+import Card from './ui/Card'
+
+export type ContentTypeFilterValue = 'all' | 'article' | 'video'
+export type MaxDurationFilterValue = 'all' | '5' | '10' | '20'
+
+interface ContentTypeFilterProps {
+  activeContentType: ContentTypeFilterValue
+  activeMaxDuration: MaxDurationFilterValue
+  onContentTypeChange: (value: ContentTypeFilterValue) => void
+  onMaxDurationChange: (value: MaxDurationFilterValue) => void
+}
+
+const TYPE_OPTIONS: { value: ContentTypeFilterValue; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'article', label: 'Articles' },
+  { value: 'video', label: 'Videos' },
+]
+
+const DURATION_OPTIONS: { value: MaxDurationFilterValue; label: string }[] = [
+  { value: 'all', label: 'Any length' },
+  { value: '5', label: '≤ 5 min' },
+  { value: '10', label: '≤ 10 min' },
+  { value: '20', label: '≤ 20 min' },
+]
+
+export default function ContentTypeFilter({
+  activeContentType,
+  activeMaxDuration,
+  onContentTypeChange,
+  onMaxDurationChange,
+}: ContentTypeFilterProps) {
+  return (
+    <Card tone="subtle" className="mb-8">
+      <h2 className="text-h3 text-gray-100 mb-4">Filter by content</h2>
+      <div className="flex flex-wrap gap-3 mb-4">
+        {TYPE_OPTIONS.map((option) => (
+          <Button
+            key={option.value}
+            variant="filter"
+            active={activeContentType === option.value}
+            data-content-type-filter={option.value}
+            aria-pressed={activeContentType === option.value}
+            onClick={() => onContentTypeChange(option.value)}
+          >
+            {option.label}
+          </Button>
+        ))}
+      </div>
+      <h3 className="text-sm font-medium text-gray-300 mb-3">Max video length</h3>
+      <div className="flex flex-wrap gap-3">
+        {DURATION_OPTIONS.map((option) => (
+          <Button
+            key={option.value}
+            variant="filter"
+            active={activeMaxDuration === option.value}
+            data-max-duration-filter={option.value}
+            aria-pressed={activeMaxDuration === option.value}
+            onClick={() => onMaxDurationChange(option.value)}
+          >
+            {option.label}
+          </Button>
+        ))}
+      </div>
+    </Card>
+  )
+}
+
+export function contentTypeFilterParams(value: ContentTypeFilterValue): {
+  content_type?: 'article' | 'video'
+} {
+  if (value === 'all') return {}
+  return { content_type: value }
+}
+
+export function maxDurationFilterParams(value: MaxDurationFilterValue): {
+  max_duration?: number
+} {
+  if (value === 'all') return {}
+  return { max_duration: Number(value) }
+}
+
+const CONTENT_TYPE_VALUES: ContentTypeFilterValue[] = ['all', 'article', 'video']
+const MAX_DURATION_VALUES: MaxDurationFilterValue[] = ['all', '5', '10', '20']
+
+export function parseContentTypeFilter(value: string | null): ContentTypeFilterValue {
+  if (value && CONTENT_TYPE_VALUES.includes(value as ContentTypeFilterValue)) {
+    return value as ContentTypeFilterValue
+  }
+  return 'all'
+}
+
+export function parseMaxDurationFilter(value: string | null): MaxDurationFilterValue {
+  if (value && MAX_DURATION_VALUES.includes(value as MaxDurationFilterValue)) {
+    return value as MaxDurationFilterValue
+  }
+  return 'all'
+}

--- a/app/frontend/components/a11y.test.tsx
+++ b/app/frontend/components/a11y.test.tsx
@@ -7,6 +7,7 @@ import ArticleCard from './ArticleCard'
 import CategoryFilter from './CategoryFilter'
 import ConfirmDialog from './ConfirmDialog'
 import InterestFilter from './InterestFilter'
+import ContentTypeFilter from './ContentTypeFilter'
 import PageHeading from './ui/PageHeading'
 import { buildKeywordFilter } from '../test/fixtures'
 
@@ -72,6 +73,24 @@ describe('accessibility audits', () => {
     expect(results).toHaveNoViolations()
   })
 
+  it('ContentTypeFilter has no critical accessibility violations', async () => {
+    const { container } = render(
+      <ContentTypeFilter
+        activeContentType="video"
+        activeMaxDuration="20"
+        onContentTypeChange={vi.fn()}
+        onMaxDurationChange={vi.fn()}
+      />
+    )
+
+    const results = await axe(container, {
+      rules: {
+        'color-contrast': { enabled: true },
+      },
+    })
+    expect(results).toHaveNoViolations()
+  })
+
   it('feed ArticleCard has no critical accessibility violations', async () => {
     const { container } = render(
       <MemoryRouter>
@@ -79,6 +98,33 @@ describe('accessibility audits', () => {
           variant="feed"
           article={baseArticle}
           categorySlug="programming-languages"
+          index={0}
+          isDismissing={false}
+          onDismiss={() => {}}
+          onBookmarkToggle={() => {}}
+          onReadToggle={() => {}}
+        />
+      </MemoryRouter>
+    )
+
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+
+  it('feed video ArticleCard has no critical accessibility violations', async () => {
+    const { container } = render(
+      <MemoryRouter>
+        <ArticleCard
+          variant="feed"
+          article={{
+            ...baseArticle,
+            content_type: 'video',
+            author: 'Thoughtbot',
+            thumbnail_url: 'https://i.ytimg.com/vi/abc123/hqdefault.jpg',
+            duration_seconds: 372,
+            source_type: 'youtube_thoughtbot',
+          }}
+          categorySlug="videos"
           index={0}
           isDismissing={false}
           onDismiss={() => {}}

--- a/app/frontend/components/articleCard/ArticleCardLayout.tsx
+++ b/app/frontend/components/articleCard/ArticleCardLayout.tsx
@@ -4,6 +4,7 @@ import { cn } from '../../utils/cn'
 import { DetailsLink } from './CardActions'
 import CardMetadata from './CardMetadata'
 import CardTitle from './CardTitle'
+import VideoThumbnail from './VideoThumbnail'
 import Badge from '../ui/Badge'
 import { CARD_THEMES, type ArticleCardData, type ArticleCardAccent, type ArticleCardTheme } from './cardThemes'
 
@@ -74,6 +75,7 @@ export default function ArticleCardLayout({
   const styles = CARD_THEMES[theme]
   const relatedSources = article.related_sources ?? []
   const matchedKeywords = article.matched_keywords ?? []
+  const isVideo = article.content_type === 'video'
 
   return (
     <article
@@ -87,6 +89,7 @@ export default function ArticleCardLayout({
       )}
       data-source={article.source_type}
       data-category={categorySlug}
+      data-content-type={article.content_type ?? 'article'}
       data-featured={featured || undefined}
       style={{
         animationDelay: `${index * 50}ms`,
@@ -101,6 +104,21 @@ export default function ArticleCardLayout({
         showSourceBadge={showSourceBadge}
         headerActions={headerActions}
       />
+
+      {isVideo && (
+        <VideoThumbnail
+          title={article.title}
+          url={article.url}
+          thumbnailUrl={article.thumbnail_url}
+          durationSeconds={article.duration_seconds}
+        />
+      )}
+
+      {isVideo && article.author && (
+        <p className="mb-4 text-sm text-gray-300" data-testid="video-channel">
+          {article.author}
+        </p>
+      )}
 
       {article.description && (
         <p className="text-body text-gray-200 mb-6 line-clamp-3 leading-relaxed max-w-prose">

--- a/app/frontend/components/articleCard/VideoThumbnail.tsx
+++ b/app/frontend/components/articleCard/VideoThumbnail.tsx
@@ -1,0 +1,75 @@
+import type { MouseEvent } from 'react'
+import { formatDuration } from '../../utils/format'
+
+interface VideoThumbnailProps {
+  title: string
+  url: string
+  thumbnailUrl?: string | null
+  durationSeconds?: number | null
+}
+
+function stopPropagation(event: MouseEvent) {
+  event.stopPropagation()
+}
+
+export default function VideoThumbnail({
+  title,
+  url,
+  thumbnailUrl,
+  durationSeconds,
+}: VideoThumbnailProps) {
+  const duration = formatDuration(durationSeconds)
+
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="relative mb-5 block overflow-hidden rounded-xl bg-dark-700 aspect-video group/thumb focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500"
+      onClick={stopPropagation}
+      data-testid="video-thumbnail"
+      aria-label={`Watch ${title}`}
+    >
+      {thumbnailUrl ? (
+        <img
+          src={thumbnailUrl}
+          alt=""
+          loading="lazy"
+          decoding="async"
+          className="h-full w-full object-cover transition-transform duration-200 group-hover/thumb:scale-[1.02]"
+        />
+      ) : (
+        <div
+          className="flex h-full w-full items-center justify-center bg-gradient-to-br from-dark-600 to-dark-800"
+          aria-hidden="true"
+        >
+          <PlayIcon className="h-12 w-12 text-gray-400 opacity-70" />
+        </div>
+      )}
+
+      <span
+        className="absolute inset-0 flex items-center justify-center bg-black/20 opacity-0 transition-opacity duration-200 group-hover/thumb:opacity-100"
+        aria-hidden="true"
+      >
+        <PlayIcon className="h-14 w-14 text-white drop-shadow-md" />
+      </span>
+
+      {duration && (
+        <span
+          className="absolute bottom-2 right-2 rounded bg-black/80 px-1.5 py-0.5 font-mono text-xs tabular-nums text-white"
+          data-testid="video-duration"
+        >
+          {duration}
+        </span>
+      )}
+    </a>
+  )
+}
+
+function PlayIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M8 5.14v13.72a1 1 0 001.5.86l11-6.86a1 1 0 000-1.72l-11-6.86a1 1 0 00-1.5.86z" />
+    </svg>
+  )
+}

--- a/app/frontend/components/articleCard/cardThemes.ts
+++ b/app/frontend/components/articleCard/cardThemes.ts
@@ -10,6 +10,10 @@ export interface ArticleCardData {
   comment_count: number
   published_at: string
   low_signal?: boolean
+  content_type?: 'article' | 'video'
+  duration_seconds?: number | null
+  thumbnail_url?: string | null
+  author?: string | null
   related_sources?: Array<{
     id: number
     source_type: string

--- a/app/frontend/pages/ArticlesIndexPage.test.tsx
+++ b/app/frontend/pages/ArticlesIndexPage.test.tsx
@@ -294,6 +294,31 @@ describe('ArticlesIndexPage dismiss flow', () => {
     expect(screen.getByText('Rust 2024 Edition Highlights')).toBeInTheDocument()
   })
 
+  it('applies content_type and max_duration from the URL', async () => {
+    renderPage(['/articles?content_type=video&max_duration=20'])
+
+    await waitForArticlesFeed()
+    expect(screen.getByRole('button', { name: 'Videos' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: '≤ 20 min' })).toHaveAttribute('aria-pressed', 'true')
+    expect(articlesApi.fetchArticles).toHaveBeenCalledWith(
+      expect.objectContaining({ content_type: 'video', max_duration: 20 })
+    )
+  })
+
+  it('updates content type params and resets pagination', async () => {
+    const user = userEvent.setup()
+    renderPage(['/articles?page=3'])
+
+    await waitForArticlesFeed()
+    await user.click(screen.getByRole('button', { name: 'Videos' }))
+
+    await waitFor(() => {
+      expect(articlesApi.fetchArticles).toHaveBeenCalledWith(
+        expect.objectContaining({ content_type: 'video', page: 1 })
+      )
+    })
+  })
+
   it('counts down dismiss toast and removes article after timeout', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true })
     const user = userEvent.setup()

--- a/app/frontend/pages/ArticlesIndexPage.tsx
+++ b/app/frontend/pages/ArticlesIndexPage.tsx
@@ -30,6 +30,14 @@ import Card from '../components/ui/Card'
 import PaginationControls from '../components/PaginationControls'
 import TopicFilter from '../components/TopicFilter'
 import ScoreFilter, { parseScoreFilter, scoreFilterParams, type ScoreFilterValue } from '../components/ScoreFilter'
+import ContentTypeFilter, {
+  contentTypeFilterParams,
+  maxDurationFilterParams,
+  parseContentTypeFilter,
+  parseMaxDurationFilter,
+  type ContentTypeFilterValue,
+  type MaxDurationFilterValue,
+} from '../components/ContentTypeFilter'
 import SortControl, { parseSort, type SortValue } from '../components/SortControl'
 import { usePatchSearchParams } from '../hooks/useSearchParamState'
 
@@ -59,6 +67,8 @@ export default function ArticlesIndexPage() {
   const activeFilter = searchParams.get('category') ?? 'all'
   const activeTag = searchParams.get('tag') ?? 'all'
   const activeScoreFilter = parseScoreFilter(searchParams.get('score'))
+  const activeContentType = parseContentTypeFilter(searchParams.get('content_type'))
+  const activeMaxDuration = parseMaxDurationFilter(searchParams.get('max_duration'))
   const activeSort = parseSort(searchParams.get('sort'))
   const showRead = searchParams.get('show_read') === 'true'
   const searchQuery = (searchParams.get('q') ?? '').trim()
@@ -123,6 +133,8 @@ export default function ArticlesIndexPage() {
         q: searchQuery || undefined,
         sort: activeSort,
         ...scoreFilterParams(activeScoreFilter),
+        ...contentTypeFilterParams(activeContentType),
+        ...maxDurationFilterParams(activeMaxDuration),
         signal,
       })
       if (signal.aborted) return
@@ -140,7 +152,19 @@ export default function ArticlesIndexPage() {
     } finally {
       if (!signal.aborted) setLoading(false)
     }
-  }, [showRead, activeScoreFilter, activeFilter, activeTag, activeInterests, activeSort, searchQuery, currentPage, patchSearchParams])
+  }, [
+    showRead,
+    activeScoreFilter,
+    activeContentType,
+    activeMaxDuration,
+    activeFilter,
+    activeTag,
+    activeInterests,
+    activeSort,
+    searchQuery,
+    currentPage,
+    patchSearchParams,
+  ])
 
   useEffect(() => {
     void loadArticles()
@@ -275,6 +299,22 @@ export default function ArticlesIndexPage() {
     patchSearchParams((params) => {
       if (value === 'all') params.delete('score')
       else params.set('score', value)
+      params.delete('page')
+    })
+  }
+
+  const handleContentTypeChange = (value: ContentTypeFilterValue) => {
+    patchSearchParams((params) => {
+      if (value === 'all') params.delete('content_type')
+      else params.set('content_type', value)
+      params.delete('page')
+    })
+  }
+
+  const handleMaxDurationChange = (value: MaxDurationFilterValue) => {
+    patchSearchParams((params) => {
+      if (value === 'all') params.delete('max_duration')
+      else params.set('max_duration', value)
       params.delete('page')
     })
   }
@@ -510,6 +550,13 @@ export default function ArticlesIndexPage() {
       <ScoreFilter
         activeScoreFilter={activeScoreFilter}
         onScoreFilterChange={handleScoreFilterChange}
+      />
+
+      <ContentTypeFilter
+        activeContentType={activeContentType}
+        activeMaxDuration={activeMaxDuration}
+        onContentTypeChange={handleContentTypeChange}
+        onMaxDurationChange={handleMaxDurationChange}
       />
 
       <SortControl

--- a/app/frontend/utils/format.ts
+++ b/app/frontend/utils/format.ts
@@ -73,3 +73,20 @@ export function truncate(text: string, length: number): string {
   if (text.length <= length) return text
   return `${text.slice(0, length)}...`
 }
+
+/** Formats seconds as `m:ss` or `h:mm:ss`. Returns null when duration is unknown. */
+export function formatDuration(seconds: number | null | undefined): string | null {
+  if (seconds == null || !Number.isFinite(seconds) || seconds < 0) return null
+
+  const total = Math.floor(seconds)
+  const hours = Math.floor(total / 3600)
+  const minutes = Math.floor((total % 3600) / 60)
+  const secs = total % 60
+  const paddedSecs = String(secs).padStart(2, '0')
+
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, '0')}:${paddedSecs}`
+  }
+
+  return `${minutes}:${paddedSecs}`
+}

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -129,7 +129,9 @@ dev-news-aggregator/
 | `app/frontend/api/keywordFilters.ts` | Keyword filter CRUD client |
 | `app/frontend/types/keywordFilter.ts` | Keyword filter TypeScript types |
 | `app/frontend/components/InterestFilter.tsx` | Interest chip filters on the articles index |
+| `app/frontend/components/ContentTypeFilter.tsx` | Content type and max video duration filters on the articles index |
 | `app/frontend/components/TermChipInput.tsx` | Chip input for interest keyword terms |
+| `app/frontend/components/articleCard/VideoThumbnail.tsx` | Thumbnail, duration badge, and play affordance for video cards |
 
 ## `config/`
 


### PR DESCRIPTION
## Summary
- Video cards show lazy thumbnail (with fallback), duration badge, channel name, and play affordance when `content_type === video`
- New `ContentTypeFilter` pills (All / Articles / Videos + max length) wired to `content_type` / `max_duration` URL params
- Vitest + axe coverage for card rendering, unknown duration, and filter → request params

Closes #386

## Test plan
- [ ] Video items render thumbnail, duration, and channel; text articles unchanged
- [ ] Missing thumbnail / unknown duration degrade cleanly
- [ ] Content type and max duration pills update the URL and reset pagination
- [ ] `npm test` and axe scans pass for new components
- [ ] CI green
