### PR TITLE
docs: define OKF-inspired knowledge conventions (#406)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@ Guidance for AI coding agents working in this repository. Keep this file concise
 ## Read First
 
 - `CONTRIBUTING.md`: contributor entry point and pull request workflow.
+- `docs/KNOWLEDGE.md`: OKF-inspired conventions for durable project knowledge (instructions vs *why*, concept files, roadmap).
 - `docs/DEVELOPMENT.md`: setup, architecture, coding standards, test expectations, and git conventions.
 - `docs/REPO_STRUCTURE.md`: repository map. Update it in the same change when structure changes.
 - `docs/PRE_COMMIT_HOOKS.md`: Overcommit setup and local hook checks.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@ Thanks for improving Dev News Aggregator. This file is the short entry point; ke
 ## Start Here
 
 - [AGENTS.md](AGENTS.md) for AI-agent workflow, scope, and verification guardrails.
+- [docs/KNOWLEDGE.md](docs/KNOWLEDGE.md) for OKF-inspired knowledge conventions (what belongs in guides vs decision/concept docs).
 - [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) for setup, architecture, coding standards, tests, and git conventions.
 - [docs/REPO_STRUCTURE.md](docs/REPO_STRUCTURE.md) for the repository map. Update it when you change project structure.
 - [docs/PRE_COMMIT_HOOKS.md](docs/PRE_COMMIT_HOOKS.md) for Overcommit setup and local hook usage.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,6 +4,8 @@ Project-specific commands, architecture, and conventions for dev-news-aggregator
 
 For the directory map, see [REPO_STRUCTURE.md](REPO_STRUCTURE.md). **Update that file whenever you change project structure** (new folders, models, routes, migrations, etc.).
 
+For how we store durable project knowledge (guides vs decision/concept docs, OKF-inspired practices), see [KNOWLEDGE.md](KNOWLEDGE.md).
+
 ## Development commands
 
 ### Prerequisites

--- a/docs/KNOWLEDGE.md
+++ b/docs/KNOWLEDGE.md
@@ -1,0 +1,100 @@
+# Knowledge conventions (OKF-inspired)
+
+How this repo stores durable project knowledge for humans and coding agents.
+
+We borrow practices from the [Open Knowledge Format (OKF)](https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing) and [okf-gem](https://okfgem.com/), without adopting the gem or a full OKF bundle yet. Milestone: [Knowledge as code (OKF-inspired)](https://github.com/MarcosLorejan/dev-news-aggregator/milestone/20).
+
+## Instructions vs curated knowledge
+
+| Layer | Lives in | Holds |
+|-------|----------|--------|
+| Standing instructions | `AGENTS.md`, Cursor rules/skills, `CONTRIBUTING.md` | Workflow, scope, verification, “always/never” guardrails |
+| How-to guides | `docs/*.md` (e.g. `DEVELOPMENT.md`, `YOUTUBE.md`) | Setup, APIs, operational steps |
+| Curated *why* | Concept / decision files under `docs/` (see roadmap) | Trade-offs and reasoning agents cannot recover from code alone |
+| Code map | `docs/REPO_STRUCTURE.md` | Directory layout and structural maintenance rules |
+
+Do **not** dump long domain reasoning into `AGENTS.md`. Keep that file short and point here (and to focused docs) instead.
+
+`REPO_STRUCTURE.md` remains the **code** map. The knowledge map (`docs/index.md`, when added) is complementary: one-line summaries of knowledge docs, not a second file-tree.
+
+## Practices we adopt
+
+### One concept = one file
+
+Prefer focused docs (like `AGENT_API.md`, `KEYWORD_FILTERS.md`, `YOUTUBE.md`) over growing `DEVELOPMENT.md` further. New durable topics get their own file; link out instead of duplicating.
+
+### Progressive disclosure
+
+Agents should orient from a short map first, then open only the files they need.
+
+- Today: `AGENTS.md` → this file → existing guides listed in `REPO_STRUCTURE.md`
+- Next: `docs/index.md` with one line per maintained knowledge doc ([#408](https://github.com/MarcosLorejan/dev-news-aggregator/issues/408))
+
+### Links are edges
+
+Cross-link related guides and concepts with relative Markdown links. A link to a concept that does not exist yet is demand (backlog), not something to paper over. Prefer fixing or filing over leaving silent rot.
+
+### Knowledge changelog
+
+When concept docs land, keep a dated `docs/log.md` (newest first, one bullet per create/update/deprecate), same PR as the knowledge change ([#407](https://github.com/MarcosLorejan/dev-news-aggregator/issues/407)).
+
+### Light frontmatter (optional)
+
+Concept-oriented docs may use YAML frontmatter. Recommended keys:
+
+```yaml
+---
+type: Guide          # or Decision, Playbook, Concept, …
+title: Short title
+description: One-line summary for maps and listings.
+tags: [ingestion, youtube]
+resource: app/services/news_fetchers/   # code or path this knowledge describes
+---
+```
+
+`type` and `description` are the most useful. Frontmatter must stay valid YAML and must not break GitHub Markdown rendering. Do not require full OKF conformance yet.
+
+### Drift checks
+
+Prefer cheap, dependency-free checks (broken relative links, orphans missing from the knowledge map) before considering `okf validate` in CI ([#411](https://github.com/MarcosLorejan/dev-news-aggregator/issues/411), optional gem spike [#410](https://github.com/MarcosLorejan/dev-news-aggregator/issues/410)).
+
+Continue updating `REPO_STRUCTURE.md` in the same change when project structure changes (existing rule).
+
+## What we skip for now
+
+- Installing `okf` as a required dependency
+- Rewriting guides into a full `.okf/` or OKF-conformant tree
+- Graph server, registry, or Claude plugin from okf-gem
+- Replacing `REPO_STRUCTURE.md` with an OKF index
+
+Revisit only after the roadmap below is in decent shape ([#410](https://github.com/MarcosLorejan/dev-news-aggregator/issues/410)).
+
+## Writing durable *why*
+
+Capture decisions agents cannot infer from code: trade-offs, rejected alternatives, operational quirks, API thinness vs richness.
+
+Suggested shape for a concept/decision file:
+
+1. **Context** — what forced the choice  
+2. **Decision** — what we did  
+3. **Consequences** — what follows (including footguns)  
+4. Links to how-to guides + `resource:` path to code  
+
+Initial concept backlog: [#409](https://github.com/MarcosLorejan/dev-news-aggregator/issues/409).
+
+## Implementation roadmap
+
+| Step | Issue |
+|------|--------|
+| Conventions (this doc) | [#406](https://github.com/MarcosLorejan/dev-news-aggregator/issues/406) |
+| `docs/index.md` + light frontmatter on guides | [#408](https://github.com/MarcosLorejan/dev-news-aggregator/issues/408) |
+| Durable why / decision concept files | [#409](https://github.com/MarcosLorejan/dev-news-aggregator/issues/409) |
+| `docs/log.md` knowledge changelog | [#407](https://github.com/MarcosLorejan/dev-news-aggregator/issues/407) |
+| Lightweight link / orphan checks | [#411](https://github.com/MarcosLorejan/dev-news-aggregator/issues/411) |
+| Optional: evaluate `okf` gem for CI | [#410](https://github.com/MarcosLorejan/dev-news-aggregator/issues/410) |
+
+## References
+
+- [Why OKF](https://okfgem.com/docs/why-okf)
+- [Bundle anatomy](https://okfgem.com/docs/bundle-anatomy)
+- Closed milestone: [AI agent friendliness](https://github.com/MarcosLorejan/dev-news-aggregator/milestone/14)

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -2,7 +2,7 @@
 
 Living map of this codebase. **Keep this file in sync with the repo** — see [Maintenance](#maintenance) below.
 
-Last updated: 2026-08-02
+Last updated: 2026-08-03
 
 ## Maintenance
 
@@ -131,6 +131,8 @@ dev-news-aggregator/
 | `app/frontend/api/keywordFilters.ts` | Keyword filter CRUD client |
 | `app/frontend/types/keywordFilter.ts` | Keyword filter TypeScript types |
 | `app/frontend/components/InterestFilter.tsx` | Interest chip filters on the articles index |
+| `app/frontend/components/FilterToolbar.tsx` | Compact search + sort/filters dropdown chrome on the articles index |
+| `app/frontend/components/FilterMenu.tsx` | Accessible dropdown shell used by the articles filter toolbar |
 | `app/frontend/components/ContentTypeFilter.tsx` | Content type and max video duration filters on the articles index |
 | `app/frontend/components/TermChipInput.tsx` | Chip input for interest keyword terms |
 | `app/frontend/components/articleCard/VideoThumbnail.tsx` | Thumbnail, duration badge, and play affordance for video cards |
@@ -203,6 +205,7 @@ dev-news-aggregator/
 
 | File | Purpose |
 |------|---------|
+| `KNOWLEDGE.md` | OKF-inspired knowledge conventions (instructions vs curated *why*, roadmap) |
 | `DEVELOPMENT.md` | Commands, architecture, coding and git conventions |
 | `AGENT_API.md` | Versioned `/api/v1` JSON contract for agents |
 | `REPO_STRUCTURE.md` | This file — directory map and maintenance rules |
@@ -255,11 +258,12 @@ Agents should start here, then use this file as the navigation map:
 
 1. [AGENTS.md](../AGENTS.md) — work rules and verification (`bin/validate`)
 2. [CONTRIBUTING.md](../CONTRIBUTING.md) — PR workflow
-3. [DEVELOPMENT.md](DEVELOPMENT.md) — setup, commands, conventions
-4. [KEYWORD_FILTERS.md](KEYWORD_FILTERS.md) — interest/keyword feed filters
-5. [YOUTUBE.md](YOUTUBE.md) — YouTube ingestion and quota
-6. [PRE_COMMIT_HOOKS.md](PRE_COMMIT_HOOKS.md) — Overcommit setup
-7. This file — directory and entry-point map
+3. [KNOWLEDGE.md](KNOWLEDGE.md) — knowledge conventions (OKF-inspired; where *why* lives)
+4. [DEVELOPMENT.md](DEVELOPMENT.md) — setup, commands, conventions
+5. [KEYWORD_FILTERS.md](KEYWORD_FILTERS.md) — interest/keyword feed filters
+6. [YOUTUBE.md](YOUTUBE.md) — YouTube ingestion and quota
+7. [PRE_COMMIT_HOOKS.md](PRE_COMMIT_HOOKS.md) — Overcommit setup
+8. This file — directory and entry-point map
 
 ## Routes (summary)
 


### PR DESCRIPTION
## Summary
- Add `docs/KNOWLEDGE.md` documenting OKF-inspired practices we adopt (and skip) without requiring the `okf` gem
- Point `AGENTS.md`, `CONTRIBUTING.md`, `DEVELOPMENT.md`, and `REPO_STRUCTURE.md` at the new conventions
- List the milestone roadmap (#408–#411, #407, #410) as the implementation path

Closes #406

## Test plan
- [ ] Skim `docs/KNOWLEDGE.md` for clarity and alignment with existing docs layout
- [ ] Confirm agent/contributor entry points link correctly
- [ ] No app/runtime behavior change (docs only)