### PR TITLE
docs: add knowledge changelog following OKF log pattern (#407)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@ Guidance for AI coding agents working in this repository. Keep this file concise
 ## Read First
 
 - `docs/index.md`: knowledge map (one line per doc — start here for orientation).
+- `docs/log.md`: knowledge changelog (append in the same PR when docs change materially).
 - `CONTRIBUTING.md`: contributor entry point and pull request workflow.
 - `docs/KNOWLEDGE.md`: OKF-inspired conventions for durable project knowledge (instructions vs *why*, concept files, roadmap).
 - `docs/DEVELOPMENT.md`: setup, architecture, coding standards, test expectations, and git conventions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@ Thanks for improving Dev News Aggregator. This file is the short entry point; ke
 ## Start Here
 
 - [docs/index.md](docs/index.md) for the knowledge map (one-line purpose per doc).
+- [docs/log.md](docs/log.md) for the knowledge changelog (append when docs change materially).
 - [AGENTS.md](AGENTS.md) for AI-agent workflow, scope, and verification guardrails.
 - [docs/KNOWLEDGE.md](docs/KNOWLEDGE.md) for OKF-inspired knowledge conventions (what belongs in guides vs decision/concept docs).
 - [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) for setup, architecture, coding standards, tests, and git conventions.

--- a/docs/KNOWLEDGE.md
+++ b/docs/KNOWLEDGE.md
@@ -44,7 +44,7 @@ Cross-link related guides and concepts with relative Markdown links. A link to a
 
 ### Knowledge changelog
 
-When concept docs land, keep a dated `docs/log.md` (newest first, one bullet per create/update/deprecate), same PR as the knowledge change ([#407](https://github.com/MarcosLorejan/dev-news-aggregator/issues/407)).
+Keep a dated [log.md](log.md) (newest first, ISO day headings, one bullet per create/update/deprecate). Append in the **same PR** when you add or materially change knowledge under `docs/` (new guides, decisions, maps, or structural moves). Skip pure typos and formatting-only edits.
 
 ### Light frontmatter (optional)
 

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -213,6 +213,7 @@ dev-news-aggregator/
 | File | Purpose |
 |------|---------|
 | `index.md` | Knowledge map — one-line purpose per maintained doc |
+| `log.md` | Knowledge changelog (dated, newest first) |
 | `KNOWLEDGE.md` | OKF-inspired knowledge conventions (instructions vs curated *why*, roadmap) |
 | `DEVELOPMENT.md` | Commands, architecture, coding and git conventions |
 | `AGENT_API.md` | Versioned `/api/v1` JSON contract for agents |

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ Conventions: [KNOWLEDGE.md](KNOWLEDGE.md). Code layout: [REPO_STRUCTURE.md](REPO
 | Doc | Purpose |
 |-----|---------|
 | [KNOWLEDGE.md](KNOWLEDGE.md) | OKF-inspired conventions: instructions vs curated *why*, roadmap |
+| [log.md](log.md) | Knowledge changelog (newest first) |
 | [DEVELOPMENT.md](DEVELOPMENT.md) | Setup, architecture, coding standards, tests, git workflow |
 | [REPO_STRUCTURE.md](REPO_STRUCTURE.md) | Living directory map; update when structure changes |
 | [../AGENTS.md](../AGENTS.md) | Standing instructions for coding agents (`bin/validate`, scope) |
@@ -40,5 +41,4 @@ Conventions: [KNOWLEDGE.md](KNOWLEDGE.md). Code layout: [REPO_STRUCTURE.md](REPO
 
 | Area | Issue |
 |------|--------|
-| Knowledge changelog (`log.md`) | [#407](https://github.com/MarcosLorejan/dev-news-aggregator/issues/407) |
 | Link / orphan drift checks | [#411](https://github.com/MarcosLorejan/dev-news-aggregator/issues/411) |

--- a/docs/log.md
+++ b/docs/log.md
@@ -1,0 +1,30 @@
+---
+type: Log
+title: Knowledge changelog
+description: Dated history of knowledge-doc creates, updates, and deprecations (newest first).
+tags: [knowledge, log]
+---
+
+# Knowledge changelog
+
+Dated history of **project knowledge** changes (guides, decisions, maps). Newest first. One bullet per create, update, or deprecate.
+
+Update this file in the **same PR** when you add or materially change knowledge under `docs/` (see [KNOWLEDGE.md](KNOWLEDGE.md)). Do not log every typo; do log new decisions, new guides, and structural doc moves.
+
+## 2026-08-03
+
+- Created [decisions/](decisions/) with six durable *why* records (React/Vite, keyword interests, Agent API thin contract, YouTube Atom-first, Solid Queue on Windows, fetch orchestration) ([#409](https://github.com/MarcosLorejan/dev-news-aggregator/issues/409)).
+- Created [index.md](index.md) knowledge map and light YAML frontmatter on maintained guides ([#408](https://github.com/MarcosLorejan/dev-news-aggregator/issues/408)).
+- Created [KNOWLEDGE.md](KNOWLEDGE.md) OKF-inspired conventions ([#406](https://github.com/MarcosLorejan/dev-news-aggregator/issues/406)).
+- Created this [log.md](log.md) ([#407](https://github.com/MarcosLorejan/dev-news-aggregator/issues/407)).
+
+## 2026-08-02
+
+- Documented YouTube ingestion paths and quota strategy in [YOUTUBE.md](YOUTUBE.md) ([#388](https://github.com/MarcosLorejan/dev-news-aggregator/issues/388)).
+
+## Earlier (seed)
+
+- [KEYWORD_FILTERS.md](KEYWORD_FILTERS.md) — interest presets and feed filter params.
+- [AGENT_API.md](AGENT_API.md) — stable `/api/v1` JSON contract for agents.
+- [AGENTS.md](../AGENTS.md) — standing instructions for coding agents (milestone [AI agent friendliness](https://github.com/MarcosLorejan/dev-news-aggregator/milestone/14)).
+- [DEVELOPMENT.md](DEVELOPMENT.md), [REPO_STRUCTURE.md](REPO_STRUCTURE.md), [REACT_SETUP.md](REACT_SETUP.md), [PRE_COMMIT_HOOKS.md](PRE_COMMIT_HOOKS.md), [SUMMARIZER.md](SUMMARIZER.md) — existing how-to corpus.


### PR DESCRIPTION
﻿## Summary
- Add `docs/log.md` (OKF-style knowledge changelog: ISO day headings, newest first)
- Seed with recent milestone work (#406–#409) plus earlier major guides
- Document when to append in `KNOWLEDGE.md`; link from `index.md`, `AGENTS.md`, `CONTRIBUTING.md`, `REPO_STRUCTURE.md`

Closes #407

## Depends on
- #423 / #409 — branched from `docs/409-why-concepts`
- #421 / #408, #414 / #406

## Test plan
- [ ] Confirm `docs/log.md` reads newest-first and links resolve
- [ ] Confirm conventions say to update the log in the same PR as knowledge changes
