### PR TITLE
feat(sources): manage youtube channels from the sources page (#387)

### DIFF
--- a/app/controllers/sources_controller.rb
+++ b/app/controllers/sources_controller.rb
@@ -22,6 +22,30 @@ class SourcesController < ApplicationController
   end
 
   def create
+    source_type = params[:source_type].presence || (params[:subreddit].present? ? "reddit" : nil)
+
+    case source_type
+    when "reddit"
+      create_reddit_source
+    when "youtube"
+      create_youtube_source
+    else
+      render json: { error: "source_type must be reddit or youtube" }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    unless %w[reddit youtube].include?(@source.source_type)
+      return render json: { error: "Only Reddit and YouTube sources can be removed" }, status: :unprocessable_entity
+    end
+
+    @source.destroy!
+    head :no_content
+  end
+
+  private
+
+  def create_reddit_source
     subreddit = RedditSubredditValidator.normalize(params.require(:subreddit))
 
     if subreddit.blank?
@@ -44,16 +68,31 @@ class SourcesController < ApplicationController
     render json: { error: e.record.errors.full_messages.to_sentence }, status: :unprocessable_entity
   end
 
-  def destroy
-    unless @source.source_type == "reddit"
-      return render json: { error: "Only Reddit sources can be removed" }, status: :unprocessable_entity
+  def create_youtube_source
+    raw = params[:channel].presence || params[:channel_id].presence || params[:channel_url].presence
+    if raw.blank?
+      return render json: { error: "Channel ID, URL, or @handle is required" }, status: :unprocessable_entity
     end
 
-    @source.destroy!
-    head :no_content
-  end
+    result = YoutubeChannelValidator.resolve(raw)
+    unless result.valid?
+      return render json: { error: result.error }, status: :unprocessable_entity
+    end
 
-  private
+    source = NewsSource.create!(
+      name: result.channel_name,
+      source_type: "youtube",
+      config: {
+        "channel_id" => result.channel_id,
+        "channel_name" => result.channel_name
+      },
+      active: true
+    )
+
+    render json: source_json(source), status: :created
+  rescue ActiveRecord::RecordInvalid => e
+    render json: { error: e.record.errors.full_messages.to_sentence }, status: :unprocessable_entity
+  end
 
   def set_source
     @source = NewsSource.find(params[:id])
@@ -81,6 +120,7 @@ class SourcesController < ApplicationController
       source_type: source.source_type,
       subreddit: source.subreddit,
       channel_id: source.channel_id,
+      channel_name: source.source_type == "youtube" ? source.channel_name : nil,
       active: source.active,
       last_fetch: last_fetch_json(fetch_run, last_article_at)
     }

--- a/app/frontend/api/sources.ts
+++ b/app/frontend/api/sources.ts
@@ -23,6 +23,7 @@ export interface NewsSource {
   source_type: 'hacker_news' | 'dev_to' | 'reddit' | 'youtube'
   subreddit: string | null
   channel_id?: string | null
+  channel_name?: string | null
   active: boolean
   last_fetch: SourceLastFetch | null
 }
@@ -45,7 +46,14 @@ export function updateSource(id: number, active: boolean) {
 export function addRedditSource(subreddit: string) {
   return apiRequest<NewsSource>('/sources.json', {
     method: 'POST',
-    body: JSON.stringify({ subreddit }),
+    body: JSON.stringify({ source_type: 'reddit', subreddit }),
+  })
+}
+
+export function addYoutubeSource(channel: string) {
+  return apiRequest<NewsSource>('/sources.json', {
+    method: 'POST',
+    body: JSON.stringify({ source_type: 'youtube', channel }),
   })
 }
 

--- a/app/frontend/pages/SourcesIndexPage.test.tsx
+++ b/app/frontend/pages/SourcesIndexPage.test.tsx
@@ -10,6 +10,7 @@ vi.mock('../api/sources', () => ({
   fetchSources: vi.fn(),
   updateSource: vi.fn(),
   addRedditSource: vi.fn(),
+  addYoutubeSource: vi.fn(),
   removeSource: vi.fn(),
 }))
 
@@ -44,6 +45,16 @@ describe('SourcesIndexPage', () => {
         name: 'programming',
         source_type: 'reddit',
         subreddit: 'programming',
+        active: true,
+      })
+    )
+    vi.mocked(sourcesApi.addYoutubeSource).mockResolvedValue(
+      buildNewsSource({
+        id: 5,
+        name: 'Fireship',
+        source_type: 'youtube',
+        channel_id: 'UCsBjURrPoezykLs9EqgamOA',
+        channel_name: 'Fireship',
         active: true,
       })
     )
@@ -140,14 +151,29 @@ describe('SourcesIndexPage', () => {
     renderPage()
     await waitForSourcesPage()
 
-    await user.type(screen.getByTestId('subreddit-input'), 'programming')
-    await user.click(screen.getByTestId('add-subreddit-button'))
+    await user.type(screen.getByTestId('source-input'), 'programming')
+    await user.click(screen.getByTestId('add-source-button'))
 
     await waitFor(() => {
       expect(sourcesApi.addRedditSource).toHaveBeenCalledWith('programming')
     })
     expect(await screen.findByText('r/programming')).toBeInTheDocument()
-    expect(screen.getByTestId('subreddit-input')).toHaveValue('')
+    expect(screen.getByTestId('source-input')).toHaveValue('')
+  })
+
+  it('adds a YouTube channel after selecting the type', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await waitForSourcesPage()
+
+    await user.click(screen.getByTestId('add-type-youtube'))
+    await user.type(screen.getByTestId('source-input'), '@fireship')
+    await user.click(screen.getByTestId('add-source-button'))
+
+    await waitFor(() => {
+      expect(sourcesApi.addYoutubeSource).toHaveBeenCalledWith('@fireship')
+    })
+    expect(await screen.findByText('Fireship')).toBeInTheDocument()
   })
 
   it('shows validation error when adding a subreddit fails', async () => {
@@ -156,10 +182,10 @@ describe('SourcesIndexPage', () => {
     renderPage()
     await waitForSourcesPage()
 
-    await user.type(screen.getByTestId('subreddit-input'), 'notarealsub')
-    await user.click(screen.getByTestId('add-subreddit-button'))
+    await user.type(screen.getByTestId('source-input'), 'notarealsub')
+    await user.click(screen.getByTestId('add-source-button'))
 
-    expect(await screen.findByTestId('subreddit-validation-error')).toHaveTextContent(
+    expect(await screen.findByTestId('source-validation-error')).toHaveTextContent(
       'Subreddit not found'
     )
   })
@@ -169,7 +195,7 @@ describe('SourcesIndexPage', () => {
     renderPage()
     await waitForSourcesPage()
 
-    await user.click(screen.getByRole('button', { name: 'Remove' }))
+    await user.click(screen.getByTestId('remove-reddit-3'))
     expect(await screen.findByTestId('confirm-dialog')).toBeInTheDocument()
     await user.click(screen.getByTestId('confirm-dialog-confirm'))
 

--- a/app/frontend/pages/SourcesIndexPage.tsx
+++ b/app/frontend/pages/SourcesIndexPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import {
   addRedditSource,
+  addYoutubeSource,
   fetchSources,
   removeSource,
   updateSource,
@@ -18,12 +19,14 @@ import SourcesIndexSkeleton from '../components/SourcesIndexSkeleton'
 import PageHeading from '../components/ui/PageHeading'
 import { formatTimeAgo } from '../utils/format'
 
+type AddSourceType = 'reddit' | 'youtube'
+
 function sourceLabel(source: NewsSource): string {
   if (source.source_type === 'reddit') {
     return `r/${source.subreddit ?? source.name}`
   }
   if (source.source_type === 'youtube') {
-    return source.name
+    return source.channel_name || source.name
   }
   return source.name
 }
@@ -84,7 +87,8 @@ export default function SourcesIndexPage() {
   const [sources, setSources] = useState<NewsSource[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [subredditInput, setSubredditInput] = useState('')
+  const [addType, setAddType] = useState<AddSourceType>('reddit')
+  const [sourceInput, setSourceInput] = useState('')
   const [adding, setAdding] = useState(false)
   const [validationError, setValidationError] = useState<string | null>(null)
   const { confirm, dialog } = useConfirmDialog()
@@ -115,27 +119,43 @@ export default function SourcesIndexPage() {
     }
   }
 
-  const handleAddSubreddit = async (event: React.FormEvent) => {
+  const handleAddSource = async (event: React.FormEvent) => {
     event.preventDefault()
-    const subreddit = subredditInput.trim()
-    if (!subreddit) return
+    const value = sourceInput.trim()
+    if (!value) return
 
     setAdding(true)
     setValidationError(null)
     try {
-      const created = await addRedditSource(subreddit)
-      setSources((current) => [...current, created].sort((a, b) => a.name.localeCompare(b.name)))
-      setSubredditInput('')
+      const created =
+        addType === 'reddit' ? await addRedditSource(value) : await addYoutubeSource(value)
+      setSources((current) =>
+        [...current, created].sort((a, b) => {
+          const typeCmp = a.source_type.localeCompare(b.source_type)
+          return typeCmp !== 0 ? typeCmp : a.name.localeCompare(b.name)
+        })
+      )
+      setSourceInput('')
     } catch (err) {
-      setValidationError(err instanceof Error ? err.message : 'Failed to add subreddit.')
+      setValidationError(
+        err instanceof Error
+          ? err.message
+          : addType === 'reddit'
+            ? 'Failed to add subreddit.'
+            : 'Failed to add YouTube channel.'
+      )
     } finally {
       setAdding(false)
     }
   }
 
   const handleRemove = async (source: NewsSource) => {
+    const label =
+      source.source_type === 'youtube'
+        ? source.channel_name || source.name
+        : `r/${source.subreddit ?? source.name}`
     const confirmed = await confirm({
-      message: `Remove r/${source.subreddit ?? source.name} from sources?`,
+      message: `Remove ${label} from sources?`,
       confirmLabel: 'Remove',
     })
     if (!confirmed) return
@@ -144,7 +164,11 @@ export default function SourcesIndexPage() {
       await removeSource(source.id)
       setSources((current) => current.filter((item) => item.id !== source.id))
     } catch {
-      setError('Failed to remove subreddit.')
+      setError(
+        source.source_type === 'youtube'
+          ? 'Failed to remove YouTube channel.'
+          : 'Failed to remove subreddit.'
+      )
     }
   }
 
@@ -167,7 +191,7 @@ export default function SourcesIndexPage() {
       <Breadcrumbs items={sourcesBreadcrumbs} />
       <PageHeading
         title="News Sources"
-        subtitle="Enable or disable sources and manage Reddit subreddits."
+        subtitle="Enable or disable sources and manage Reddit subreddits and YouTube channels."
         titleClassName="text-gray-100"
       />
 
@@ -197,27 +221,72 @@ export default function SourcesIndexPage() {
         </div>
       </Card>
 
-      <Card as="section">
-        <h2 className="text-h3 text-gray-200 mb-4">Reddit subreddits</h2>
+      <Card as="section" className="mb-8">
+        <h2 className="text-h3 text-gray-200 mb-4">Add a source</h2>
+        <div className="flex flex-wrap gap-3 mb-4" role="group" aria-label="Source type">
+          <Button
+            type="button"
+            variant="filter"
+            active={addType === 'reddit'}
+            aria-pressed={addType === 'reddit'}
+            data-testid="add-type-reddit"
+            onClick={() => {
+              setAddType('reddit')
+              setValidationError(null)
+            }}
+          >
+            Reddit
+          </Button>
+          <Button
+            type="button"
+            variant="filter"
+            active={addType === 'youtube'}
+            aria-pressed={addType === 'youtube'}
+            data-testid="add-type-youtube"
+            onClick={() => {
+              setAddType('youtube')
+              setValidationError(null)
+            }}
+          >
+            YouTube
+          </Button>
+        </div>
 
-        <form onSubmit={handleAddSubreddit} className="flex flex-col sm:flex-row gap-3 mb-6">
+        <form onSubmit={handleAddSource} className="flex flex-col sm:flex-row gap-3 mb-2">
           <input
             type="text"
-            value={subredditInput}
-            onChange={(event) => setSubredditInput(event.target.value)}
-            placeholder="e.g. programming"
+            value={sourceInput}
+            onChange={(event) => setSourceInput(event.target.value)}
+            placeholder={
+              addType === 'reddit'
+                ? 'e.g. programming'
+                : 'UC… ID, @handle, or youtube.com/@channel'
+            }
             className="flex-1 px-4 py-2 bg-dark-800 border border-dark-700 rounded-xl text-gray-200 placeholder-gray-500 focus-visible:outline-none focus-visible:border-primary-500 focus-visible:ring-2 focus-visible:ring-primary-500"
-            data-testid="subreddit-input"
+            data-testid="source-input"
           />
-          <Button type="submit" disabled={adding || !subredditInput.trim()} data-testid="add-subreddit-button">
-            {adding ? 'Validating...' : 'Add subreddit'}
+          <Button
+            type="submit"
+            disabled={adding || !sourceInput.trim()}
+            data-testid="add-source-button"
+          >
+            {adding
+              ? 'Validating...'
+              : addType === 'reddit'
+                ? 'Add subreddit'
+                : 'Add channel'}
           </Button>
         </form>
 
         {validationError && (
-          <p className="text-sm text-red-400 mb-4" data-testid="subreddit-validation-error">{validationError}</p>
+          <p className="text-sm text-red-400 mb-4" data-testid="source-validation-error">
+            {validationError}
+          </p>
         )}
+      </Card>
 
+      <Card as="section" className="mb-8">
+        <h2 className="text-h3 text-gray-200 mb-4">Reddit subreddits</h2>
         <div className="space-y-3">
           {redditSources.map((source) => (
             <div key={source.id} className="flex items-center justify-between gap-4 py-3 border-b border-dark-700 last:border-0">
@@ -239,6 +308,7 @@ export default function SourcesIndexPage() {
                   type="button"
                   className="text-sm text-red-400 hover:text-red-300"
                   onClick={() => handleRemove(source)}
+                  data-testid={`remove-reddit-${source.id}`}
                 >
                   Remove
                 </button>
@@ -251,20 +321,20 @@ export default function SourcesIndexPage() {
         </div>
       </Card>
 
-      {youtubeSources.length > 0 && (
-        <Card as="section" className="mt-8">
-          <h2 className="text-h3 text-gray-200 mb-4">YouTube channels</h2>
-          <div className="space-y-3">
-            {youtubeSources.map((source) => (
-              <div key={source.id} className="flex items-center justify-between gap-4 py-3 border-b border-dark-700 last:border-0">
-                <div className="min-w-0">
-                  <span className="text-gray-200 font-medium">{source.name}</span>
-                  {source.channel_id && (
-                    <p className="text-caption text-gray-500 mt-1">{source.channel_id}</p>
-                  )}
-                  <SourceFetchStatus lastFetch={source.last_fetch} />
-                </div>
-                <label className="flex items-center gap-2 text-sm text-gray-400 cursor-pointer shrink-0">
+      <Card as="section">
+        <h2 className="text-h3 text-gray-200 mb-4">YouTube channels</h2>
+        <div className="space-y-3">
+          {youtubeSources.map((source) => (
+            <div key={source.id} className="flex items-center justify-between gap-4 py-3 border-b border-dark-700 last:border-0">
+              <div className="min-w-0">
+                <span className="text-gray-200 font-medium">{sourceLabel(source)}</span>
+                {source.channel_id && (
+                  <p className="text-caption text-gray-500 mt-1">{source.channel_id}</p>
+                )}
+                <SourceFetchStatus lastFetch={source.last_fetch} />
+              </div>
+              <div className="flex items-center gap-4 shrink-0">
+                <label className="flex items-center gap-2 text-sm text-gray-400 cursor-pointer">
                   <input
                     type="checkbox"
                     className="rounded border-dark-600 bg-dark-800 text-primary-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
@@ -274,11 +344,22 @@ export default function SourcesIndexPage() {
                   />
                   {source.active ? 'Enabled' : 'Disabled'}
                 </label>
+                <button
+                  type="button"
+                  className="text-sm text-red-400 hover:text-red-300"
+                  onClick={() => handleRemove(source)}
+                  data-testid={`remove-youtube-${source.id}`}
+                >
+                  Remove
+                </button>
               </div>
-            ))}
-          </div>
-        </Card>
-      )}
+            </div>
+          ))}
+          {youtubeSources.length === 0 && (
+            <p className="text-gray-500 text-sm">No YouTube channels configured.</p>
+          )}
+        </div>
+      </Card>
       {dialog}
     </PageContainer>
   )

--- a/app/frontend/test/fixtures.ts
+++ b/app/frontend/test/fixtures.ts
@@ -152,6 +152,7 @@ export function buildNewsSource(overrides: Partial<NewsSource> = {}): NewsSource
     source_type: 'hacker_news',
     subreddit: null,
     channel_id: null,
+    channel_name: null,
     active: true,
     last_fetch: null,
     ...overrides,

--- a/app/services/youtube_channel_validator.rb
+++ b/app/services/youtube_channel_validator.rb
@@ -1,0 +1,146 @@
+# Validates and resolves YouTube channel identifiers before saving a NewsSource.
+# Accepts UC… IDs, /channel/UC… URLs, @handles, and youtube.com/@handle URLs.
+# Verifies the public Atom feed responds and captures the channel title.
+class YoutubeChannelValidator
+  CHANNEL_ID_PATTERN = /\AUC[\w-]{20,}\z/
+
+  Result = Struct.new(:ok, :channel_id, :channel_name, :error, keyword_init: true) do
+    def valid?
+      ok
+    end
+  end
+
+  class << self
+    def resolve(input)
+      normalized = normalize(input)
+      return failure("Channel ID, URL, or @handle is required") if normalized.blank?
+
+      channel_id = extract_channel_id(normalized)
+      channel_id ||= resolve_handle(normalized)
+
+      return failure("Could not resolve YouTube channel from that input") if channel_id.blank?
+      return failure("Invalid YouTube channel ID") unless CHANNEL_ID_PATTERN.match?(channel_id)
+
+      cache_key = "youtube_channel_valid:#{channel_id}"
+      cached = Rails.cache.read(cache_key)
+      return Result.new(**cached.symbolize_keys) if cached.is_a?(Hash)
+
+      feed = fetch_atom_feed(channel_id)
+      unless feed[:valid]
+        result = failure(feed[:error] || "YouTube channel not found or feed unavailable")
+        Rails.cache.write(cache_key, result.to_h, expires_in: 15.minutes)
+        return result
+      end
+
+      result = Result.new(
+        ok: true,
+        channel_id: channel_id,
+        channel_name: feed[:title].presence || channel_id,
+        error: nil
+      )
+      Rails.cache.write(cache_key, result.to_h, expires_in: 1.hour)
+      result
+    rescue StandardError => e
+      failure("Could not validate YouTube channel: #{e.message}")
+    end
+
+    def normalize(input)
+      input.to_s.strip
+    end
+
+    private
+
+    def failure(message)
+      Result.new(ok: false, channel_id: nil, channel_name: nil, error: message)
+    end
+
+    def extract_channel_id(value)
+      return value if CHANNEL_ID_PATTERN.match?(value)
+
+      if (match = value.match(%r{youtube\.com/channel/(UC[\w-]+)}i))
+        return match[1]
+      end
+
+      nil
+    end
+
+    def resolve_handle(value)
+      handle = extract_handle(value)
+      return nil if handle.blank?
+
+      resolve_handle_via_api(handle) || resolve_handle_via_page(handle)
+    end
+
+    def extract_handle(value)
+      if (match = value.match(%r{youtube\.com/@([\w.-]+)}i))
+        return match[1]
+      end
+
+      return nil if value.include?("/") || CHANNEL_ID_PATTERN.match?(value)
+
+      stripped = value.delete_prefix("@")
+      return stripped if stripped.match?(/\A[\w.-]{3,30}\z/i)
+
+      nil
+    end
+
+    def resolve_handle_via_api(handle)
+      api_key = ENV["YOUTUBE_API_KEY"].presence
+      return nil if api_key.blank?
+
+      response = HTTParty.get(
+        "https://www.googleapis.com/youtube/v3/channels",
+        query: { part: "snippet", forHandle: handle, key: api_key },
+        timeout: 5
+      )
+      return nil unless response.success?
+
+      item = Array(response.parsed_response["items"]).first
+      item&.dig("id").presence
+    rescue StandardError
+      nil
+    end
+
+    def resolve_handle_via_page(handle)
+      response = HTTParty.get(
+        "https://www.youtube.com/@#{handle}",
+        headers: { "User-Agent" => "DevNewsAggregator/1.0" },
+        timeout: 8,
+        follow_redirects: true
+      )
+      return nil unless response.success?
+
+      body = response.body.to_s
+      match = body.match(/"channelId"\s*:\s*"(UC[\w-]+)"/) ||
+              body.match(%r{youtube\.com/channel/(UC[\w-]+)})
+      match&.[](1)
+    rescue StandardError
+      nil
+    end
+
+    def fetch_atom_feed(channel_id)
+      base = NewsAggregatorConfig.youtube_feed_base_url
+      uri = URI.parse(base)
+      response = HTTParty.get(
+        "#{uri.scheme}://#{uri.host}#{uri.path}",
+        query: { channel_id: channel_id },
+        timeout: 5,
+        headers: { "User-Agent" => "DevNewsAggregator/1.0" }
+      )
+
+      body = response.body.to_s
+      unless response.code == 200 && body.include?("<feed")
+        return { valid: false, error: "YouTube channel not found or feed unavailable" }
+      end
+
+      document = Nokogiri::XML(body)
+      document.remove_namespaces!
+      title = document.at_xpath("//author/name")&.text&.strip.presence ||
+              document.at_xpath("//title")&.text&.strip.presence
+
+      { valid: true, title: title }
+    rescue StandardError => e
+      { valid: false, error: e.message }
+    end
+  end
+end

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -103,6 +103,7 @@ dev-news-aggregator/
 | `news_fetchers/reddit_fetcher.rb` | Reddit API (one instance per subreddit) |
 | `news_fetchers/youtube_fetcher.rb` | YouTube channel Atom feeds (no API key) |
 | `youtube_keyword_discovery.rb` | Opt-in keyword search.list discovery with daily quota budget |
+| `youtube_channel_validator.rb` | Resolve/validate YouTube channel IDs, URLs, and @handles |
 | `personal_feed_ranker.rb` | For you sort — source affinity from bookmarks/dismissals |
 | `article_topic_classifier.rb` | Schema-validated topic tagging (keyword heuristics) |
 | `feed_noise_classifier.rb` | Heuristics to flag low-signal / meme feed items |

--- a/test/controllers/sources_controller_test.rb
+++ b/test/controllers/sources_controller_test.rb
@@ -63,7 +63,7 @@ class SourcesControllerTest < ActionDispatch::IntegrationTest
     assert @reddit_source.reload.active
   end
 
-  test "should not remove non-reddit source" do
+  test "should not remove built-in source" do
     hn = news_sources(:hacker_news)
     delete source_url(hn), as: :json
     assert_response :unprocessable_entity
@@ -76,11 +76,24 @@ class SourcesControllerTest < ActionDispatch::IntegrationTest
     assert_not NewsSource.exists?(@reddit_source.id)
   end
 
+  test "should remove youtube source" do
+    youtube = NewsSource.create!(
+      name: "Confreaks",
+      source_type: "youtube",
+      config: { "channel_id" => "UCWnPjmqvljcafA0QXblOU1A", "channel_name" => "Confreaks" },
+      active: true
+    )
+
+    delete source_url(youtube), as: :json
+    assert_response :no_content
+    assert_not NewsSource.exists?(youtube.id)
+  end
+
   test "should reject invalid subreddit" do
     original = RedditSubredditValidator.method(:valid?)
     RedditSubredditValidator.define_singleton_method(:valid?) { |_subreddit| false }
     begin
-      post sources_url, params: { subreddit: "not-a-real-subreddit-xyz" }, as: :json
+      post sources_url, params: { source_type: "reddit", subreddit: "not-a-real-subreddit-xyz" }, as: :json
       assert_response :unprocessable_entity
       assert_equal "Subreddit not found or not accessible", JSON.parse(response.body)["error"]
     ensure
@@ -93,7 +106,7 @@ class SourcesControllerTest < ActionDispatch::IntegrationTest
     RedditSubredditValidator.define_singleton_method(:valid?) { |_subreddit| true }
     begin
       assert_difference("NewsSource.count", 1) do
-        post sources_url, params: { subreddit: "golang" }, as: :json
+        post sources_url, params: { source_type: "reddit", subreddit: "golang" }, as: :json
       end
 
       assert_response :created
@@ -102,6 +115,55 @@ class SourcesControllerTest < ActionDispatch::IntegrationTest
       assert_equal "golang", json["subreddit"]
     ensure
       RedditSubredditValidator.define_singleton_method(:valid?, original)
+    end
+  end
+
+  test "should add valid youtube channel" do
+    channel_id = "UCWnPjmqvljcafA0QXblOU1A"
+    original = YoutubeChannelValidator.method(:resolve)
+    YoutubeChannelValidator.define_singleton_method(:resolve) do |_input|
+      YoutubeChannelValidator::Result.new(
+        ok: true,
+        channel_id: channel_id,
+        channel_name: "Confreaks",
+        error: nil
+      )
+    end
+    begin
+      assert_difference("NewsSource.count", 1) do
+        post sources_url, params: { source_type: "youtube", channel: "@confreaks" }, as: :json
+      end
+
+      assert_response :created
+      json = JSON.parse(response.body)
+      assert_equal "youtube", json["source_type"]
+      assert_equal channel_id, json["channel_id"]
+      assert_equal "Confreaks", json["channel_name"]
+    ensure
+      YoutubeChannelValidator.define_singleton_method(:resolve) do |*args, **kwargs, &block|
+        original.call(*args, **kwargs, &block)
+      end
+    end
+  end
+
+  test "should reject invalid youtube channel" do
+    original = YoutubeChannelValidator.method(:resolve)
+    YoutubeChannelValidator.define_singleton_method(:resolve) do |_input|
+      YoutubeChannelValidator::Result.new(
+        ok: false,
+        channel_id: nil,
+        channel_name: nil,
+        error: "YouTube channel not found or feed unavailable"
+      )
+    end
+    begin
+      post sources_url, params: { source_type: "youtube", channel: "@nope" }, as: :json
+      assert_response :unprocessable_entity
+      assert_equal "YouTube channel not found or feed unavailable", JSON.parse(response.body)["error"]
+    ensure
+      YoutubeChannelValidator.define_singleton_method(:resolve) do |*args, **kwargs, &block|
+        original.call(*args, **kwargs, &block)
+      end
     end
   end
 end

--- a/test/services/youtube_channel_validator_test.rb
+++ b/test/services/youtube_channel_validator_test.rb
@@ -1,0 +1,101 @@
+require "test_helper"
+
+class YoutubeChannelValidatorTest < ActiveSupport::TestCase
+  CHANNEL_ID = "UCWnPjmqvljcafA0QXblOU1A"
+
+  setup do
+    Rails.cache.clear
+  end
+
+  teardown do
+    Rails.cache.clear
+    ENV.delete("YOUTUBE_API_KEY") if ENV["YOUTUBE_API_KEY"] == "test-key"
+  end
+
+  test "resolves a bare channel ID when Atom feed is valid" do
+    stub_atom_feed(CHANNEL_ID, title: "Confreaks")
+
+    result = YoutubeChannelValidator.resolve(CHANNEL_ID)
+
+    assert result.valid?
+    assert_equal CHANNEL_ID, result.channel_id
+    assert_equal "Confreaks", result.channel_name
+  end
+
+  test "resolves a channel URL" do
+    stub_atom_feed(CHANNEL_ID, title: "Confreaks")
+
+    result = YoutubeChannelValidator.resolve("https://www.youtube.com/channel/#{CHANNEL_ID}")
+
+    assert result.valid?
+    assert_equal CHANNEL_ID, result.channel_id
+  end
+
+  test "resolves an @handle via page scrape when no API key" do
+    stub_request(:get, "https://www.youtube.com/@fireship")
+      .to_return(
+        status: 200,
+        body: %(<html>"channelId":"#{CHANNEL_ID}"</html>),
+        headers: { "Content-Type" => "text/html" }
+      )
+    stub_atom_feed(CHANNEL_ID, title: "Fireship")
+
+    result = YoutubeChannelValidator.resolve("@fireship")
+
+    assert result.valid?
+    assert_equal CHANNEL_ID, result.channel_id
+    assert_equal "Fireship", result.channel_name
+  end
+
+  test "resolves a handle via channels.list when API key is set" do
+    ENV["YOUTUBE_API_KEY"] = "test-key"
+    stub_request(:get, %r{https://www\.googleapis\.com/youtube/v3/channels})
+      .with(query: hash_including("forHandle" => "fireship", "key" => "test-key"))
+      .to_return(
+        status: 200,
+        body: { items: [ { "id" => CHANNEL_ID } ] }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+    stub_atom_feed(CHANNEL_ID, title: "Fireship")
+
+    result = YoutubeChannelValidator.resolve("https://www.youtube.com/@fireship")
+
+    assert result.valid?
+    assert_equal CHANNEL_ID, result.channel_id
+  end
+
+  test "rejects blank input" do
+    result = YoutubeChannelValidator.resolve("  ")
+
+    refute result.valid?
+    assert_match(/required/i, result.error)
+  end
+
+  test "rejects when Atom feed is missing" do
+    stub_request(:get, %r{youtube\.com/feeds/videos\.xml})
+      .with(query: hash_including("channel_id" => CHANNEL_ID))
+      .to_return(status: 404, body: "not found")
+
+    result = YoutubeChannelValidator.resolve(CHANNEL_ID)
+
+    refute result.valid?
+    assert_match(/not found|unavailable/i, result.error)
+  end
+
+  private
+
+  def stub_atom_feed(channel_id, title:)
+    body = <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <title>#{title}</title>
+        <author><name>#{title}</name></author>
+        <entry><title>Sample</title></entry>
+      </feed>
+    XML
+
+    stub_request(:get, %r{youtube\.com/feeds/videos\.xml})
+      .with(query: hash_including("channel_id" => channel_id))
+      .to_return(status: 200, body: body, headers: { "Content-Type" => "application/atom+xml" })
+  end
+end


### PR DESCRIPTION
## Summary
- Generalize `SourcesController#create` for `reddit` and `youtube`; allow deleting YouTube sources
- Add `YoutubeChannelValidator` (UC ID, channel URL, @handle) with Atom feed verification and title capture
- Sources UI: type selector, add/remove YouTube channels, grouped list with toggle

Closes #387

## Test plan
- [ ] Add a channel by UC ID, URL, and @handle from Sources
- [ ] Invalid channels are rejected with a clear error
- [ ] Channel title is stored/shown; toggle and remove work
- [ ] Reddit add/remove and built-in sources unchanged
- [ ] CI green
