### PR TITLE
fix(fetch): harden multi-source polling against aggressive rate limits (#422)

### DIFF
--- a/app/models/news_aggregator_config.rb
+++ b/app/models/news_aggregator_config.rb
@@ -41,11 +41,15 @@ module NewsAggregatorConfig
     end
 
     def reddit_min_request_interval_seconds
-      config.dig(:apis, :reddit, :min_request_interval_seconds) || 2.5
+      config.dig(:apis, :reddit, :min_request_interval_seconds) || 60
     end
 
     def reddit_rate_limit_max_retries
       config.dig(:apis, :reddit, :rate_limit_max_retries) || 4
+    end
+
+    def reddit_rate_limit_max_wait_seconds
+      config.dig(:apis, :reddit, :rate_limit_max_wait_seconds) || 90
     end
 
     def hacker_news_base_url
@@ -81,6 +85,10 @@ module NewsAggregatorConfig
 
     def youtube_rate_limit_max_retries
       config.dig(:apis, :youtube, :rate_limit_max_retries) || 4
+    end
+
+    def youtube_rate_limit_max_wait_seconds
+      config.dig(:apis, :youtube, :rate_limit_max_wait_seconds) || 90
     end
 
     def youtube_feed_base_url

--- a/app/services/news_fetchers/base_fetcher.rb
+++ b/app/services/news_fetchers/base_fetcher.rb
@@ -3,6 +3,16 @@ class NewsFetchers::BaseFetcher
 
   class FetchError < StandardError; end
 
+  class RateLimitedError < FetchError
+    attr_reader :http_status, :retry_after_seconds
+
+    def initialize(message, http_status:, retry_after_seconds: nil)
+      super(message)
+      @http_status = http_status
+      @retry_after_seconds = retry_after_seconds
+    end
+  end
+
   RETRYABLE_ERRORS = [
     Net::OpenTimeout,
     Net::ReadTimeout,
@@ -12,6 +22,22 @@ class NewsFetchers::BaseFetcher
   ].freeze
 
   class << self
+    attr_writer :retry_jitter_factor
+
+    def retry_jitter_factor
+      @retry_jitter_factor.nil? ? 0.25 : @retry_jitter_factor
+    end
+
+    def with_jitter(seconds, factor: retry_jitter_factor)
+      base = seconds.to_f
+      return 0.0 if base <= 0
+
+      jitter = factor.to_f
+      return base if jitter <= 0
+
+      base + (rand * jitter * base)
+    end
+
     def get(*args, **kwargs)
       kwargs[:timeout] = NewsAggregatorConfig.request_timeout unless kwargs.key?(:timeout)
 
@@ -24,8 +50,35 @@ class NewsFetchers::BaseFetcher
         attempt += 1
         raise if attempt >= max_attempts
 
-        sleep(2**(attempt - 1))
+        Kernel.sleep(with_jitter(2**(attempt - 1)))
         retry
+      end
+    end
+
+    def parse_retry_after_seconds(response)
+      headers = http_headers(response)
+      retry_after = header_value(headers, "Retry-After")
+      if retry_after.present?
+        return retry_after.to_f if retry_after.to_s.match?(/\A\d+(\.\d+)?\z/)
+
+        begin
+          return [ Time.httpdate(retry_after.to_s) - Time.now, 0 ].max
+        rescue ArgumentError
+          # Fall through to x-ratelimit-reset.
+        end
+      end
+
+      reset = header_value(headers, "x-ratelimit-reset")
+      return nil if reset.blank?
+
+      value = reset.to_f
+      return nil if value <= 0
+
+      # Absolute unix timestamp vs relative seconds-until-reset.
+      if value > 1_000_000_000
+        [ value - Time.now.to_f, 0 ].max
+      else
+        value
       end
     end
 
@@ -36,13 +89,44 @@ class NewsFetchers::BaseFetcher
 
       unless response.success?
         body_preview = response.body.to_s.gsub(/\s+/, " ").strip[0, 200]
-        raise FetchError,
-              "HTTP #{response.code} for #{response.request&.uri}: #{body_preview.presence || '(empty body)'}"
+        message = "HTTP #{response.code} for #{response.request&.uri}: #{body_preview.presence || '(empty body)'}"
+        code = response.code.to_i
+
+        if code == 429
+          raise RateLimitedError.new(
+            message,
+            http_status: code,
+            retry_after_seconds: parse_retry_after_seconds(response)
+          )
+        end
+
+        raise FetchError, message
       end
 
       response.parsed_response
     rescue JSON::ParserError => e
       raise FetchError, "Invalid JSON response: #{e.message}"
+    end
+
+    def http_headers(response)
+      return {} unless response.respond_to?(:headers)
+
+      response.headers || {}
+    end
+
+    def header_value(headers, name)
+      return nil if headers.blank?
+
+      if headers.respond_to?(:[])
+        value = headers[name] || headers[name.downcase] || headers[name.upcase]
+        return Array(value).first if value
+      end
+
+      headers.each do |key, value|
+        return Array(value).first if key.to_s.casecmp?(name)
+      end
+
+      nil
     end
   end
 

--- a/app/services/news_fetchers/reddit_fetcher.rb
+++ b/app/services/news_fetchers/reddit_fetcher.rb
@@ -8,10 +8,15 @@ class NewsFetchers::RedditFetcher < NewsFetchers::BaseFetcher
   headers "User-Agent" => USER_AGENT
 
   class << self
-    attr_writer :min_request_interval_seconds, :access_token, :access_token_expires_at, :rate_limit_backoff_seconds
+    attr_writer :min_request_interval_seconds, :access_token, :access_token_expires_at,
+                :rate_limit_backoff_seconds, :rate_limit_jitter_factor
 
     def min_request_interval_seconds
       @min_request_interval_seconds || NewsAggregatorConfig.reddit_min_request_interval_seconds
+    end
+
+    def rate_limit_jitter_factor
+      @rate_limit_jitter_factor.nil? ? 0.25 : @rate_limit_jitter_factor
     end
 
     def rate_limit_backoff_seconds(attempt)
@@ -38,7 +43,7 @@ class NewsFetchers::RedditFetcher < NewsFetchers::BaseFetcher
         now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         if @last_request_at
           wait = min_request_interval_seconds - (now - @last_request_at)
-          sleep(wait) if wait.positive?
+          Kernel.sleep(wait) if wait.positive?
         end
         @last_request_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       end
@@ -174,8 +179,18 @@ class NewsFetchers::RedditFetcher < NewsFetchers::BaseFetcher
 
     unless response.success?
       body_preview = response.body.to_s.gsub(/\s+/, " ").strip[0, 200]
-      raise FetchError,
-            "HTTP #{response.code} for #{response.request&.uri}: #{body_preview.presence || '(empty body)'}"
+      message = "HTTP #{response.code} for #{response.request&.uri}: #{body_preview.presence || '(empty body)'}"
+      code = response.code.to_i
+
+      if code == 429
+        raise RateLimitedError.new(
+          message,
+          http_status: code,
+          retry_after_seconds: self.class.parse_retry_after_seconds(response)
+        )
+      end
+
+      raise FetchError, message
     end
 
     payload = response.parsed_response
@@ -197,17 +212,31 @@ class NewsFetchers::RedditFetcher < NewsFetchers::BaseFetcher
       attempt += 1
       raise if attempt >= max_attempts
 
-      wait = rate_limit_backoff_seconds(attempt)
+      wait = compute_rate_limit_wait(e, attempt)
       Rails.logger.warn(
-        "Reddit r/#{@subreddit} rate limited (attempt #{attempt}/#{max_attempts - 1}); sleeping #{wait}s"
+        "Reddit r/#{@subreddit} rate limited (attempt #{attempt}/#{max_attempts - 1}); sleeping #{wait.round(2)}s"
       )
-      sleep(wait)
+      Kernel.sleep(wait)
       retry
     end
   end
 
   def rate_limited_error?(error)
-    error.message.match?(/HTTP 429\b/)
+    return true if error.is_a?(RateLimitedError)
+    return true if error.message.match?(/HTTP 429\b/)
+
+    # Unauthenticated Atom path: Reddit often returns transient 403 under back-pressure.
+    !self.class.oauth_configured? && error.message.match?(/HTTP 403\b/)
+  end
+
+  def compute_rate_limit_wait(error, attempt)
+    header_wait = error.is_a?(RateLimitedError) ? error.retry_after_seconds : nil
+    wait = header_wait.nil? ? rate_limit_backoff_seconds(attempt).to_f : header_wait.to_f
+    max_wait = NewsAggregatorConfig.reddit_rate_limit_max_wait_seconds
+    wait = [ wait, max_wait ].min
+    return 0.0 if wait <= 0
+
+    self.class.with_jitter(wait, factor: self.class.rate_limit_jitter_factor)
   end
 
   def rate_limit_backoff_seconds(attempt)

--- a/app/services/news_fetchers/youtube_fetcher.rb
+++ b/app/services/news_fetchers/youtube_fetcher.rb
@@ -6,10 +6,14 @@ class NewsFetchers::YoutubeFetcher < NewsFetchers::BaseFetcher
   headers "User-Agent" => USER_AGENT
 
   class << self
-    attr_writer :min_request_interval_seconds, :rate_limit_backoff_seconds
+    attr_writer :min_request_interval_seconds, :rate_limit_backoff_seconds, :rate_limit_jitter_factor
 
     def min_request_interval_seconds
       @min_request_interval_seconds || NewsAggregatorConfig.youtube_min_request_interval_seconds
+    end
+
+    def rate_limit_jitter_factor
+      @rate_limit_jitter_factor.nil? ? 0.25 : @rate_limit_jitter_factor
     end
 
     def rate_limit_backoff_seconds(attempt)
@@ -30,7 +34,7 @@ class NewsFetchers::YoutubeFetcher < NewsFetchers::BaseFetcher
         now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         if @last_request_at
           wait = min_request_interval_seconds - (now - @last_request_at)
-          sleep(wait) if wait.positive?
+          Kernel.sleep(wait) if wait.positive?
         end
         @last_request_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       end
@@ -92,17 +96,27 @@ class NewsFetchers::YoutubeFetcher < NewsFetchers::BaseFetcher
       attempt += 1
       raise if attempt >= max_attempts
 
-      wait = self.class.rate_limit_backoff_seconds(attempt)
+      wait = compute_rate_limit_wait(e, attempt)
       Rails.logger.warn(
-        "YouTube channel #{@channel_id} rate limited (attempt #{attempt}/#{max_attempts - 1}); sleeping #{wait}s"
+        "YouTube channel #{@channel_id} rate limited (attempt #{attempt}/#{max_attempts - 1}); sleeping #{wait.round(2)}s"
       )
-      sleep(wait)
+      Kernel.sleep(wait)
       retry
     end
   end
 
   def rate_limited_error?(error)
-    error.message.match?(/HTTP 429\b/)
+    error.is_a?(RateLimitedError) || error.message.match?(/HTTP 429\b/)
+  end
+
+  def compute_rate_limit_wait(error, attempt)
+    header_wait = error.is_a?(RateLimitedError) ? error.retry_after_seconds : nil
+    wait = header_wait.nil? ? self.class.rate_limit_backoff_seconds(attempt).to_f : header_wait.to_f
+    max_wait = NewsAggregatorConfig.youtube_rate_limit_max_wait_seconds
+    wait = [ wait, max_wait ].min
+    return 0.0 if wait <= 0
+
+    self.class.with_jitter(wait, factor: self.class.rate_limit_jitter_factor)
   end
 
   def parse_atom_entries(feed_body)

--- a/config/news_aggregator.yml
+++ b/config/news_aggregator.yml
@@ -50,12 +50,17 @@ development: &default
       # Public JSON listings return 403 without OAuth. Default path is Atom RSS
       # (.rss). Set REDDIT_CLIENT_ID + REDDIT_CLIENT_SECRET to use OAuth JSON
       # listings (includes score / comment_count).
+      #
+      # Unauthenticated Atom is throttled ~1 req/min (2026). Shared throttle
+      # across all RedditFetcher instances — keep this >= 60s for Atom-only
+      # installs, or use OAuth for denser polling.
       base_url: "https://www.reddit.com/r"
       format: ".rss"
-      # Shared throttle across all RedditFetcher instances (seconds).
-      min_request_interval_seconds: 2.5
-      # Extra retries after HTTP 429 before the source FetchRun fails.
+      min_request_interval_seconds: 60
+      # Extra retries after HTTP 429/transient 403 before the source FetchRun fails.
       rate_limit_max_retries: 4
+      # Cap a single Retry-After / x-ratelimit-reset sleep (seconds).
+      rate_limit_max_wait_seconds: 90
       subreddits:
         - programming
         - webdev
@@ -74,6 +79,7 @@ development: &default
       feed_base_url: "https://www.youtube.com/feeds/videos.xml"
       min_request_interval_seconds: 2.0
       rate_limit_max_retries: 4
+      rate_limit_max_wait_seconds: 90
       # Optional videos.list enrichment (1 unit / call, up to 50 IDs). Needs YOUTUBE_API_KEY.
       enrich_with_api: true
       enrich_batch_size: 50

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -214,7 +214,7 @@ whenever --clear-crontab
 
 **Service-oriented architecture**: Business logic separated into service classes rather than fat models. Each news source has its own fetcher service.
 
-**Fail-safe aggregation**: If one news source fails, others continue processing. Errors are logged but don't stop the entire aggregation process. Sources run in parallel threads; each fetcher uses configured HTTP timeouts and retries with exponential backoff.
+**Fail-safe aggregation**: If one news source fails, others continue processing. Errors are logged but don't stop the entire aggregation process. Sources run in parallel threads; each fetcher uses configured HTTP timeouts and retries with jittered exponential backoff. Rate-limited responses honor `Retry-After` / `x-ratelimit-reset` when present.
 
 **Idempotent updates**: Articles use `find_or_initialize_by(external_id, source_type)` to prevent duplicates while allowing updates to existing articles.
 
@@ -252,7 +252,9 @@ config/schedule.rb                      # Cron job definitions
 
 **Dev.to**: Uses REST API (`dev.to/api/articles`) with query params for pagination and filtering by top posts from last 7 days.
 
-**Reddit**: Multiple instances for different subreddits. Each subreddit is treated as a separate source type in the database. By default, fetchers read the public Atom feed (`/r/{subreddit}/.rss`) because unauthenticated `.json` listings return HTTP 403 (Atom has no score fields, so new articles seed `score`/`comment_count` to 0). Set `REDDIT_CLIENT_ID` and `REDDIT_CLIENT_SECRET` in `.env` (loaded into the Rails process by `LocalEnv` / `dev.ps1` / `bin/dev` — see Environment configuration) to switch to OAuth JSON listings on `oauth.reddit.com`, which persist real scores and comment counts. Check with `bin/rails news:reddit_oauth_status` (prints present/length only, never secret values). Requests share a configurable throttle (`apis.reddit.min_request_interval_seconds`); HTTP 429 responses are retried with backoff (`apis.reddit.rate_limit_max_retries`) and failures are recorded on `FetchRun` instead of silent zero-article success.
+**Reddit**: Multiple instances for different subreddits. Each subreddit is treated as a separate source type in the database. By default, fetchers read the public Atom feed (`/r/{subreddit}/.rss`) because unauthenticated `.json` listings return HTTP 403 (Atom has no score fields, so new articles seed `score`/`comment_count` to 0). Set `REDDIT_CLIENT_ID` and `REDDIT_CLIENT_SECRET` in `.env` (loaded into the Rails process by `LocalEnv` / `dev.ps1` / `bin/dev` — see Environment configuration) to switch to OAuth JSON listings on `oauth.reddit.com`, which persist real scores and comment counts. Check with `bin/rails news:reddit_oauth_status` (prints present/length only, never secret values).
+
+Unauthenticated Atom is aggressively rate-limited (~1 request/minute as of mid-2026). Requests share a configurable throttle (`apis.reddit.min_request_interval_seconds`, default **60s**) so a full multi-subreddit run does not burst into HTTP 429. HTTP 429 (and transient Atom 403) responses are retried with bounded backoff that prefers `Retry-After` / `x-ratelimit-reset`, capped by `apis.reddit.rate_limit_max_wait_seconds`. Prefer OAuth when you need denser polling or scores. Failures are recorded on `FetchRun` instead of silent zero-article success.
 
 **YouTube**: Channel uploads via public Atom feeds (no API key). Optional `YOUTUBE_API_KEY` enables `videos.list` enrichment (duration/stats) and opt-in keyword `search.list` discovery with a hard daily budget. Manage channels at `/sources`. Full quota/config details: [YOUTUBE.md](YOUTUBE.md).
 

--- a/test/models/news_aggregator_config_test.rb
+++ b/test/models/news_aggregator_config_test.rb
@@ -27,7 +27,8 @@ class NewsAggregatorConfigTest < ActiveSupport::TestCase
   end
 
   test "loads reddit throttle settings from news_aggregator.yml" do
-    assert_equal 2.5, NewsAggregatorConfig.reddit_min_request_interval_seconds
+    assert_equal 60, NewsAggregatorConfig.reddit_min_request_interval_seconds
     assert_equal 4, NewsAggregatorConfig.reddit_rate_limit_max_retries
+    assert_equal 90, NewsAggregatorConfig.reddit_rate_limit_max_wait_seconds
   end
 end

--- a/test/services/news_fetchers/base_fetcher_test.rb
+++ b/test/services/news_fetchers/base_fetcher_test.rb
@@ -105,6 +105,50 @@ class NewsFetchers::BaseFetcherTest < ActiveSupport::TestCase
       NewsFetchers::BaseFetcher.send(:parse_http_response, fake_response)
     end
     assert_match(/HTTP 403/, error.message)
+    assert_not_kind_of NewsFetchers::BaseFetcher::RateLimitedError, error
+  end
+
+  test "parse_http_response raises RateLimitedError for HTTP 429 with retry headers" do
+    request = Object.new
+    request.define_singleton_method(:uri) { "https://example.com/api" }
+
+    fake_response = Object.new
+    fake_response.define_singleton_method(:success?) { false }
+    fake_response.define_singleton_method(:code) { 429 }
+    fake_response.define_singleton_method(:body) { "slow down" }
+    fake_response.define_singleton_method(:request) { request }
+    fake_response.define_singleton_method(:headers) do
+      { "Retry-After" => "5", "x-ratelimit-reset" => "12" }
+    end
+    fake_response.define_singleton_method(:is_a?) { |klass| klass == HTTParty::Response }
+
+    error = assert_raises(NewsFetchers::BaseFetcher::RateLimitedError) do
+      NewsFetchers::BaseFetcher.send(:parse_http_response, fake_response)
+    end
+    assert_equal 429, error.http_status
+    assert_equal 5.0, error.retry_after_seconds
+  end
+
+  test "parse_retry_after_seconds prefers Retry-After over x-ratelimit-reset" do
+    fake_response = Object.new
+    fake_response.define_singleton_method(:headers) do
+      { "Retry-After" => "4", "x-ratelimit-reset" => "60" }
+    end
+
+    assert_equal 4.0, NewsFetchers::BaseFetcher.parse_retry_after_seconds(fake_response)
+  end
+
+  test "parse_retry_after_seconds uses relative x-ratelimit-reset" do
+    fake_response = Object.new
+    fake_response.define_singleton_method(:headers) do
+      { "x-ratelimit-reset" => "58" }
+    end
+
+    assert_equal 58.0, NewsFetchers::BaseFetcher.parse_retry_after_seconds(fake_response)
+  end
+
+  test "with_jitter returns base when factor is zero" do
+    assert_equal 10.0, NewsFetchers::BaseFetcher.with_jitter(10, factor: 0)
   end
 
   test "get retries transient network errors with backoff before succeeding" do

--- a/test/services/news_fetchers/reddit_fetcher_test.rb
+++ b/test/services/news_fetchers/reddit_fetcher_test.rb
@@ -4,6 +4,7 @@ class NewsFetchers::RedditFetcherTest < ActiveSupport::TestCase
   def setup
     @fetcher = NewsFetchers::RedditFetcher.new(subreddit: "programming")
     NewsFetchers::RedditFetcher.min_request_interval_seconds = 0
+    NewsFetchers::RedditFetcher.rate_limit_jitter_factor = 0
     NewsFetchers::RedditFetcher.reset_throttle!
     NewsFetchers::RedditFetcher.reset_oauth_token!
     @previous_client_id = ENV["REDDIT_CLIENT_ID"]
@@ -15,6 +16,7 @@ class NewsFetchers::RedditFetcherTest < ActiveSupport::TestCase
   def teardown
     NewsFetchers::RedditFetcher.min_request_interval_seconds = nil
     NewsFetchers::RedditFetcher.rate_limit_backoff_seconds = nil
+    NewsFetchers::RedditFetcher.rate_limit_jitter_factor = nil
     NewsFetchers::RedditFetcher.reset_throttle!
     NewsFetchers::RedditFetcher.reset_oauth_token!
     if @previous_client_id
@@ -73,14 +75,44 @@ class NewsFetchers::RedditFetcherTest < ActiveSupport::TestCase
     end
   end
 
-  test "fetch_articles raises when Reddit returns HTTP errors" do
+  test "fetch_articles raises after exhausting retries on persistent HTTP 403" do
     stub_request(:get, "https://www.reddit.com/r/programming/.rss")
       .to_return(status: 403, body: "<html>Blocked</html>", headers: { "Content-Type" => "text/html" })
 
+    NewsFetchers::RedditFetcher.rate_limit_backoff_seconds = 0
     error = assert_raises(NewsFetchers::BaseFetcher::FetchError) do
       @fetcher.fetch_articles
     end
     assert_match(/HTTP 403/, error.message)
+  end
+
+  test "fetch_articles retries transient HTTP 403 on Atom then succeeds" do
+    stub_request(:get, "https://www.reddit.com/r/programming/.rss")
+      .to_return(
+        { status: 403, body: "<html>Blocked</html>", headers: { "Content-Type" => "text/html" } },
+        {
+          status: 200,
+          body: <<~ATOM,
+            <feed xmlns="http://www.w3.org/2005/Atom">
+              <entry>
+                <id>t3_403retry</id>
+                <title>After 403</title>
+                <link href="https://www.reddit.com/r/programming/comments/403retry/title/" />
+                <published>2023-11-14T22:13:20+00:00</published>
+                <content type="html">&lt;a href="https://example.com/ok"&gt;[link]&lt;/a&gt;</content>
+              </entry>
+            </feed>
+          ATOM
+          headers: { "Content-Type" => "application/atom+xml" }
+        }
+      )
+
+    NewsFetchers::RedditFetcher.rate_limit_backoff_seconds = 0
+    assert_difference "Article.count", 1 do
+      article = @fetcher.fetch_articles.first
+      assert_equal "After 403", article.title
+      assert_equal "403retry", article.external_id
+    end
   end
 
   test "fetch_articles retries HTTP 429 then succeeds" do
@@ -109,6 +141,90 @@ class NewsFetchers::RedditFetcherTest < ActiveSupport::TestCase
       article = @fetcher.fetch_articles.first
       assert_equal "After Retry", article.title
       assert_equal "retry1", article.external_id
+    end
+  end
+
+  test "fetch_articles honors x-ratelimit-reset on HTTP 429" do
+    stub_request(:get, "https://www.reddit.com/r/programming/.rss")
+      .to_return(
+        {
+          status: 429,
+          body: "",
+          headers: {
+            "Content-Type" => "text/html",
+            "x-ratelimit-remaining" => "0",
+            "x-ratelimit-reset" => "7"
+          }
+        },
+        {
+          status: 200,
+          body: <<~ATOM,
+            <feed xmlns="http://www.w3.org/2005/Atom">
+              <entry>
+                <id>t3_reset1</id>
+                <title>After Reset Header</title>
+                <link href="https://www.reddit.com/r/programming/comments/reset1/title/" />
+                <published>2023-11-14T22:13:20+00:00</published>
+                <content type="html">&lt;a href="https://example.com/ok"&gt;[link]&lt;/a&gt;</content>
+              </entry>
+            </feed>
+          ATOM
+          headers: { "Content-Type" => "application/atom+xml" }
+        }
+      )
+
+    slept = []
+    original_sleep = Kernel.method(:sleep)
+    Kernel.define_singleton_method(:sleep) do |duration = nil|
+      slept << duration.to_f
+    end
+
+    begin
+      article = @fetcher.fetch_articles.first
+      assert_equal "After Reset Header", article.title
+      assert_includes slept, 7.0
+    ensure
+      Kernel.define_singleton_method(:sleep, original_sleep)
+    end
+  end
+
+  test "fetch_articles honors Retry-After on HTTP 429" do
+    stub_request(:get, "https://www.reddit.com/r/programming/.rss")
+      .to_return(
+        {
+          status: 429,
+          body: "",
+          headers: { "Content-Type" => "text/html", "Retry-After" => "3" }
+        },
+        {
+          status: 200,
+          body: <<~ATOM,
+            <feed xmlns="http://www.w3.org/2005/Atom">
+              <entry>
+                <id>t3_ra1</id>
+                <title>After Retry-After</title>
+                <link href="https://www.reddit.com/r/programming/comments/ra1/title/" />
+                <published>2023-11-14T22:13:20+00:00</published>
+                <content type="html">&lt;a href="https://example.com/ok"&gt;[link]&lt;/a&gt;</content>
+              </entry>
+            </feed>
+          ATOM
+          headers: { "Content-Type" => "application/atom+xml" }
+        }
+      )
+
+    slept = []
+    original_sleep = Kernel.method(:sleep)
+    Kernel.define_singleton_method(:sleep) do |duration = nil|
+      slept << duration.to_f
+    end
+
+    begin
+      article = @fetcher.fetch_articles.first
+      assert_equal "After Retry-After", article.title
+      assert_includes slept, 3.0
+    ensure
+      Kernel.define_singleton_method(:sleep, original_sleep)
     end
   end
 

--- a/test/services/news_fetchers/youtube_fetcher_test.rb
+++ b/test/services/news_fetchers/youtube_fetcher_test.rb
@@ -5,6 +5,7 @@ class NewsFetchers::YoutubeFetcherTest < ActiveSupport::TestCase
     NewsFetchers::YoutubeFetcher.reset_throttle!
     NewsFetchers::YoutubeFetcher.min_request_interval_seconds = 0
     NewsFetchers::YoutubeFetcher.rate_limit_backoff_seconds = 0
+    NewsFetchers::YoutubeFetcher.rate_limit_jitter_factor = 0
     @channel_id = "UCWnPjmqvljcafA0QXblOU1A"
     @fetcher = NewsFetchers::YoutubeFetcher.new(channel_id: @channel_id, channel_name: "Confreaks")
   end
@@ -12,6 +13,7 @@ class NewsFetchers::YoutubeFetcherTest < ActiveSupport::TestCase
   teardown do
     NewsFetchers::YoutubeFetcher.min_request_interval_seconds = nil
     NewsFetchers::YoutubeFetcher.rate_limit_backoff_seconds = nil
+    NewsFetchers::YoutubeFetcher.rate_limit_jitter_factor = nil
     NewsFetchers::YoutubeFetcher.reset_throttle!
   end
 


### PR DESCRIPTION
## Summary

- Raise Reddit Atom shared throttle from **2.5s → 60s** to match mid-2026 upstream ~1 req/min limits (fixes intermittent multi-subreddit 429 cascades).
- Add `RateLimitedError` that preserves `Retry-After` / `x-ratelimit-reset`, with capped jittered backoff on Reddit and YouTube.
- Retry transient **HTTP 403** on unauthenticated Atom (bounded); keep OAuth 403 as a hard failure.
- Document the 2026 Reddit rate-limit reality and OAuth preference in `docs/DEVELOPMENT.md`.

Closes #422

## Test plan

- [x] `bin/rails test` for base/reddit/youtube fetchers + config (41 runs, green)
- [x] RuboCop on changed files
- [ ] Manual: Atom-only (no OAuth) full `NewsAggregatorService.fetch_all_news` — Reddit `FetchRun`s should not cascade 429
- [ ] Manual: with OAuth credentials, denser polling still works and scores persist
