### PR TITLE
docs: document youtube ingestion paths and quota strategy (#388)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,8 +44,8 @@ SECRET_KEY_BASE=your_secret_key_base_here
 # REDDIT_CLIENT_ID=
 # REDDIT_CLIENT_SECRET=
 
-# Optional YouTube Data API key for videos.list duration/stats enrichment
-# (1 quota unit per call, up to 50 IDs). Channel Atom feeds work without this.
+# Optional YouTube Data API key for videos.list enrichment and optional search.list
+# discovery (see docs/YOUTUBE.md). Channel Atom feeds work without this.
 # YOUTUBE_API_KEY=
 
 # Optional article summarizer (default: none — app works without it).

--- a/docs/AGENT_API.md
+++ b/docs/AGENT_API.md
@@ -32,16 +32,18 @@ Query params:
 | `show_read` | `true` to include read articles |
 | `page`, `per_page` | Pagination (`per_page` max 100) |
 
-For the richer HTML/JSON feed (`GET /articles.json` / `.atom`) — including `keywords`, `match`, `interest` / `interests`, categories, and tags — see [KEYWORD_FILTERS.md](KEYWORD_FILTERS.md). Those params are not yet mirrored on `/api/v1/articles`.
+For the richer HTML/JSON feed (`GET /articles.json` / `.atom`) — including `keywords`, `match`, `interest` / `interests`, `content_type`, `max_duration`, categories, and tags — see [KEYWORD_FILTERS.md](KEYWORD_FILTERS.md) and [YOUTUBE.md](YOUTUBE.md). Those params are not yet mirrored on `/api/v1/articles`.
 
 Response:
 
 ```json
 {
-  "articles": [ { "id": 1, "title": "...", "url": "...", "source_type": "hacker_news", "score": 10, "bookmarked": false, "read": false, "dismissed": false, "pending_dismissal": false } ],
+  "articles": [ { "id": 1, "title": "...", "url": "...", "source_type": "hacker_news", "score": 10, "content_type": "article", "duration_seconds": null, "thumbnail_url": null, "author": null, "bookmarked": false, "read": false, "dismissed": false, "pending_dismissal": false } ],
   "pagination": { "current_page": 1, "per_page": 50, "total_count": 10, "total_pages": 1 }
 }
 ```
+
+Video items use `content_type: "video"` with optional `duration_seconds`, `thumbnail_url`, and `author` (same fields on `GET /articles.json`).
 
 ### Show article
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -182,16 +182,16 @@ whenever --clear-crontab
 
 ### Core components
 
-**NewsAggregatorService**: Central orchestrator that coordinates all news fetchers. Builds the fetcher list from enabled `NewsSource` records when present, otherwise from `config/news_aggregator.yml` (Hacker News, Dev.to, and configured Reddit subreddits). Handles error logging and aggregates results.
+**NewsAggregatorService**: Central orchestrator that coordinates all news fetchers. Builds the fetcher list from enabled `NewsSource` records when present, otherwise from `config/news_aggregator.yml` (Hacker News, Dev.to, configured Reddit subreddits, and YouTube channels). Handles error logging and aggregates results.
 
-**NewsAggregatorConfig**: Loads `config/news_aggregator.yml` via `Rails.application.config_for`. Provides fetching limits (`max_articles_per_source`), retention settings, Reddit subreddit lists, and API endpoint metadata. Fetchers read article limits from config; `news:clean` uses configured retention days.
+**NewsAggregatorConfig**: Loads `config/news_aggregator.yml` via `Rails.application.config_for`. Provides fetching limits (`max_articles_per_source`), retention settings, Reddit/YouTube source lists, and API endpoint metadata. Fetchers read article limits from config; `news:clean` uses configured retention days.
 
-**Fetcher architecture**: Modular fetcher system with `NewsFetchers::BaseFetcher` as the abstract base class. Each fetcher (HackerNews, DevTo, Reddit) inherits and implements `fetch_articles`. Common pattern: fetch from API, transform data, call `create_or_update_article`.
+**Fetcher architecture**: Modular fetcher system with `NewsFetchers::BaseFetcher` as the abstract base class. Each fetcher (HackerNews, DevTo, Reddit, YouTube) inherits and implements `fetch_articles`. Common pattern: fetch from API, transform data, call `create_or_update_article`.
 
 **Data models**:
-- `Article`: Stores aggregated news with unified schema (title, url, published_at, description, external_id, source_type, score, comment_count)
+- `Article`: Stores aggregated news with unified schema (title, url, published_at, description, external_id, source_type, score, comment_count, plus optional video fields: `content_type`, `duration_seconds`, `thumbnail_url`, `author`)
 - `Bookmark`: Tracks bookmarked articles for personal reading list functionality
-- `NewsSource`: Database-backed source registry with admin UI at `/sources`. `bootstrap_defaults!` seeds Hacker News, Dev.to, and Reddit subreddits from `config/news_aggregator.yml`. When any enabled records exist, they override the YAML default fetcher list
+- `NewsSource`: Database-backed source registry with admin UI at `/sources`. `bootstrap_defaults!` seeds Hacker News, Dev.to, Reddit subreddits, and YouTube channels from `config/news_aggregator.yml`. When any enabled records exist, they override the YAML default fetcher list
 
 **Scheduled jobs**: Uses `whenever` gem to run `news:fetch` hourly during business hours (9 AM - 6 PM) and `news:clean` daily at 2 AM. `news:fetch` enqueues `FetchNewsJob` so cron exits immediately; workers process the fetch asynchronously. Logs to `log/cron.log`.
 
@@ -212,19 +212,23 @@ whenever --clear-crontab
 ```
 app/
   controllers/articles_controller.rb    # Main web interface
-  controllers/sources_controller.rb     # Enable/disable sources, add Reddit subreddits
+  controllers/sources_controller.rb     # Enable/disable sources; add Reddit / YouTube
   models/
     article.rb                          # Article data model
     news_aggregator_config.rb           # YAML config loader for news fetching
     news_source.rb                      # Database-backed source registry
   services/
     news_aggregator_service.rb          # Main orchestrator
+    youtube_video_enricher.rb           # Optional videos.list duration/stats
+    youtube_keyword_discovery.rb        # Opt-in search.list discovery (budgeted)
+    youtube_channel_validator.rb        # Resolve/validate YouTube channels for /sources
     news_fetchers/
       base_fetcher.rb                   # Abstract fetcher base class
       hacker_news_fetcher.rb            # HN API integration
       dev_to_fetcher.rb                 # Dev.to API integration
       reddit_fetcher.rb                 # Reddit API integration
-config/news_aggregator.yml              # Fetch limits, retention, subreddit list
+      youtube_fetcher.rb                # YouTube channel Atom feeds
+config/news_aggregator.yml              # Fetch limits, retention, Reddit/YouTube sources
 lib/tasks/news.rake                     # Rake tasks for news operations
 config/schedule.rb                      # Cron job definitions
 ```
@@ -237,13 +241,17 @@ config/schedule.rb                      # Cron job definitions
 
 **Reddit**: Multiple instances for different subreddits. Each subreddit is treated as a separate source type in the database. By default, fetchers read the public Atom feed (`/r/{subreddit}/.rss`) because unauthenticated `.json` listings return HTTP 403 (Atom has no score fields, so new articles seed `score`/`comment_count` to 0). Set `REDDIT_CLIENT_ID` and `REDDIT_CLIENT_SECRET` to switch to OAuth JSON listings on `oauth.reddit.com`, which persist real scores and comment counts. Requests share a configurable throttle (`apis.reddit.min_request_interval_seconds`, default 2.5s); HTTP 429 responses are retried with backoff (`apis.reddit.rate_limit_max_retries`) and failures are recorded on `FetchRun` instead of silent zero-article success.
 
+**YouTube**: Channel uploads via public Atom feeds (no API key). Optional `YOUTUBE_API_KEY` enables `videos.list` enrichment (duration/stats) and opt-in keyword `search.list` discovery with a hard daily budget. Manage channels at `/sources`. Full quota/config details: [YOUTUBE.md](YOUTUBE.md).
+
 ### Database schema
 
 Articles table uses generic fields to accommodate all news sources:
-- `source_type`: String identifier (hacker_news, dev_to, reddit_programming, etc.)
-- `external_id`: Source-specific unique identifier
-- `score`: Votes/reactions from source (HN score, Dev.to reactions, Reddit upvotes)
+- `source_type`: String identifier (hacker_news, dev_to, reddit_programming, youtube_UC…, youtube_search_<slug>, etc.)
+- `external_id`: Source-specific unique identifier (YouTube video ID for videos)
+- `score`: Votes/reactions from source (HN score, Dev.to reactions, Reddit upvotes, YouTube views when enriched)
 - `comment_count`: Source-specific comment counts
+- `content_type`: `article` (default) or `video`
+- `duration_seconds` / `thumbnail_url` / `author`: Video metadata (nullable)
 
 ### Environment configuration
 
@@ -262,13 +270,16 @@ Copy `.env.example` to `.env` before starting the stack. Docker Compose reads it
 
 **Keyword interests**: Saved topic presets (`KeywordFilter`) filter the feed by title/description terms (`keywords`, `interest` / `interests`). Manage them at `/interests`; see [KEYWORD_FILTERS.md](KEYWORD_FILTERS.md).
 
-**Multi-source aggregation**: Default sources are defined in `config/news_aggregator.yml` — Hacker News, Dev.to, and 11 Reddit subreddits (programming, webdev, javascript, ruby, rust, netsec, cybersecurity, technology, MachineLearning, artificial, LocalLLaMA). Override via enabled `NewsSource` records.
+**YouTube videos**: Channel Atom ingestion plus optional API enrichment/discovery; content-type and duration filters on the feed. See [YOUTUBE.md](YOUTUBE.md).
+
+**Multi-source aggregation**: Default sources are defined in `config/news_aggregator.yml` — Hacker News, Dev.to, Reddit subreddits, and starter YouTube channels. Override via enabled `NewsSource` records.
 
 ### Adding new news sources
 
 **Via config (default path)**:
 1. For Reddit: add the subreddit to `config/news_aggregator.yml` under `apis.reddit.subreddits`
-2. Adjust `fetching.max_articles_per_source` if needed
+2. For YouTube: add `{ channel_id, name }` under `apis.youtube.channels`, or use `/sources` in the UI
+3. Adjust `fetching.max_articles_per_source` if needed
 
 **Via database (optional override)**:
 1. Create or enable a `NewsSource` record (`NewsSource.bootstrap_defaults!` seeds defaults)

--- a/docs/KEYWORD_FILTERS.md
+++ b/docs/KEYWORD_FILTERS.md
@@ -27,6 +27,8 @@ Interests filter by matching terms against **title + description**. They are ort
 | `category` | Source-category slug. |
 | `tag` | Topic tag slug. |
 | `min_score` / `top_percent` / `sort` / `show_read` / `page` | Unchanged score/sort/pagination params. |
+| `content_type` | `video` or `article` (absent = both). See [YOUTUBE.md](YOUTUBE.md). |
+| `max_duration` | Max video length in **minutes**; text articles untouched; unknown duration included. |
 
 ### Combining filters
 

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -209,6 +209,8 @@ dev-news-aggregator/
 | `PRE_COMMIT_HOOKS.md` | Overcommit setup and usage |
 | `REACT_SETUP.md` | React/Vite frontend setup |
 | `SUMMARIZER.md` | Optional pluggable article summarizer (env, providers, caching) |
+| `KEYWORD_FILTERS.md` | Interest/keyword feed filters and articles index API params |
+| `YOUTUBE.md` | YouTube Atom vs Data API paths, quota strategy, config, Sources UI |
 
 ## `.github/`
 
@@ -255,14 +257,16 @@ Agents should start here, then use this file as the navigation map:
 2. [CONTRIBUTING.md](../CONTRIBUTING.md) — PR workflow
 3. [DEVELOPMENT.md](DEVELOPMENT.md) — setup, commands, conventions
 4. [KEYWORD_FILTERS.md](KEYWORD_FILTERS.md) — interest/keyword feed filters
-5. This file — directory and entry-point map
+5. [YOUTUBE.md](YOUTUBE.md) — YouTube ingestion and quota
+6. [PRE_COMMIT_HOOKS.md](PRE_COMMIT_HOOKS.md) — Overcommit setup
+7. This file — directory and entry-point map
 
 ## Routes (summary)
 
 | Path | Controller#action |
 |------|-------------------|
 | `/` | `articles#index` |
-| `/articles.atom` | `articles#index` (Atom feed; honors `q`, `keywords`, `match`, `interest`/`interests`, `category`, `tag`, `sort`, score filters — see [KEYWORD_FILTERS.md](KEYWORD_FILTERS.md)) |
+| `/articles.atom` | `articles#index` (Atom feed; honors `q`, `keywords`, `match`, `interest`/`interests`, `category`, `tag`, `content_type`, `max_duration`, `sort`, score filters — see [KEYWORD_FILTERS.md](KEYWORD_FILTERS.md) and [YOUTUBE.md](YOUTUBE.md)) |
 | `/articles/:id` | `articles#show` |
 | `/articles/:id/summarize` | `articles#summarize` (POST; optional AI/heuristic summary) |
 | `/keyword_filters` | `keyword_filters#index` (CRUD JSON for interest presets) |

--- a/docs/YOUTUBE.md
+++ b/docs/YOUTUBE.md
@@ -1,0 +1,116 @@
+# YouTube ingestion
+
+Short developer videos in the same feed as HN / Dev.to / Reddit. Two paths with very different quota profiles — prefer Atom for channels; treat Data API search as a scarce budget.
+
+## Two ingestion paths
+
+| Path | How | API key? | Quota | What you get |
+|------|-----|----------|-------|--------------|
+| **Channel Atom** | `GET https://www.youtube.com/feeds/videos.xml?channel_id=UC…` | No | None | Latest ~15 uploads per channel; title, URL, thumbnail, author; **no duration** until enrichment |
+| **Data API** | `videos.list`, optional `search.list` / `channels.list` | `YOUTUBE_API_KEY` | Yes | Duration, view/comment counts; keyword discovery |
+
+`FetchNewsJob` order:
+
+1. `NewsAggregatorService.fetch_all_news` (includes `NewsFetchers::YoutubeFetcher` for enabled YouTube `NewsSource`s)
+2. `YoutubeKeywordDiscovery.run!` (no-op unless search is enabled + key present)
+3. `YoutubeVideoEnricher.enrich!` (no-op without key / when `enrich_with_api` is false)
+
+## Quota (rules of thumb)
+
+YouTube Data API v3 units change over time; verify against [Google’s quota docs](https://developers.google.com/youtube/v3/determine_quota_cost). Practical defaults this app assumes:
+
+| Method | Approx. cost | Notes |
+|--------|--------------|-------|
+| `videos.list` | **1 unit / call** | Up to **50** video IDs per call — batch aggressively |
+| `channels.list` | **1 unit / call** | Used optionally to resolve `@handles` when adding a source |
+| `search.list` | Separate expensive bucket (~**100 calls/day** class of limit as of mid-2026) | **Never** call on every hourly fetch |
+
+**Do not** enable keyword search on the same cadence as Atom/RSS. Discovery is opt-in, budgeted, and interval-gated (see config below).
+
+Without `YOUTUBE_API_KEY`:
+
+- Channel Atom ingestion still works
+- Cards show thumbnails/authors from Atom; duration stays unknown until a key is added
+- Keyword discovery and duration enrichment are skipped
+- Handle → `UC…` resolution falls back to scraping the public channel page
+
+## Setup
+
+1. (Optional) Create a Google Cloud API key with YouTube Data API v3 enabled.
+2. Copy `.env.example` → `.env` and set:
+
+```bash
+# YOUTUBE_API_KEY=
+```
+
+3. Manage channels in the UI at `/sources` (YouTube tab) or seed defaults from `config/news_aggregator.yml` → `apis.youtube.channels`.
+4. Leave `apis.youtube.search.enabled: false` unless you intentionally want keyword discovery.
+
+Do not commit real keys.
+
+## Config reference (`apis.youtube`)
+
+| Key | Default | Purpose |
+|-----|---------|---------|
+| `channels` | starter list | Bootstrap `NewsSource` rows (`channel_id`, `name`) |
+| `feed_base_url` | YouTube Atom URL | Channel feed endpoint |
+| `min_request_interval_seconds` | `2.0` | Throttle between Atom requests |
+| `rate_limit_max_retries` | `4` | Backoff on HTTP 429 |
+| `enrich_with_api` | `true` | Run `videos.list` when a key is present |
+| `enrich_batch_size` | `50` | IDs per `videos.list` call (clamped 1–50) |
+| `enrich_max_per_run` | `100` | Max videos enriched per job run |
+| `max_duration_seconds` | `1200` | After enrichment, destroy non-bookmarked/non-read videos longer than this (`0` disables) |
+| `search.enabled` | `false` | Keyword `search.list` discovery |
+| `search.daily_call_budget` | `20` | Hard cap on search calls per UTC day |
+| `search.min_interval_hours` | `12` | Per-interest minimum gap between searches |
+| `search.max_results` | `10` | Results per search page (one page per interest per run) |
+| `search.video_duration` | `medium` | `short` / `medium` / `long` / `any` |
+| `search.order` | `date` | `date` / `relevance` / `viewCount` / `rating` |
+| `search.relevance_language` | `en` | Passed to `search.list` |
+| `search.region_code` | `US` | Passed to `search.list` |
+| `search.published_after_days` | `7` | Window when an interest has never been searched |
+
+Daily search call counts are stored in Rails cache (`youtube_search_api_calls:YYYY-MM-DD`). Per-interest last run lives on `FetchRun` rows keyed `youtube_search_<slug>`.
+
+## Sources UI
+
+`/sources` can add YouTube channels by:
+
+- Bare `UC…` channel ID
+- `https://www.youtube.com/channel/UC…`
+- `@handle` or `https://www.youtube.com/@handle`
+
+`YoutubeChannelValidator` resolves handles (API `channels.list` if keyed, else page scrape), verifies the Atom feed, and stores `channel_id` + `channel_name`. Channels can be toggled and deleted like Reddit sources. Built-in HN / Dev.to sources stay non-deletable.
+
+## Feed filters & article fields
+
+Videos use `content_type: "video"` with optional `duration_seconds`, `thumbnail_url`, and `author`.
+
+`GET /articles.json` / `.atom` (shared scope):
+
+| Param | Description |
+|-------|-------------|
+| `content_type` | `video` or `article` (absent = both) |
+| `max_duration` | Minutes; applied to videos only. Unknown duration stays included. Text articles untouched. |
+
+UI: content-type pills and max-length controls on the articles index; video cards show thumbnail, duration badge, and channel name.
+
+Search hits use `source_type = youtube_search_<interest_slug>`. Channel uploads use `youtube_<channel_id>`. Discovery skips any `external_id` already present from another source so the same video is not double-listed.
+
+## Operational notes
+
+- Datacenter IPs sometimes see **404/5xx** from the public Atom endpoint; treat as transient and rely on `FetchRun` health on `/sources`.
+- Atom only exposes **recent** uploads (~15), not the full channel history.
+- Invidious / Piped could be future fallbacks for environments that cannot reach YouTube; not implemented.
+- Enrichment and search degrade without failing the overall fetch when the key is missing or quota is exceeded.
+
+## Related code
+
+| Piece | Path |
+|-------|------|
+| Channel Atom fetcher | `app/services/news_fetchers/youtube_fetcher.rb` |
+| Duration/stats enricher | `app/services/youtube_video_enricher.rb` |
+| Keyword discovery | `app/services/youtube_keyword_discovery.rb` |
+| Channel validator | `app/services/youtube_channel_validator.rb` |
+| Config accessors | `app/models/news_aggregator_config.rb` |
+| YAML | `config/news_aggregator.yml` → `apis.youtube` |


### PR DESCRIPTION
## Summary
- Add `docs/YOUTUBE.md` covering Atom vs Data API paths, quota rules, setup, config keys, Sources UI, and feed filters
- Cross-link from DEVELOPMENT, REPO_STRUCTURE, KEYWORD_FILTERS, AGENT_API; clarify optional `YOUTUBE_API_KEY` in `.env.example`

Closes #388

## Test plan
- [ ] Skim `docs/YOUTUBE.md` for accuracy against `apis.youtube` config
- [ ] Confirm doc links resolve
- [ ] CI green (docs-only)
