### PR TITLE
feat(youtube): keyword-driven video discovery with quota budget (#384)

### DIFF
--- a/app/jobs/fetch_news_job.rb
+++ b/app/jobs/fetch_news_job.rb
@@ -3,6 +3,7 @@ class FetchNewsJob < ApplicationJob
 
   def perform
     result = NewsAggregatorService.fetch_all_news
+    YoutubeKeywordDiscovery.run!
     YoutubeVideoEnricher.enrich!
     result
   end

--- a/app/models/news_aggregator_config.rb
+++ b/app/models/news_aggregator_config.rb
@@ -105,5 +105,47 @@ module NewsAggregatorConfig
     def youtube_max_duration_seconds
       config.dig(:apis, :youtube, :max_duration_seconds) || 1200
     end
+
+    def youtube_search
+      config.dig(:apis, :youtube, :search) || {}
+    end
+
+    def youtube_search_enabled?
+      ActiveModel::Type::Boolean.new.cast(youtube_search[:enabled])
+    end
+
+    def youtube_search_daily_call_budget
+      [ youtube_search.fetch(:daily_call_budget, 20).to_i, 0 ].max
+    end
+
+    def youtube_search_min_interval_hours
+      [ youtube_search.fetch(:min_interval_hours, 12).to_i, 0 ].max
+    end
+
+    def youtube_search_max_results
+      [ youtube_search.fetch(:max_results, 10).to_i, 1 ].max.clamp(1, 50)
+    end
+
+    def youtube_search_video_duration
+      value = youtube_search[:video_duration].to_s
+      %w[short medium long any].include?(value) ? value : "medium"
+    end
+
+    def youtube_search_order
+      value = youtube_search[:order].to_s
+      %w[date relevance viewCount rating].include?(value) ? value : "date"
+    end
+
+    def youtube_search_relevance_language
+      youtube_search[:relevance_language].presence || "en"
+    end
+
+    def youtube_search_region_code
+      youtube_search[:region_code].presence || "US"
+    end
+
+    def youtube_search_published_after_days
+      [ youtube_search.fetch(:published_after_days, 7).to_i, 1 ].max
+    end
   end
 end

--- a/app/services/youtube_keyword_discovery.rb
+++ b/app/services/youtube_keyword_discovery.rb
@@ -1,0 +1,226 @@
+# Opt-in YouTube search.list discovery driven by enabled KeywordFilter terms.
+# Enforces a hard daily call budget and a per-filter minimum interval so the
+# expensive search quota bucket (~100 units/call) is not exhausted by hourly fetches.
+class YoutubeKeywordDiscovery
+  include HTTParty
+
+  API_URL = "https://www.googleapis.com/youtube/v3/search"
+  SOURCE_KEY_PREFIX = "youtube_search_".freeze
+  CACHE_KEY_PREFIX = "youtube_search_api_calls:".freeze
+
+  class << self
+    def run!
+      new.run!
+    end
+
+    def api_key
+      ENV["YOUTUBE_API_KEY"].presence
+    end
+
+    def enabled?
+      NewsAggregatorConfig.youtube_search_enabled? && api_key.present?
+    end
+
+    def source_key_for(filter)
+      "#{SOURCE_KEY_PREFIX}#{filter.slug}"
+    end
+
+    def daily_calls_cache_key(date = Time.current.utc.to_date)
+      "#{CACHE_KEY_PREFIX}#{date.iso8601}"
+    end
+
+    # Overridable so tests can use a MemoryStore (Rails test env uses null_store).
+    attr_writer :call_store
+
+    def call_store
+      @call_store || Rails.cache
+    end
+
+    def reset_call_store!
+      @call_store = nil
+    end
+  end
+
+  def run!
+    unless self.class.enabled?
+      Rails.logger.info "YouTube keyword discovery skipped (disabled or no API key)"
+      return { created: 0, searched: 0, skipped: true }
+    end
+
+    created = 0
+    searched = 0
+    skipped_budget = false
+
+    KeywordFilter.enabled.ordered.each do |filter|
+      if remaining_budget <= 0
+        skipped_budget = true
+        Rails.logger.info "YouTube keyword discovery stopping: daily search budget exhausted"
+        break
+      end
+
+      next if too_soon?(filter)
+
+      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      begin
+        count = discover_for(filter)
+        created += count
+        searched += 1
+        FetchRun.record_outcome(
+          source_key: self.class.source_key_for(filter),
+          status: "success",
+          articles_count: count,
+          duration_seconds: elapsed(started)
+        )
+      rescue StandardError => e
+        Rails.error.report(e, handled: true, context: {
+          service: "YoutubeKeywordDiscovery",
+          filter: filter.slug
+        })
+        Rails.logger.error "YouTube search for #{filter.slug} failed: #{e.class}: #{e.message}"
+        FetchRun.record_outcome(
+          source_key: self.class.source_key_for(filter),
+          status: "failure",
+          articles_count: 0,
+          duration_seconds: elapsed(started),
+          error: e
+        )
+        break if quota_exhausted_error?(e)
+      end
+    end
+
+    { created: created, searched: searched, skipped: false, budget_exhausted: skipped_budget }
+  end
+
+  private
+
+  def discover_for(filter)
+    terms = Array(filter.terms).map(&:to_s).map(&:strip).reject(&:blank?)
+    return 0 if terms.empty?
+
+    payload = search_videos(query: terms.join("|"), filter: filter)
+    consume_call!
+    items = payload.is_a?(Hash) ? Array(payload["items"]) : []
+
+    items.count { |item| create_article_from_search_item(item, filter) }
+  end
+
+  def create_article_from_search_item(item, filter)
+    video_id = item.dig("id", "videoId").presence
+    return false if video_id.blank?
+
+    # Prefer the channel-feed row when the same video was already ingested.
+    if Article.exists?(external_id: video_id)
+      Rails.logger.debug { "Skipping YouTube search hit #{video_id} (already ingested)" }
+      return false
+    end
+
+    snippet = item["snippet"] || {}
+    thumbnails = snippet["thumbnails"] || {}
+    thumbnail = thumbnails.dig("high", "url") ||
+                thumbnails.dig("medium", "url") ||
+                thumbnails.dig("default", "url")
+
+    published_at = begin
+      Time.iso8601(snippet["publishedAt"])
+    rescue ArgumentError, TypeError
+      Time.current
+    end
+
+    article = Article.new(
+      title: snippet["title"].presence || "YouTube video #{video_id}",
+      url: "https://www.youtube.com/watch?v=#{video_id}",
+      description: snippet["description"].presence,
+      external_id: video_id,
+      source_type: self.class.source_key_for(filter),
+      published_at: published_at,
+      content_type: "video",
+      thumbnail_url: thumbnail,
+      author: snippet["channelTitle"].presence,
+      score: 0,
+      comment_count: 0
+    )
+
+    unless article.save
+      Rails.logger.warn(
+        "Skipping invalid YouTube search video #{video_id}: #{article.errors.full_messages.join(', ')}"
+      )
+      return false
+    end
+
+    Rails.logger.info "Created YouTube search video: #{article.title}"
+    true
+  rescue StandardError => e
+    Rails.logger.error "Error creating YouTube search video: #{e.message}"
+    false
+  end
+
+  def search_videos(query:, filter:)
+    params = {
+      part: "snippet",
+      type: "video",
+      q: query,
+      maxResults: NewsAggregatorConfig.youtube_search_max_results,
+      order: NewsAggregatorConfig.youtube_search_order,
+      relevanceLanguage: NewsAggregatorConfig.youtube_search_relevance_language,
+      regionCode: NewsAggregatorConfig.youtube_search_region_code,
+      publishedAfter: published_after_for(filter).utc.iso8601,
+      key: self.class.api_key
+    }
+
+    duration = NewsAggregatorConfig.youtube_search_video_duration
+    params[:videoDuration] = duration unless duration == "any"
+
+    response = HTTParty.get(
+      API_URL,
+      query: params,
+      timeout: NewsAggregatorConfig.request_timeout
+    )
+
+    unless response.success?
+      body_preview = response.body.to_s.gsub(/\s+/, " ").strip[0, 200]
+      raise NewsFetchers::BaseFetcher::FetchError,
+            "HTTP #{response.code} for search.list: #{body_preview.presence || '(empty body)'}"
+    end
+
+    response.parsed_response
+  end
+
+  def published_after_for(filter)
+    run = FetchRun.find_by(source_key: self.class.source_key_for(filter))
+    return run.last_success_at if run&.last_success_at.present?
+
+    NewsAggregatorConfig.youtube_search_published_after_days.days.ago
+  end
+
+  def too_soon?(filter)
+    hours = NewsAggregatorConfig.youtube_search_min_interval_hours
+    return false if hours <= 0
+
+    run = FetchRun.find_by(source_key: self.class.source_key_for(filter))
+    return false if run.blank? || run.finished_at.blank?
+
+    run.finished_at > hours.hours.ago
+  end
+
+  def remaining_budget
+    NewsAggregatorConfig.youtube_search_daily_call_budget - calls_today
+  end
+
+  def calls_today
+    self.class.call_store.read(self.class.daily_calls_cache_key).to_i
+  end
+
+  def consume_call!
+    key = self.class.daily_calls_cache_key
+    self.class.call_store.write(key, calls_today + 1, expires_in: 36.hours)
+  end
+
+  def quota_exhausted_error?(error)
+    message = error.message.to_s.downcase
+    message.include?("quota") || message.include?("403")
+  end
+
+  def elapsed(started)
+    Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+  end
+end

--- a/config/news_aggregator.yml
+++ b/config/news_aggregator.yml
@@ -80,6 +80,17 @@ development: &default
       enrich_max_per_run: 100
       # After enrichment, drop videos longer than this (seconds). 0 disables.
       max_duration_seconds: 1200
+      # Keyword search discovery (search.list). Disabled by default — burns ~100 units/call.
+      search:
+        enabled: false
+        daily_call_budget: 20
+        min_interval_hours: 12
+        max_results: 10
+        video_duration: medium # short | medium | long | any
+        order: date # date | relevance | viewCount | rating
+        relevance_language: en
+        region_code: US
+        published_after_days: 7 # used when a filter has never been searched
       channels:
         - channel_id: "UCWnPjmqvljcafA0QXblOU1A"
           name: "Confreaks"

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -102,6 +102,7 @@ dev-news-aggregator/
 | `news_fetchers/dev_to_fetcher.rb` | Dev.to REST API |
 | `news_fetchers/reddit_fetcher.rb` | Reddit API (one instance per subreddit) |
 | `news_fetchers/youtube_fetcher.rb` | YouTube channel Atom feeds (no API key) |
+| `youtube_keyword_discovery.rb` | Opt-in keyword search.list discovery with daily quota budget |
 | `personal_feed_ranker.rb` | For you sort — source affinity from bookmarks/dismissals |
 | `article_topic_classifier.rb` | Schema-validated topic tagging (keyword heuristics) |
 | `feed_noise_classifier.rb` | Heuristics to flag low-signal / meme feed items |

--- a/test/jobs/fetch_news_job_test.rb
+++ b/test/jobs/fetch_news_job_test.rb
@@ -10,14 +10,17 @@ class FetchNewsJobTest < ActiveJob::TestCase
     }
 
     original = NewsAggregatorService.method(:fetch_all_news)
+    discovery_original = YoutubeKeywordDiscovery.method(:run!)
     enrich_original = YoutubeVideoEnricher.method(:enrich!)
     NewsAggregatorService.define_singleton_method(:fetch_all_news) { expected }
+    YoutubeKeywordDiscovery.define_singleton_method(:run!) { { created: 0, searched: 0, skipped: true } }
     YoutubeVideoEnricher.define_singleton_method(:enrich!) { { enriched: 0, skipped: true } }
     begin
       result = FetchNewsJob.perform_now
       assert_equal expected, result
     ensure
       NewsAggregatorService.define_singleton_method(:fetch_all_news, original)
+      YoutubeKeywordDiscovery.define_singleton_method(:run!, discovery_original)
       YoutubeVideoEnricher.define_singleton_method(:enrich!, enrich_original)
     end
   end

--- a/test/services/youtube_keyword_discovery_test.rb
+++ b/test/services/youtube_keyword_discovery_test.rb
@@ -1,0 +1,223 @@
+require "test_helper"
+
+class YoutubeKeywordDiscoveryTest < ActiveSupport::TestCase
+  setup do
+    @previous_key = ENV["YOUTUBE_API_KEY"]
+    ENV["YOUTUBE_API_KEY"] = "test-key"
+    NewsAggregatorConfig.reset!
+    YoutubeKeywordDiscovery.call_store = ActiveSupport::Cache::MemoryStore.new
+
+    @ruby = keyword_filters(:ruby_interest)
+    @rust = keyword_filters(:rust_interest)
+  end
+
+  teardown do
+    if @previous_key
+      ENV["YOUTUBE_API_KEY"] = @previous_key
+    else
+      ENV.delete("YOUTUBE_API_KEY")
+    end
+    NewsAggregatorConfig.reset!
+    YoutubeKeywordDiscovery.reset_call_store!
+  end
+
+  test "run! is a no-op when search is disabled" do
+    result = YoutubeKeywordDiscovery.run!
+
+    assert result[:skipped]
+    assert_equal 0, result[:created]
+    assert_equal 0, result[:searched]
+  end
+
+  test "run! is a no-op without an API key even when enabled" do
+    ENV.delete("YOUTUBE_API_KEY")
+
+    with_search_enabled do
+      result = YoutubeKeywordDiscovery.run!
+
+      assert result[:skipped]
+      assert_equal 0, result[:created]
+    end
+  end
+
+  test "run! searches enabled filters and creates video articles" do
+    stub_search_list(
+      query: "ruby|rubygems",
+      items: [ search_item(video_id: "rubyVid001", title: "Rails tip", channel: "Confreaks") ]
+    )
+    stub_search_list(
+      query: "rust|cargo",
+      items: [ search_item(video_id: "rustVid001", title: "Ownership", channel: "Jon Gjengset") ]
+    )
+
+    result = nil
+    with_search_enabled do
+      result = YoutubeKeywordDiscovery.run!
+    end
+
+    assert_equal 2, result[:created]
+    assert_equal 2, result[:searched]
+    refute result[:skipped]
+
+    ruby_video = Article.find_by!(external_id: "rubyVid001")
+    assert_equal "video", ruby_video.content_type
+    assert_equal "youtube_search_ruby", ruby_video.source_type
+    assert_equal "Confreaks", ruby_video.author
+    assert_equal "https://i.ytimg.com/vi/rubyVid001/hqdefault.jpg", ruby_video.thumbnail_url
+
+    assert FetchRun.exists?(source_key: "youtube_search_ruby", status: "success")
+    assert FetchRun.exists?(source_key: "youtube_search_rust", status: "success")
+  end
+
+  test "run! does not search inactive keyword filters" do
+    stub_search_list(query: "ruby|rubygems", items: [])
+    stub_search_list(query: "rust|cargo", items: [])
+
+    with_search_enabled do
+      YoutubeKeywordDiscovery.run!
+    end
+
+    assert_not FetchRun.exists?(source_key: "youtube_search_elixir")
+    assert_requested :get, %r{youtube/v3/search}, times: 2
+  end
+
+  test "run! skips videos already ingested from channel feeds" do
+    Article.create!(
+      title: "Already from channel",
+      url: "https://www.youtube.com/watch?v=dupVid001",
+      external_id: "dupVid001",
+      source_type: "youtube_UCWnPjmqvljcafA0QXblOU1A",
+      published_at: Time.current,
+      content_type: "video",
+      score: 5,
+      comment_count: 0
+    )
+
+    stub_search_list(
+      query: "ruby|rubygems",
+      items: [ search_item(video_id: "dupVid001", title: "Duplicate hit") ]
+    )
+    stub_search_list(query: "rust|cargo", items: [])
+
+    result = nil
+    with_search_enabled do
+      result = YoutubeKeywordDiscovery.run!
+    end
+
+    assert_equal 0, result[:created]
+    assert_equal 1, Article.where(external_id: "dupVid001").count
+    refute Article.exists?(source_type: "youtube_search_ruby", external_id: "dupVid001")
+  end
+
+  test "run! enforces the daily search call budget" do
+    stub_search_list(
+      query: "ruby|rubygems",
+      items: [ search_item(video_id: "budgetVid1", title: "First") ]
+    )
+
+    result = nil
+    with_config_overrides(
+      youtube_search_enabled?: true,
+      youtube_search_daily_call_budget: 1,
+      youtube_search_min_interval_hours: 0
+    ) do
+      result = YoutubeKeywordDiscovery.run!
+    end
+
+    assert_equal 1, result[:searched]
+    assert result[:budget_exhausted]
+    assert_equal 1, Article.where(external_id: "budgetVid1").count
+    assert_not FetchRun.exists?(source_key: "youtube_search_rust")
+  end
+
+  test "run! respects per-filter minimum interval" do
+    FetchRun.record_outcome(
+      source_key: "youtube_search_ruby",
+      status: "success",
+      articles_count: 0
+    )
+    ruby_finished_at = FetchRun.find_by!(source_key: "youtube_search_ruby").finished_at
+
+    stub_search_list(query: "rust|cargo", items: [])
+
+    with_config_overrides(youtube_search_enabled?: true) do
+      YoutubeKeywordDiscovery.run!
+    end
+
+    assert_requested :get, %r{youtube/v3/search}, times: 1
+    assert_equal ruby_finished_at.to_i, FetchRun.find_by!(source_key: "youtube_search_ruby").finished_at.to_i
+    assert FetchRun.exists?(source_key: "youtube_search_rust", status: "success")
+  end
+
+  test "run! records failure and stops on quota errors without raising" do
+    stub_request(:get, %r{https://www\.googleapis\.com/youtube/v3/search})
+      .to_return(
+        status: 403,
+        body: { error: { message: "quotaExceeded" } }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+
+    result = nil
+    with_search_enabled do
+      assert_nothing_raised do
+        result = YoutubeKeywordDiscovery.run!
+      end
+    end
+
+    assert_equal 0, result[:created]
+    failure = FetchRun.find_by(source_key: "youtube_search_ruby")
+    assert failure
+    assert_equal "failure", failure.status
+    assert_match(/403/, failure.error_message)
+  end
+
+  private
+
+  def with_search_enabled
+    with_config_overrides(
+      youtube_search_enabled?: true,
+      youtube_search_min_interval_hours: 0
+    ) { yield }
+  end
+
+  def with_config_overrides(overrides)
+    originals = {}
+    overrides.each do |name, return_value|
+      originals[name] = NewsAggregatorConfig.method(name)
+      captured = return_value
+      NewsAggregatorConfig.define_singleton_method(name) { captured }
+    end
+    yield
+  ensure
+    originals.each do |name, original|
+      NewsAggregatorConfig.define_singleton_method(name) { |*args, **kwargs, &block|
+        original.call(*args, **kwargs, &block)
+      }
+    end
+  end
+
+  def search_item(video_id:, title:, channel: "Example Channel")
+    {
+      "id" => { "videoId" => video_id },
+      "snippet" => {
+        "title" => title,
+        "description" => "A talk about #{title}",
+        "publishedAt" => "2024-06-01T12:00:00Z",
+        "channelTitle" => channel,
+        "thumbnails" => {
+          "high" => { "url" => "https://i.ytimg.com/vi/#{video_id}/hqdefault.jpg" }
+        }
+      }
+    }
+  end
+
+  def stub_search_list(query:, items:)
+    stub_request(:get, %r{https://www\.googleapis\.com/youtube/v3/search})
+      .with(query: hash_including("q" => query, "type" => "video", "key" => "test-key"))
+      .to_return(
+        status: 200,
+        body: { items: items }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+  end
+end


### PR DESCRIPTION
## Summary
- Add opt-in `YoutubeKeywordDiscovery` (`search.list`) driven by enabled `KeywordFilter` terms
- Enforce daily call budget + per-filter min interval via config; skip duplicates already ingested from channel feeds
- Wire into `FetchNewsJob` before enrichment; disabled by default (`apis.youtube.search.enabled`)

Closes #384

## Test plan
- [ ] With search disabled / no API key, discovery is a no-op
- [ ] Enabled filters create `youtube_search_<slug>` videos; inactive filters skipped
- [ ] Channel-ingested `external_id`s are not double-listed
- [ ] Daily budget and min interval are enforced; quota 403 does not fail the overall fetch
- [ ] CI green
