### PR TITLE
fix(frontend): keep filters visible when Videos has no matches (#427)

### DIFF
--- a/app/controllers/sources_controller.rb
+++ b/app/controllers/sources_controller.rb
@@ -5,7 +5,9 @@ class SourcesController < ApplicationController
   before_action :set_source, only: [ :update, :destroy ]
 
   def index
-    NewsSource.bootstrap_defaults! if NewsSource.none?
+    # Idempotent: fills in defaults (incl. YouTube) even when older DBs already
+    # have HN/Reddit rows — otherwise Videos stays empty forever.
+    NewsSource.bootstrap_defaults!
 
     respond_to do |format|
       format.html

--- a/app/frontend/pages/ArticlesIndexPage.test.tsx
+++ b/app/frontend/pages/ArticlesIndexPage.test.tsx
@@ -305,6 +305,43 @@ describe('ArticlesIndexPage dismiss flow', () => {
     )
   })
 
+  it('keeps content filters visible when Videos has no matches', async () => {
+    vi.mocked(articlesApi.fetchArticles).mockResolvedValue(
+      buildArticlesIndexResponse({
+        articles: [],
+        articles_by_category: {},
+        category_counts: {},
+        pagination: {
+          current_page: 1,
+          per_page: 20,
+          total_count: 0,
+          total_pages: 0,
+        },
+      })
+    )
+
+    const user = userEvent.setup()
+    renderPage(['/articles?content_type=video'])
+
+    await screen.findByTestId('articles-page')
+    expect(await screen.findByText('No videos found')).toBeInTheDocument()
+    expect(screen.queryByText('Your feed is empty')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Videos' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: 'All' })).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'All' }))
+
+    await waitFor(() => {
+      const calls = vi.mocked(articlesApi.fetchArticles).mock.calls
+      const lastCall = calls[calls.length - 1]?.[0] as {
+        content_type?: string
+        page?: number
+      }
+      expect(lastCall?.page).toBe(1)
+      expect(lastCall?.content_type).toBeUndefined()
+    })
+  })
+
   it('updates content type params and resets pagination', async () => {
     const user = userEvent.setup()
     renderPage(['/articles?page=3'])

--- a/app/frontend/pages/ArticlesIndexPage.tsx
+++ b/app/frontend/pages/ArticlesIndexPage.tsx
@@ -467,11 +467,27 @@ export default function ArticlesIndexPage() {
   }
 
   const hasInterestFilter = activeInterests.length > 0
+  const hasContentFilters = activeContentType !== 'all' || activeMaxDuration !== 'all'
+  const hasCategoryOrTag = activeFilter !== 'all' || activeTag !== 'all'
+  const hasScoreFilter = activeScoreFilter !== 'all'
+  const hasNarrowingFilter =
+    hasInterestFilter || hasContentFilters || hasCategoryOrTag || hasScoreFilter
   const noResults = articles.length === 0 && (data?.pagination.total_count ?? 0) === 0
+  // Only the true empty inbox — never hide filters when a narrowing filter is active
+  // (e.g. Videos with 0 matches used to trap users with no All button).
   const showEmptyFeed =
-    !data || (!searchQuery && !hasInterestFilter && allArticlesCount === 0 && articles.length === 0)
+    !data ||
+    (!searchQuery && !hasNarrowingFilter && allArticlesCount === 0 && articles.length === 0)
   const showNoSearchResults = Boolean(searchQuery) && noResults
   const showNoInterestResults = !searchQuery && hasInterestFilter && noResults
+  const showNoContentTypeResults =
+    !searchQuery && !hasInterestFilter && hasContentFilters && noResults
+  const showNoOtherFilterResults =
+    !searchQuery &&
+    !hasInterestFilter &&
+    !hasContentFilters &&
+    (hasCategoryOrTag || hasScoreFilter) &&
+    noResults
 
   let emptyResults: { title: string; description: string } | null = null
   if (showNoSearchResults) {
@@ -483,6 +499,30 @@ export default function ArticlesIndexPage() {
     emptyResults = {
       title: 'No articles match these interests',
       description: `Nothing in the feed mentions ${interestLabels}. Try picking fewer interests or clearing them.`,
+    }
+  } else if (showNoContentTypeResults) {
+    if (activeContentType === 'video') {
+      emptyResults = {
+        title: 'No videos found',
+        description:
+          'There are no videos in your feed yet. Add YouTube channels on Sources, click Fetch News, then tap All to return to the full feed.',
+      }
+    } else if (activeContentType === 'article') {
+      emptyResults = {
+        title: 'No text articles found',
+        description: 'Nothing matched the Articles filter. Tap All to see the full feed again.',
+      }
+    } else {
+      emptyResults = {
+        title: 'No videos match this length',
+        description:
+          'Try a longer max duration, or tap All / Any length to clear the video length filter.',
+      }
+    }
+  } else if (showNoOtherFilterResults) {
+    emptyResults = {
+      title: 'No articles match these filters',
+      description: 'Try clearing the category, topic, or score filter to see more of the feed.',
     }
   }
 

--- a/test/controllers/sources_controller_test.rb
+++ b/test/controllers/sources_controller_test.rb
@@ -14,6 +14,17 @@ class SourcesControllerTest < ActionDispatch::IntegrationTest
     assert json["sources"].any? { |source| source["source_type"] == "hacker_news" }
   end
 
+  test "index backfills default youtube channels when older DBs lack them" do
+    NewsSource.where(source_type: "youtube").delete_all
+    assert_equal 0, NewsSource.where(source_type: "youtube").count
+
+    get sources_url, as: :json
+    assert_response :success
+
+    assert NewsSource.where(source_type: "youtube").exists?
+    assert JSON.parse(response.body)["sources"].any? { |source| source["source_type"] == "youtube" }
+  end
+
   test "index JSON includes last_fetch for sources with FetchRun" do
     FetchRun.record_outcome(
       source_key: "hacker_news",


### PR DESCRIPTION
## Summary
- Stop treating an empty **Videos** (or other narrowing) filter as a fully empty feed, so **All / Articles / Videos** stay visible and users can leave the filter
- Add filter-specific empty copy (including guidance for missing YouTube content)
- Always run `NewsSource.bootstrap_defaults!` on `/sources` so older DBs without YouTube channels get the YAML defaults backfilled

## Test plan
- [ ] Open feed with articles, click **Videos** with no videos → filters remain, empty copy shown, click **All** returns to full feed
- [ ] Delete YouTube `NewsSource` rows, visit `/sources` → default YouTube channels reappear
- [ ] `npm test -- app/frontend/pages/ArticlesIndexPage.test.tsx`
- [ ] `bundle exec rails test test/controllers/sources_controller_test.rb`

Closes #427