### PR TITLE
test: add lightweight docs link and orphan checks (#411)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,20 @@ jobs:
       - name: Lint code for consistent style
         run: bundle exec rubocop -f github
 
+  docs_check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+
+      - name: Check docs links and knowledge-map orphans
+        run: ruby bin/check-docs
+
   frontend_lint:
     runs-on: ubuntu-latest
     steps:
@@ -278,12 +292,12 @@ jobs:
   quality_gate:
     runs-on: ubuntu-latest
     permissions: {}
-    needs: [scan_ruby, scan_dependencies, scan_js, lint, frontend_lint, typecheck, frontend_test, test, docker_build, docker_scan]
+    needs: [scan_ruby, scan_dependencies, scan_js, lint, docs_check, frontend_lint, typecheck, frontend_test, test, docker_build, docker_scan]
     if: always()
     steps:
       - name: Check all jobs status
         run: |
-          if [[ "${{ needs.scan_ruby.result }}" == "failure" || "${{ needs.scan_dependencies.result }}" == "failure" || "${{ needs.scan_js.result }}" == "failure" || "${{ needs.lint.result }}" == "failure" || "${{ needs.frontend_lint.result }}" == "failure" || "${{ needs.typecheck.result }}" == "failure" || "${{ needs.frontend_test.result }}" == "failure" || "${{ needs.test.result }}" == "failure" || "${{ needs.docker_build.result }}" == "failure" || "${{ needs.docker_scan.result }}" == "failure" ]]; then
+          if [[ "${{ needs.scan_ruby.result }}" == "failure" || "${{ needs.scan_dependencies.result }}" == "failure" || "${{ needs.scan_js.result }}" == "failure" || "${{ needs.lint.result }}" == "failure" || "${{ needs.docs_check.result }}" == "failure" || "${{ needs.frontend_lint.result }}" == "failure" || "${{ needs.typecheck.result }}" == "failure" || "${{ needs.frontend_test.result }}" == "failure" || "${{ needs.test.result }}" == "failure" || "${{ needs.docker_build.result }}" == "failure" || "${{ needs.docker_scan.result }}" == "failure" ]]; then
             echo "One or more jobs failed"
             exit 1
           fi

--- a/bin/check-docs
+++ b/bin/check-docs
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Lightweight docs link + orphan checks (no Rails boot).
+# Usage: bin/check-docs
+#        bin/check-docs /path/to/repo
+
+require_relative "../lib/docs_knowledge_check"
+
+root = ARGV[0] || File.expand_path("..", __dir__)
+result = DocsKnowledgeCheck.run(root: root)
+
+if result.ok?
+  puts "Docs knowledge check passed."
+  exit 0
+end
+
+warn "Docs knowledge check failed:"
+result.errors.each { |error| warn "  - #{error}" }
+exit 1

--- a/bin/validate
+++ b/bin/validate
@@ -55,6 +55,7 @@ skip_check() {
 }
 
 run_check "RuboCop" bundle exec rubocop -f github
+run_check "Docs knowledge check" bin/check-docs
 
 if "$fast"; then
   skip_check "Brakeman"

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -155,13 +155,14 @@ Prettier is configured (`.prettierrc.json`) but not enforced: most of the existi
 Prefer the CI-oriented wrapper before opening a PR (documented in [AGENTS.md](../AGENTS.md#verification)):
 
 ```bash
-bin/validate          # RuboCop, Brakeman, typecheck, npm test, rails test
-bin/validate --fast   # skips Brakeman and Rails tests
+bin/validate          # RuboCop, docs check, Brakeman, typecheck, npm test, rails test
+bin/validate --fast   # skips Brakeman and Rails tests (still runs docs check)
 ```
 
 | Check | `bin/validate` | CI job(s) |
 |-------|----------------|-----------|
 | RuboCop | yes | `lint` |
+| `bin/check-docs` | yes (also with `--fast`) | `docs_check` |
 | Brakeman | yes (skipped with `--fast`) | `scan_ruby` |
 | `npm run typecheck` | yes | `typecheck` |
 | `npm run lint` | yes | `frontend_lint` |

--- a/docs/KNOWLEDGE.md
+++ b/docs/KNOWLEDGE.md
@@ -64,7 +64,15 @@ resource: app/services/news_fetchers/   # code or path this knowledge describes
 
 ### Drift checks
 
-Prefer cheap, dependency-free checks (broken relative links, orphans missing from the knowledge map) before considering `okf validate` in CI ([#411](https://github.com/MarcosLorejan/dev-news-aggregator/issues/411), optional gem spike [#410](https://github.com/MarcosLorejan/dev-news-aggregator/issues/410)).
+Run the dependency-free checker locally (also wired into `bin/validate` / `bin/validate --fast` and CI `docs_check`):
+
+```bash
+bin/check-docs
+```
+
+It fails on broken relative Markdown links under `docs/` (plus `AGENTS.md` / `CONTRIBUTING.md`) and on `docs/**/*.md` files missing from [index.md](index.md).
+
+Graduate to `okf validate` in CI only after the tree is intentionally OKF-shaped ([#410](https://github.com/MarcosLorejan/dev-news-aggregator/issues/410)). Until then, keep this lightweight gate.
 
 Continue updating `REPO_STRUCTURE.md` in the same change when project structure changes (existing rule).
 

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -9,7 +9,7 @@ tags: [structure, map]
 
 Living map of this codebase. **Keep this file in sync with the repo** — see [Maintenance](#maintenance) below.
 
-Last updated: 2026-08-03
+Last updated: 2026-08-04
 
 ## Maintenance
 
@@ -193,6 +193,7 @@ dev-news-aggregator/
 
 | Path | Purpose |
 |------|---------|
+| `lib/docs_knowledge_check.rb` | Dependency-free docs link + knowledge-map orphan checks |
 | `lib/tasks/news.rake` | `news:fetch`, `news:fetch_status`, `news:latest`, `news:clean` rake tasks |
 
 ## `test/`
@@ -206,6 +207,7 @@ dev-news-aggregator/
 | `test/helpers/` | Helper tests |
 | `test/integration/` | Multi-step workflow tests |
 | `test/system/` | Browser/system tests (Capybara) |
+| `test/lib/` | Library unit tests (e.g. docs knowledge check) |
 | `test/fixtures/` | YAML test data |
 
 ## `docs/`
@@ -248,6 +250,8 @@ dev-news-aggregator/
 | `Gemfile` / `Gemfile.lock` | Ruby gems |
 | `package.json` / `package-lock.json` | Node packages |
 | `bin/dev` | Rails-only server wrapper (`bin/rails server`); does **not** start Vite |
+| `bin/validate` | Local CI-equivalent checks (includes `bin/check-docs`) |
+| `bin/check-docs` | Docs relative-link + knowledge-map orphan checker |
 | `dev.ps1` | Windows helper that starts Postgres (if needed), Vite + Rails, and opens the browser |
 | `start-app.bat` | Double-click launcher for `dev.ps1` (full stack) |
 | `setup-local-env.ps1` | Windows one-time/repeat setup (bundle, npm, Postgres, `db:prepare`) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,4 +41,4 @@ Conventions: [KNOWLEDGE.md](KNOWLEDGE.md). Code layout: [REPO_STRUCTURE.md](REPO
 
 | Area | Issue |
 |------|--------|
-| Link / orphan drift checks | [#411](https://github.com/MarcosLorejan/dev-news-aggregator/issues/411) |
+| Optional: evaluate `okf` gem for CI | [#410](https://github.com/MarcosLorejan/dev-news-aggregator/issues/410) |

--- a/docs/log.md
+++ b/docs/log.md
@@ -11,6 +11,10 @@ Dated history of **project knowledge** changes (guides, decisions, maps). Newest
 
 Update this file in the **same PR** when you add or materially change knowledge under `docs/` (see [KNOWLEDGE.md](KNOWLEDGE.md)). Do not log every typo; do log new decisions, new guides, and structural doc moves.
 
+## 2026-08-04
+
+- Added `bin/check-docs` (broken relative links + knowledge-map orphans), wired into `bin/validate` and CI `docs_check` ([#411](https://github.com/MarcosLorejan/dev-news-aggregator/issues/411)).
+
 ## 2026-08-03
 
 - Created [decisions/](decisions/) with six durable *why* records (React/Vite, keyword interests, Agent API thin contract, YouTube Atom-first, Solid Queue on Windows, fetch orchestration) ([#409](https://github.com/MarcosLorejan/dev-news-aggregator/issues/409)).

--- a/lib/docs_knowledge_check.rb
+++ b/lib/docs_knowledge_check.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require "pathname"
+
+# Dependency-free checks for docs knowledge hygiene (OKF-inspired).
+# See docs/KNOWLEDGE.md and issue #411.
+module DocsKnowledgeCheck
+  ROOT_ENTRY_FILES = %w[AGENTS.md CONTRIBUTING.md].freeze
+  INDEX_REL = "docs/index.md"
+  DOCS_GLOB = "docs/**/*.md"
+  LINK_RE = /\[(?:[^\]]*)\]\(([^)]+)\)/
+
+  Result = Struct.new(:errors, keyword_init: true) do
+    def ok?
+      errors.empty?
+    end
+  end
+
+  module_function
+
+  def run(root:)
+    root = Pathname(root).expand_path
+    errors = []
+    errors.concat(broken_links(root))
+    errors.concat(orphans(root))
+    Result.new(errors: errors)
+  end
+
+  def broken_links(root)
+    errors = []
+    markdown_files(root).each do |file|
+      relative_file = file.relative_path_from(root).to_s
+      each_relative_link(file) do |raw_target, line_no|
+        target = resolve_link(file, raw_target)
+        next if target.nil?
+
+        unless target.exist?
+          errors << "#{relative_file}:#{line_no}: broken link -> #{raw_target}"
+        end
+      end
+    end
+    errors
+  end
+
+  def orphans(root)
+    index = root.join(INDEX_REL)
+    return [ "#{INDEX_REL}: missing knowledge map" ] unless index.exist?
+
+    listed = linked_doc_paths(root, index)
+    errors = []
+
+    root.glob(DOCS_GLOB).sort.each do |file|
+      rel = file.relative_path_from(root).to_s
+      next if rel == INDEX_REL
+      next if listed.include?(rel)
+
+      errors << "#{rel}: not listed in #{INDEX_REL}"
+    end
+    errors
+  end
+
+  def markdown_files(root)
+    files = root.glob(DOCS_GLOB)
+    ROOT_ENTRY_FILES.each do |name|
+      path = root.join(name)
+      files << path if path.exist?
+    end
+    files.sort
+  end
+
+  def each_relative_link(file)
+    file.each_line.with_index(1) do |line, line_no|
+      line.scan(LINK_RE) do |match|
+        raw = match[0].strip
+        next if skip_link?(raw)
+
+        yield raw, line_no
+      end
+    end
+  end
+
+  def skip_link?(raw)
+    return true if raw.empty?
+    return true if raw.start_with?("#", "http://", "https://", "mailto:")
+
+    false
+  end
+
+  def resolve_link(from_file, raw)
+    path_part = raw.split("#", 2).first
+    return nil if path_part.nil? || path_part.empty?
+
+    (from_file.dirname + path_part).cleanpath
+  end
+
+  def linked_doc_paths(root, index_file)
+    listed = {}
+    each_relative_link(index_file) do |raw, _line|
+      target = resolve_link(index_file, raw)
+      next if target.nil?
+
+      begin
+        rel = target.relative_path_from(root).to_s.tr("\\", "/")
+      rescue ArgumentError
+        next
+      end
+      next unless rel.start_with?("docs/") && rel.end_with?(".md")
+
+      listed[rel] = true
+    end
+    listed
+  end
+  private_class_method :markdown_files, :each_relative_link, :skip_link?,
+                       :resolve_link, :linked_doc_paths
+end

--- a/test/lib/docs_knowledge_check_test.rb
+++ b/test/lib/docs_knowledge_check_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "fileutils"
+require "tmpdir"
+require_relative "../../lib/docs_knowledge_check"
+
+class DocsKnowledgeCheckTest < ActiveSupport::TestCase
+  def with_fixture_repo
+    Dir.mktmpdir("docs-knowledge-check-") do |dir|
+      root = Pathname(dir)
+      FileUtils.mkdir_p(root.join("docs/decisions"))
+      yield root
+    end
+  end
+
+  def write(root, relative, contents)
+    path = root.join(relative)
+    FileUtils.mkdir_p(path.dirname)
+    path.write(contents)
+  end
+
+  test "passes when links resolve and index lists every doc" do
+    with_fixture_repo do |root|
+      write(root, "docs/index.md", <<~MD)
+        # Map
+        - [Guide](guide.md)
+        - [Decision](decisions/why.md)
+      MD
+      write(root, "docs/guide.md", "[decision](decisions/why.md)\n")
+      write(root, "docs/decisions/why.md", "ok\n")
+      write(root, "AGENTS.md", "See [guide](docs/guide.md)\n")
+
+      result = DocsKnowledgeCheck.run(root: root)
+
+      assert_predicate result, :ok?, result.errors.inspect
+    end
+  end
+
+  test "fails on broken relative markdown links" do
+    with_fixture_repo do |root|
+      write(root, "docs/index.md", "- [Guide](guide.md)\n")
+      write(root, "docs/guide.md", "[missing](nope.md)\n")
+
+      result = DocsKnowledgeCheck.run(root: root)
+
+      assert_not result.ok?
+      assert result.errors.any? { |e| e.include?("broken link") && e.include?("nope.md") },
+             result.errors.inspect
+    end
+  end
+
+  test "fails when a docs file is missing from the knowledge map" do
+    with_fixture_repo do |root|
+      write(root, "docs/index.md", "- [Guide](guide.md)\n")
+      write(root, "docs/guide.md", "ok\n")
+      write(root, "docs/orphan.md", "forgotten\n")
+
+      result = DocsKnowledgeCheck.run(root: root)
+
+      assert_not result.ok?
+      assert result.errors.any? { |e| e.include?("docs/orphan.md") && e.include?("not listed") },
+             result.errors.inspect
+    end
+  end
+
+  test "ignores external and anchor-only links" do
+    with_fixture_repo do |root|
+      write(root, "docs/index.md", <<~MD)
+        - [Guide](guide.md)
+        - [Site](https://example.com/x)
+        - [Jump](#section)
+      MD
+      write(root, "docs/guide.md", "[mail](mailto:a@b.c)\n")
+
+      result = DocsKnowledgeCheck.run(root: root)
+
+      assert_predicate result, :ok?, result.errors.inspect
+    end
+  end
+end


### PR DESCRIPTION
﻿## Summary
- Add dependency-free `bin/check-docs` / `DocsKnowledgeCheck` for broken relative Markdown links and docs orphans missing from `docs/index.md`
- Cover failure modes with Minitest fixtures
- Wire into `bin/validate` (including `--fast`) and CI job `docs_check` (required by `quality_gate`)
- Document in `KNOWLEDGE.md` / `DEVELOPMENT.md` / `log.md`

Closes #411

## Depends on
- #425 / #407 — branched from `docs/407-knowledge-log`
- #423 / #409, #421 / #408, #414 / #406

## Test plan
- [ ] `ruby bin/check-docs` passes on this branch
- [ ] `bundle exec ruby -Itest test/lib/docs_knowledge_check_test.rb` passes
- [ ] CI `docs_check` green
