### PR TITLE
docs: capture durable why-knowledge as decision files (#409)

### DIFF
--- a/docs/AGENT_API.md
+++ b/docs/AGENT_API.md
@@ -11,6 +11,8 @@ resource: app/controllers/api/v1/
 Stable JSON contract for machine clients and coding agents. Prefer these
 routes over scraping the HTML UI.
 
+*Why a thinner `/api/v1`:* [decisions/agent-api-thin-contract.md](decisions/agent-api-thin-contract.md).
+
 Base path: `/api/v1`
 
 ## Auth and rate limits

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -57,7 +57,7 @@ SOLID_QUEUE_IN_PUMA=1 bin/rails server
 # Or double-click start-app.bat in Explorer (same thing)
 ```
 
-Note: on Windows, `SOLID_QUEUE_IN_PUMA` is **not** used — Solid Queue’s Puma plugin requires `fork()`, which Windows does not support. The web app still runs; background jobs (e.g. delayed dismissal cleanup) won’t process until you run workers on a Unix-like environment.
+Note: on Windows, `SOLID_QUEUE_IN_PUMA` is **not** used — Solid Queue’s Puma plugin requires `fork()`, which Windows does not support. The web app still runs; background jobs (e.g. delayed dismissal cleanup) won’t process until you run workers on a Unix-like environment. *Why:* [decisions/solid-queue-windows.md](decisions/solid-queue-windows.md).
 
 Development uses `skipProxy: true` in `config/vite.json` so the browser loads Vite assets directly from port 3036. That avoids blank pages caused by Vite’s many module requests queueing behind a few Puma threads.
 
@@ -191,7 +191,7 @@ whenever --clear-crontab
 
 ### Core components
 
-**NewsAggregatorService**: Central orchestrator that coordinates all news fetchers. Builds the fetcher list from enabled `NewsSource` records when present, otherwise from `config/news_aggregator.yml` (Hacker News, Dev.to, configured Reddit subreddits, and YouTube channels). Handles error logging and aggregates results.
+**NewsAggregatorService**: Central orchestrator that coordinates all news fetchers. Builds the fetcher list from enabled `NewsSource` records when present, otherwise from `config/news_aggregator.yml` (Hacker News, Dev.to, configured Reddit subreddits, and YouTube channels). Handles error logging and aggregates results. *Why this split:* [decisions/fetch-orchestration.md](decisions/fetch-orchestration.md).
 
 **NewsAggregatorConfig**: Loads `config/news_aggregator.yml` via `Rails.application.config_for`. Provides fetching limits (`max_articles_per_source`), retention settings, Reddit/YouTube source lists, and API endpoint metadata. Fetchers read article limits from config; `news:clean` uses configured retention days.
 

--- a/docs/KEYWORD_FILTERS.md
+++ b/docs/KEYWORD_FILTERS.md
@@ -10,6 +10,8 @@ resource: app/models/keyword_filter.rb
 
 Drive the feed from personal topics (ruby, rails, rust, software architecture, AI performance) in addition to source categories and free-text search.
 
+*Why presets + query params:* [decisions/keyword-interests.md](decisions/keyword-interests.md).
+
 ## Concepts
 
 | Mechanism | What it is | Where it lives |

--- a/docs/KNOWLEDGE.md
+++ b/docs/KNOWLEDGE.md
@@ -17,7 +17,7 @@ We borrow practices from the [Open Knowledge Format (OKF)](https://cloud.google.
 |-------|----------|--------|
 | Standing instructions | `AGENTS.md`, Cursor rules/skills, `CONTRIBUTING.md` | Workflow, scope, verification, “always/never” guardrails |
 | How-to guides | `docs/*.md` (e.g. `DEVELOPMENT.md`, `YOUTUBE.md`) | Setup, APIs, operational steps |
-| Curated *why* | Concept / decision files under `docs/` (see roadmap) | Trade-offs and reasoning agents cannot recover from code alone |
+| Curated *why* | `docs/decisions/` (and future concept files) | Trade-offs and reasoning agents cannot recover from code alone |
 | Code map | `docs/REPO_STRUCTURE.md` | Directory layout and structural maintenance rules |
 
 Do **not** dump long domain reasoning into `AGENTS.md`. Keep that file short and point here (and to focused docs) instead.
@@ -88,7 +88,7 @@ Suggested shape for a concept/decision file:
 3. **Consequences** — what follows (including footguns)  
 4. Links to how-to guides + `resource:` path to code  
 
-Initial concept backlog: [#409](https://github.com/MarcosLorejan/dev-news-aggregator/issues/409).
+Initial decision set: [docs/decisions/](decisions/) ([#409](https://github.com/MarcosLorejan/dev-news-aggregator/issues/409)).
 
 ## Implementation roadmap
 

--- a/docs/REACT_SETUP.md
+++ b/docs/REACT_SETUP.md
@@ -10,6 +10,8 @@ resource: app/frontend/
 
 This project now uses React with Vite for the frontend.
 
+*Why this shape:* [decisions/react-vite-two-process.md](decisions/react-vite-two-process.md).
+
 ## Prerequisites
 
 - Ruby 3.3.x (see `.ruby-version`) and Bundler

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -222,6 +222,7 @@ dev-news-aggregator/
 | `SUMMARIZER.md` | Optional pluggable article summarizer (env, providers, caching) |
 | `KEYWORD_FILTERS.md` | Interest/keyword feed filters and articles index API params |
 | `YOUTUBE.md` | YouTube Atom vs Data API paths, quota strategy, config, Sources UI |
+| `decisions/` | Durable *why* decision records (Context / Decision / Consequences) |
 
 ## `.github/`
 
@@ -269,10 +270,11 @@ Agents should start here, then use this file as the navigation map:
 3. [CONTRIBUTING.md](../CONTRIBUTING.md) — PR workflow
 4. [KNOWLEDGE.md](KNOWLEDGE.md) — knowledge conventions (OKF-inspired; where *why* lives)
 5. [DEVELOPMENT.md](DEVELOPMENT.md) — setup, commands, conventions
-6. [KEYWORD_FILTERS.md](KEYWORD_FILTERS.md) — interest/keyword feed filters
-7. [YOUTUBE.md](YOUTUBE.md) — YouTube ingestion and quota
-8. [PRE_COMMIT_HOOKS.md](PRE_COMMIT_HOOKS.md) — Overcommit setup
-9. This file — directory and entry-point map
+6. [index.md](index.md) Decisions section — durable *why* under `docs/decisions/`
+7. [KEYWORD_FILTERS.md](KEYWORD_FILTERS.md) — interest/keyword feed filters
+8. [YOUTUBE.md](YOUTUBE.md) — YouTube ingestion and quota
+9. [PRE_COMMIT_HOOKS.md](PRE_COMMIT_HOOKS.md) — Overcommit setup
+10. This file — directory and entry-point map
 
 ## Routes (summary)
 

--- a/docs/YOUTUBE.md
+++ b/docs/YOUTUBE.md
@@ -10,6 +10,8 @@ resource: app/services/news_fetchers/
 
 Short developer videos in the same feed as HN / Dev.to / Reddit. Two paths with very different quota profiles — prefer Atom for channels; treat Data API search as a scarce budget.
 
+*Why Atom first:* [decisions/youtube-atom-first.md](decisions/youtube-atom-first.md).
+
 ## Two ingestion paths
 
 | Path | How | API key? | Quota | What you get |

--- a/docs/decisions/agent-api-thin-contract.md
+++ b/docs/decisions/agent-api-thin-contract.md
@@ -1,0 +1,30 @@
+---
+type: Decision
+title: Agent API v1 is a thinner contract than articles JSON
+description: Why /api/v1 stays a stable, smaller surface than the rich HTML/JSON feed.
+tags: [api, agents, decision]
+resource: app/controllers/api/v1/
+---
+
+# Agent API v1 is a thinner contract than articles JSON
+
+## Context
+
+The HTML/JSON articles index accumulated many filters (interests, content type, duration, tags, scores). Machine clients need a **stable**, predictable contract. Mirroring every UI param onto `/api/v1` would couple agents to a moving feed surface and complicate auth/rate-limit semantics.
+
+## Decision
+
+- Ship a dedicated `/api/v1` under `ActionController::API` (no CSRF / `allow_browser`).
+- Keep v1 list/search params intentionally small (`q`, `sort`, `show_read`, pagination).
+- Leave richer feed filters on `/articles.json` / `.atom` until explicitly versioned onto the agent API.
+- Mutations (bookmark/dismiss) use optional HTTP Basic + Rack::Attack limits.
+
+## Consequences
+
+- Agents should prefer `/api/v1` over scraping HTML, but must not assume parity with the SPA feed.
+- Expanding v1 is a conscious API change — document in [AGENT_API.md](../AGENT_API.md); do not silently copy every `ArticlesController` param.
+- UI and agent clients can evolve on different clocks.
+
+## See also
+
+- How-to: [AGENT_API.md](../AGENT_API.md), [KEYWORD_FILTERS.md](../KEYWORD_FILTERS.md)

--- a/docs/decisions/fetch-orchestration.md
+++ b/docs/decisions/fetch-orchestration.md
@@ -1,0 +1,29 @@
+---
+type: Decision
+title: Fetch orchestration vs per-source fetchers
+description: Why NewsAggregatorService orchestrates and each source has its own fetcher object.
+tags: [ingestion, architecture, decision]
+resource: app/services/news_aggregator_service.rb
+---
+
+# Fetch orchestration vs per-source fetchers
+
+## Context
+
+The app ingests many heterogeneous APIs (HN, Dev.to, Reddit Atom/OAuth, YouTube Atom/API). Putting HTTP, parsing, and persistence for every source in one class made failures opaque and new sources expensive.
+
+## Decision
+
+- `NewsAggregatorService` orchestrates: build fetcher list from enabled `NewsSource` rows (else YAML defaults), rescue/log per source, aggregate results.
+- Each source implements a focused fetcher under `app/services/news_fetchers/` (and related enrichers/discovery services for YouTube).
+- `NewsSource#build_fetcher` (and defaults) is the wiring point for new sources.
+
+## Consequences
+
+- Prefer adding or fixing a fetcher over growing the orchestrator with source-specific branches.
+- Per-source `FetchRun` status on the Sources page is intentional — orchestrator success ≠ every source succeeded.
+- YouTube keyword discovery/enrichment can run as sibling steps in `FetchNewsJob` without stuffing them into `YoutubeFetcher`.
+
+## See also
+
+- How-to: [DEVELOPMENT.md](../DEVELOPMENT.md) (architecture / adding sources), [YOUTUBE.md](../YOUTUBE.md)

--- a/docs/decisions/keyword-interests.md
+++ b/docs/decisions/keyword-interests.md
@@ -1,0 +1,29 @@
+---
+type: Decision
+title: Keyword interests as presets plus query params
+description: Why topic filtering uses saved KeywordFilter presets and URL params, not only source categories.
+tags: [filtering, interests, decision]
+resource: app/models/keyword_filter.rb
+---
+
+# Keyword interests as presets plus query params
+
+## Context
+
+Source categories (HN, Dev.to, Reddit, …) group *where* an item came from. Personal reading is driven by *topics* (ruby, rails, rust, architecture) that cut across sources. Encoding topics only as categories or one-off `q=` searches made presets and shareable URLs awkward.
+
+## Decision
+
+- Persist named presets as `KeywordFilter` rows (name + terms).
+- Filter the feed with query params (`keywords`, `interest` / `interests`, `match`) that AND with category/tag/score filters.
+- Manage presets at `/interests`; keep free-text `q` as orthogonal search.
+
+## Consequences
+
+- Agents and Atom clients must learn interest params separately from categories — see the guide, not only `source_type`.
+- Matching is title + description term logic, not embeddings; tune terms, not model weights.
+- Do not collapse interests into `ArticlesHelper::CATEGORIES`; they solve different jobs.
+
+## See also
+
+- How-to: [KEYWORD_FILTERS.md](../KEYWORD_FILTERS.md)

--- a/docs/decisions/react-vite-two-process.md
+++ b/docs/decisions/react-vite-two-process.md
@@ -1,0 +1,29 @@
+---
+type: Decision
+title: React SPA with Vite two-process development
+description: Why the UI is a Vite React SPA with a separate HMR process, not asset-pipeline-only.
+tags: [frontend, vite, react, decision]
+resource: app/frontend/
+---
+
+# React SPA with Vite two-process development
+
+## Context
+
+The app needed a responsive SPA for filtering, bookmarks, and source management. Shipping that through the classic Rails asset pipeline alone made HMR slow and left blank-page failure modes when many module requests queued behind a few Puma threads.
+
+## Decision
+
+- Frontend lives under `app/frontend/` as a React + Vite app.
+- Local full stack runs **two processes**: Vite (HMR, port 3036) and Rails (port 3000). `bin/dev` stays Rails-only on purpose.
+- Development uses `skipProxy: true` in `config/vite.json` so the browser talks to Vite directly.
+
+## Consequences
+
+- Contributors (and agents) who only start `bin/dev` get Rails without the React UI — use `npm run dev` + Rails, or `.\dev.ps1` / `start-app.bat` on Windows.
+- Deploy still builds Vite assets into the Rails image; the two-process split is a **dev** ergonomics choice.
+- Frontend and Rails change at different cadences; keep API contracts and page props explicit.
+
+## See also
+
+- How-to: [REACT_SETUP.md](../REACT_SETUP.md), [DEVELOPMENT.md](../DEVELOPMENT.md)

--- a/docs/decisions/solid-queue-windows.md
+++ b/docs/decisions/solid-queue-windows.md
@@ -1,0 +1,29 @@
+---
+type: Decision
+title: Solid Queue and dismissal jobs on Windows
+description: Why SOLID_QUEUE_IN_PUMA is unused on Windows and what that means for delayed jobs.
+tags: [jobs, windows, solid-queue, decision]
+resource: config/queue.yml
+---
+
+# Solid Queue and dismissal jobs on Windows
+
+## Context
+
+Active Job uses Solid Queue. In Unix development, `SOLID_QUEUE_IN_PUMA=1` runs the supervisor inside Puma via `fork()`. Windows does not provide `fork()`, so that plugin path is not available on typical local Windows setups.
+
+## Decision
+
+- Document and script Unix-friendly `SOLID_QUEUE_IN_PUMA=1 bin/rails server` (or `bin/jobs`) for background work.
+- On Windows, `.\dev.ps1` / full-stack helpers start web + Vite **without** assuming in-Puma Solid Queue.
+- Production (Kamal/Linux) keeps a real queue DB and Solid Queue enabled.
+
+## Consequences
+
+- Local Windows: dismiss-and-cleanup style jobs may not run until workers run on Unix (WSL, CI, or deploy).
+- Do not “fix” Windows by forcing the Puma plugin — use a separate job process on a fork-capable environment instead.
+- Agents debugging stuck dismissals should check OS + whether a queue worker is actually running.
+
+## See also
+
+- How-to: [DEVELOPMENT.md](../DEVELOPMENT.md)

--- a/docs/decisions/youtube-atom-first.md
+++ b/docs/decisions/youtube-atom-first.md
@@ -1,0 +1,29 @@
+---
+type: Decision
+title: YouTube channel Atom before Data API
+description: Why channel uploads use public Atom feeds first and treat Data API search as a scarce budget.
+tags: [ingestion, youtube, decision]
+resource: app/services/news_fetchers/youtube_fetcher.rb
+---
+
+# YouTube channel Atom before Data API
+
+## Context
+
+YouTube Data API quota is easy to burn (`search.list` especially). The product goal is “short relevant videos in the same feed,” which mostly means **known channels’ uploads**, not open-ended search on every fetch.
+
+## Decision
+
+- Default path: public channel Atom (`feeds/videos.xml?channel_id=…`) — no API key, no quota.
+- Optional `YOUTUBE_API_KEY`: batch `videos.list` enrichment (duration/stats) and opt-in, budgeted `search.list` discovery.
+- Never run keyword discovery on the same cadence as hourly Atom/RSS fetches.
+
+## Consequences
+
+- Without a key, videos appear without duration until enrichment is configured.
+- Agents debugging “missing duration” or “no discovery” should check key + config flags, not assume Atom is broken.
+- Adding channels at `/sources` is the scalable path; search is a scarce supplement.
+
+## See also
+
+- How-to: [YOUTUBE.md](../YOUTUBE.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,10 +25,20 @@ Conventions: [KNOWLEDGE.md](KNOWLEDGE.md). Code layout: [REPO_STRUCTURE.md](REPO
 | [SUMMARIZER.md](SUMMARIZER.md) | Optional pluggable article summarizer providers |
 | [PRE_COMMIT_HOOKS.md](PRE_COMMIT_HOOKS.md) | Overcommit setup, Conventional Commits hooks |
 
+## Decisions (*why*)
+
+| Doc | Purpose |
+|-----|---------|
+| [decisions/react-vite-two-process.md](decisions/react-vite-two-process.md) | Why Vite SPA + two-process local dev |
+| [decisions/keyword-interests.md](decisions/keyword-interests.md) | Why interests are presets + query params |
+| [decisions/agent-api-thin-contract.md](decisions/agent-api-thin-contract.md) | Why `/api/v1` stays thinner than the rich feed |
+| [decisions/youtube-atom-first.md](decisions/youtube-atom-first.md) | Why channel Atom precedes Data API search |
+| [decisions/solid-queue-windows.md](decisions/solid-queue-windows.md) | Why Solid Queue in Puma is skipped on Windows |
+| [decisions/fetch-orchestration.md](decisions/fetch-orchestration.md) | Why orchestrator vs per-source fetchers |
+
 ## Planned (milestone)
 
 | Area | Issue |
 |------|--------|
-| Decision / *why* concept files | [#409](https://github.com/MarcosLorejan/dev-news-aggregator/issues/409) |
 | Knowledge changelog (`log.md`) | [#407](https://github.com/MarcosLorejan/dev-news-aggregator/issues/407) |
 | Link / orphan drift checks | [#411](https://github.com/MarcosLorejan/dev-news-aggregator/issues/411) |


### PR DESCRIPTION
﻿## Summary
- Add six durable decision records under `docs/decisions/` (Context / Decision / Consequences)
- Link them from `docs/index.md` and the related how-to guides (no duplicated how-to content)
- Update `REPO_STRUCTURE.md` / `KNOWLEDGE.md` for the new tree

Closes #409

## Decisions
- React SPA + Vite two-process
- Keyword interests as presets + query params
- Agent API v1 thinner than `/articles.json`
- YouTube Atom before Data API
- Solid Queue / Windows `fork` limitation
- Fetch orchestration vs per-source fetchers

## Depends on
- #421 / #408 (knowledge map) — this PR is branched from `docs/408-knowledge-map`
- #414 / #406 (conventions)

## Test plan
- [ ] Skim each file under `docs/decisions/` for accuracy
- [ ] Confirm `docs/index.md` Decisions table lists all six
- [ ] Confirm guides only link out (no copy-paste of how-to)
