### PR TITLE
docs: add knowledge map and light frontmatter (#408)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@ Guidance for AI coding agents working in this repository. Keep this file concise
 
 ## Read First
 
+- `docs/index.md`: knowledge map (one line per doc — start here for orientation).
 - `CONTRIBUTING.md`: contributor entry point and pull request workflow.
 - `docs/KNOWLEDGE.md`: OKF-inspired conventions for durable project knowledge (instructions vs *why*, concept files, roadmap).
 - `docs/DEVELOPMENT.md`: setup, architecture, coding standards, test expectations, and git conventions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,7 @@ Thanks for improving Dev News Aggregator. This file is the short entry point; ke
 
 ## Start Here
 
+- [docs/index.md](docs/index.md) for the knowledge map (one-line purpose per doc).
 - [AGENTS.md](AGENTS.md) for AI-agent workflow, scope, and verification guardrails.
 - [docs/KNOWLEDGE.md](docs/KNOWLEDGE.md) for OKF-inspired knowledge conventions (what belongs in guides vs decision/concept docs).
 - [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) for setup, architecture, coding standards, tests, and git conventions.

--- a/docs/AGENT_API.md
+++ b/docs/AGENT_API.md
@@ -1,3 +1,11 @@
+---
+type: Guide
+title: Agent API (v1)
+description: Stable /api/v1 JSON contract for machine clients and coding agents.
+tags: [api, agents]
+resource: app/controllers/api/v1/
+---
+
 # Agent API (v1)
 
 Stable JSON contract for machine clients and coding agents. Prefer these

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,10 +1,17 @@
+---
+type: Guide
+title: Development guide
+description: Setup, architecture, coding standards, tests, and git conventions.
+tags: [development, setup]
+---
+
 # Development Guide
 
 Project-specific commands, architecture, and conventions for dev-news-aggregator.
 
 For the directory map, see [REPO_STRUCTURE.md](REPO_STRUCTURE.md). **Update that file whenever you change project structure** (new folders, models, routes, migrations, etc.).
 
-For how we store durable project knowledge (guides vs decision/concept docs, OKF-inspired practices), see [KNOWLEDGE.md](KNOWLEDGE.md).
+For orientation across docs, start at [index.md](index.md). For how we store durable project knowledge (guides vs decision/concept docs, OKF-inspired practices), see [KNOWLEDGE.md](KNOWLEDGE.md).
 
 ## Development commands
 

--- a/docs/KEYWORD_FILTERS.md
+++ b/docs/KEYWORD_FILTERS.md
@@ -1,3 +1,11 @@
+---
+type: Guide
+title: Keyword interests and filtering
+description: Interest presets, keyword query params, and how they combine with category and tag filters.
+tags: [filtering, interests, api]
+resource: app/models/keyword_filter.rb
+---
+
 # Keyword interests & filtering
 
 Drive the feed from personal topics (ruby, rails, rust, software architecture, AI performance) in addition to source categories and free-text search.

--- a/docs/KNOWLEDGE.md
+++ b/docs/KNOWLEDGE.md
@@ -1,3 +1,10 @@
+---
+type: Guide
+title: Knowledge conventions (OKF-inspired)
+description: What we borrow from OKF for durable project knowledge without requiring the okf gem.
+tags: [knowledge, agents, conventions]
+---
+
 # Knowledge conventions (OKF-inspired)
 
 How this repo stores durable project knowledge for humans and coding agents.
@@ -15,7 +22,7 @@ We borrow practices from the [Open Knowledge Format (OKF)](https://cloud.google.
 
 Do **not** dump long domain reasoning into `AGENTS.md`. Keep that file short and point here (and to focused docs) instead.
 
-`REPO_STRUCTURE.md` remains the **code** map. The knowledge map (`docs/index.md`, when added) is complementary: one-line summaries of knowledge docs, not a second file-tree.
+`REPO_STRUCTURE.md` remains the **code** map. The knowledge map ([index.md](index.md)) is complementary: one-line summaries of knowledge docs, not a second file-tree.
 
 ## Practices we adopt
 
@@ -27,8 +34,9 @@ Prefer focused docs (like `AGENT_API.md`, `KEYWORD_FILTERS.md`, `YOUTUBE.md`) ov
 
 Agents should orient from a short map first, then open only the files they need.
 
-- Today: `AGENTS.md` → this file → existing guides listed in `REPO_STRUCTURE.md`
-- Next: `docs/index.md` with one line per maintained knowledge doc ([#408](https://github.com/MarcosLorejan/dev-news-aggregator/issues/408))
+- Start: [index.md](index.md) (one line per doc)
+- Then: [AGENTS.md](../AGENTS.md) → this file → focused guides as needed
+- Code layout stays in [REPO_STRUCTURE.md](REPO_STRUCTURE.md)
 
 ### Links are edges
 

--- a/docs/PRE_COMMIT_HOOKS.md
+++ b/docs/PRE_COMMIT_HOOKS.md
@@ -1,3 +1,11 @@
+---
+type: Guide
+title: Pre-commit hooks setup
+description: Overcommit install and Conventional Commits enforcement for local hooks.
+tags: [tooling, git, overcommit]
+resource: .overcommit.yml
+---
+
 # Pre-commit Hooks Setup
 
 This project uses [Overcommit](https://github.com/sds/overcommit) to manage Git hooks that run automatically before commits and when writing commit messages.

--- a/docs/REACT_SETUP.md
+++ b/docs/REACT_SETUP.md
@@ -1,3 +1,11 @@
+---
+type: Guide
+title: React with Vite setup
+description: Frontend install, Vite HMR, and two-process local development.
+tags: [frontend, vite, react]
+resource: app/frontend/
+---
+
 # React with Vite Setup
 
 This project now uses React with Vite for the frontend.

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -1,3 +1,10 @@
+---
+type: Map
+title: Repository structure
+description: Living directory map and structural maintenance rules for this codebase.
+tags: [structure, map]
+---
+
 # Repository Structure
 
 Living map of this codebase. **Keep this file in sync with the repo** — see [Maintenance](#maintenance) below.
@@ -205,6 +212,7 @@ dev-news-aggregator/
 
 | File | Purpose |
 |------|---------|
+| `index.md` | Knowledge map — one-line purpose per maintained doc |
 | `KNOWLEDGE.md` | OKF-inspired knowledge conventions (instructions vs curated *why*, roadmap) |
 | `DEVELOPMENT.md` | Commands, architecture, coding and git conventions |
 | `AGENT_API.md` | Versioned `/api/v1` JSON contract for agents |
@@ -256,14 +264,15 @@ dev-news-aggregator/
 
 Agents should start here, then use this file as the navigation map:
 
-1. [AGENTS.md](../AGENTS.md) — work rules and verification (`bin/validate`)
-2. [CONTRIBUTING.md](../CONTRIBUTING.md) — PR workflow
-3. [KNOWLEDGE.md](KNOWLEDGE.md) — knowledge conventions (OKF-inspired; where *why* lives)
-4. [DEVELOPMENT.md](DEVELOPMENT.md) — setup, commands, conventions
-5. [KEYWORD_FILTERS.md](KEYWORD_FILTERS.md) — interest/keyword feed filters
-6. [YOUTUBE.md](YOUTUBE.md) — YouTube ingestion and quota
-7. [PRE_COMMIT_HOOKS.md](PRE_COMMIT_HOOKS.md) — Overcommit setup
-8. This file — directory and entry-point map
+1. [index.md](index.md) — knowledge map (one line per doc)
+2. [AGENTS.md](../AGENTS.md) — work rules and verification (`bin/validate`)
+3. [CONTRIBUTING.md](../CONTRIBUTING.md) — PR workflow
+4. [KNOWLEDGE.md](KNOWLEDGE.md) — knowledge conventions (OKF-inspired; where *why* lives)
+5. [DEVELOPMENT.md](DEVELOPMENT.md) — setup, commands, conventions
+6. [KEYWORD_FILTERS.md](KEYWORD_FILTERS.md) — interest/keyword feed filters
+7. [YOUTUBE.md](YOUTUBE.md) — YouTube ingestion and quota
+8. [PRE_COMMIT_HOOKS.md](PRE_COMMIT_HOOKS.md) — Overcommit setup
+9. This file — directory and entry-point map
 
 ## Routes (summary)
 

--- a/docs/SUMMARIZER.md
+++ b/docs/SUMMARIZER.md
@@ -1,3 +1,11 @@
+---
+type: Guide
+title: Optional article summarizer
+description: Pluggable providers (none, heuristic, openai, ollama) for article show summaries.
+tags: [summarizer, optional]
+resource: app/services/
+---
+
 # Optional article summarizer
 
 Pluggable short summaries for article show pages. Disabled by default so the core app never depends on an LLM.

--- a/docs/YOUTUBE.md
+++ b/docs/YOUTUBE.md
@@ -1,3 +1,11 @@
+---
+type: Guide
+title: YouTube ingestion
+description: Channel Atom vs Data API paths, quota strategy, and Sources UI.
+tags: [ingestion, youtube]
+resource: app/services/news_fetchers/
+---
+
 # YouTube ingestion
 
 Short developer videos in the same feed as HN / Dev.to / Reddit. Two paths with very different quota profiles — prefer Atom for channels; treat Data API search as a scarce budget.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,34 @@
+# Knowledge map
+
+One-line index of maintained project knowledge. Orient here, then open only what you need.
+
+Conventions: [KNOWLEDGE.md](KNOWLEDGE.md). Code layout: [REPO_STRUCTURE.md](REPO_STRUCTURE.md). Agent workflow: [../AGENTS.md](../AGENTS.md).
+
+## Entry points
+
+| Doc | Purpose |
+|-----|---------|
+| [KNOWLEDGE.md](KNOWLEDGE.md) | OKF-inspired conventions: instructions vs curated *why*, roadmap |
+| [DEVELOPMENT.md](DEVELOPMENT.md) | Setup, architecture, coding standards, tests, git workflow |
+| [REPO_STRUCTURE.md](REPO_STRUCTURE.md) | Living directory map; update when structure changes |
+| [../AGENTS.md](../AGENTS.md) | Standing instructions for coding agents (`bin/validate`, scope) |
+| [../CONTRIBUTING.md](../CONTRIBUTING.md) | Contributor entry point and PR workflow |
+
+## Guides
+
+| Doc | Purpose |
+|-----|---------|
+| [REACT_SETUP.md](REACT_SETUP.md) | React/Vite frontend install and two-process dev |
+| [AGENT_API.md](AGENT_API.md) | Stable `/api/v1` JSON contract for agents |
+| [KEYWORD_FILTERS.md](KEYWORD_FILTERS.md) | Interest presets, keyword query params, feed filters |
+| [YOUTUBE.md](YOUTUBE.md) | Channel Atom vs Data API, quota, Sources UI |
+| [SUMMARIZER.md](SUMMARIZER.md) | Optional pluggable article summarizer providers |
+| [PRE_COMMIT_HOOKS.md](PRE_COMMIT_HOOKS.md) | Overcommit setup, Conventional Commits hooks |
+
+## Planned (milestone)
+
+| Area | Issue |
+|------|--------|
+| Decision / *why* concept files | [#409](https://github.com/MarcosLorejan/dev-news-aggregator/issues/409) |
+| Knowledge changelog (`log.md`) | [#407](https://github.com/MarcosLorejan/dev-news-aggregator/issues/407) |
+| Link / orphan drift checks | [#411](https://github.com/MarcosLorejan/dev-news-aggregator/issues/411) |


### PR DESCRIPTION
﻿## Summary
- Add `docs/index.md` as the progressive-disclosure knowledge map (one line per doc)
- Add light YAML frontmatter (`type`, `title`, `description`, `tags`, `resource`) to maintained guides
- Point `AGENTS.md`, `CONTRIBUTING.md`, `DEVELOPMENT.md`, `KNOWLEDGE.md`, and `REPO_STRUCTURE.md` at the map

Closes #408

## Depends on
- #414 / #406 (knowledge conventions) — this PR is branched from `docs/406-okf-knowledge-conventions`

## Test plan
- [ ] Open `docs/index.md` and confirm every current guide is listed
- [ ] Spot-check a guide on GitHub: frontmatter + H1 still readable
- [ ] Confirm agent/contributor entry points mention the map first
