### PR TITLE
fix(digests): surface load errors and retry transient fetch failures (#426)

### DIFF
--- a/app/frontend/api/client.test.ts
+++ b/app/frontend/api/client.test.ts
@@ -3,6 +3,7 @@ import {
   apiRequest,
   clearMutatingAuthCredentials,
   isAbortError,
+  isTransientNetworkError,
   setMutatingAuthCredentials,
 } from './client'
 
@@ -94,5 +95,14 @@ describe('apiRequest', () => {
     expect(isAbortError(new DOMException('Aborted', 'AbortError'))).toBe(true)
     expect(isAbortError(Object.assign(new Error('Aborted'), { name: 'AbortError' }))).toBe(true)
     expect(isAbortError(new Error('other'))).toBe(false)
+  })
+
+  it('isTransientNetworkError detects common fetch failures', () => {
+    expect(isTransientNetworkError(new TypeError('Failed to fetch'))).toBe(true)
+    expect(isTransientNetworkError(new Error('NetworkError when attempting to fetch resource.'))).toBe(
+      true
+    )
+    expect(isTransientNetworkError(new Error('Request failed: 500'))).toBe(false)
+    expect(isTransientNetworkError(new DOMException('Aborted', 'AbortError'))).toBe(false)
   })
 })

--- a/app/frontend/api/client.ts
+++ b/app/frontend/api/client.ts
@@ -11,6 +11,19 @@ export function isAbortError(error: unknown): boolean {
   )
 }
 
+/** True for common transient browser network failures (offline, connection reset, CORS-ish TypeErrors). */
+export function isTransientNetworkError(error: unknown): boolean {
+  if (!(error instanceof Error) || isAbortError(error)) return false
+  const message = error.message.toLowerCase()
+  return (
+    error.name === 'TypeError' ||
+    message.includes('failed to fetch') ||
+    message.includes('networkerror') ||
+    message.includes('network request failed') ||
+    message.includes('load failed')
+  )
+}
+
 export function setMutatingAuthCredentials(username: string, password: string): void {
   sessionStorage.setItem(MUTATING_AUTH_STORAGE_KEY, btoa(`${username}:${password}`))
 }

--- a/app/frontend/hooks/useAsyncResource.test.ts
+++ b/app/frontend/hooks/useAsyncResource.test.ts
@@ -36,6 +36,19 @@ describe('useAsyncResource', () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false))
     expect(result.current.data).toBeNull()
+    expect(result.current.error).toBe('boom')
+  })
+
+  it('falls back to errorMessage when the loader throws a non-Error', async () => {
+    const loader = vi.fn(async (_signal: AbortSignal) => {
+      throw 'nope'
+    })
+
+    const { result } = renderHook(() =>
+      useAsyncResource(loader, { errorMessage: 'Could not load.' })
+    )
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
     expect(result.current.error).toBe('Could not load.')
   })
 

--- a/app/frontend/hooks/useAsyncResource.ts
+++ b/app/frontend/hooks/useAsyncResource.ts
@@ -14,6 +14,11 @@ interface AsyncResourceState<T> {
   setError: Dispatch<SetStateAction<string | null>>
 }
 
+function resolveLoadError(err: unknown, fallback: string): string {
+  if (err instanceof Error && err.message.trim()) return err.message.trim()
+  return fallback
+}
+
 export function useAsyncResource<T>(
   loader: (signal: AbortSignal) => Promise<T>,
   options: UseAsyncResourceOptions = {}
@@ -43,7 +48,7 @@ export function useAsyncResource<T>(
       setData(result)
     } catch (err) {
       if (isAbortError(err) || signal.aborted) return
-      setError(errorMessage)
+      setError(resolveLoadError(err, errorMessage))
     } finally {
       if (!signal.aborted) setLoading(false)
     }

--- a/app/frontend/pages/BookmarksIndexPage.test.tsx
+++ b/app/frontend/pages/BookmarksIndexPage.test.tsx
@@ -84,7 +84,7 @@ describe('BookmarksIndexPage', () => {
 
     renderPage()
 
-    expect(await screen.findByText('Failed to load reading list. Please try again.')).toBeInTheDocument()
+    expect(await screen.findByText('network')).toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: 'Retry' }))
 

--- a/app/frontend/pages/DigestsIndexPage.test.tsx
+++ b/app/frontend/pages/DigestsIndexPage.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import DigestsIndexPage from './DigestsIndexPage'
+import * as digestsApi from '../api/digests'
+import type { DigestSummary } from '../api/digests'
+
+vi.mock('../api/digests', () => ({
+  fetchDigests: vi.fn(),
+  createDigest: vi.fn(),
+}))
+
+function buildDigest(overrides: Partial<DigestSummary> = {}): DigestSummary {
+  return {
+    id: 1,
+    period: 'daily',
+    window_start: '2026-08-01T00:00:00Z',
+    window_end: '2026-08-02T00:00:00Z',
+    payload: {
+      period: 'daily',
+      generated_at: '2026-08-02T00:00:00Z',
+      window_start: '2026-08-01T00:00:00Z',
+      window_end: '2026-08-02T00:00:00Z',
+      themes: [{ title: 'General Tech', summary: 'One title', article_ids: [10] }],
+      articles: [
+        {
+          id: 10,
+          title: 'Example article',
+          url: 'https://example.com/a',
+          source_type: 'hacker_news',
+          score: 42,
+          why: 'Unread from hacker news',
+        },
+      ],
+    },
+    created_at: '2026-08-02T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/digests']}>
+      <DigestsIndexPage />
+    </MemoryRouter>
+  )
+}
+
+describe('DigestsIndexPage', () => {
+  beforeEach(() => {
+    vi.mocked(digestsApi.fetchDigests).mockResolvedValue({ digests: [] })
+    vi.mocked(digestsApi.createDigest).mockResolvedValue(buildDigest())
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows empty state when there are no digests', async () => {
+    renderPage()
+
+    expect(await screen.findByRole('heading', { name: 'Digests' })).toBeInTheDocument()
+    expect(screen.getByText('No digests yet')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Generate daily digest' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Generate weekly digest' })).toBeInTheDocument()
+  })
+
+  it('lists digests when the API returns rows', async () => {
+    vi.mocked(digestsApi.fetchDigests).mockResolvedValue({ digests: [buildDigest()] })
+
+    renderPage()
+
+    expect(await screen.findByText('daily digest')).toBeInTheDocument()
+    expect(screen.getByText('1 articles · 1 themes')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'View digest' })).toHaveAttribute('href', '/digests/1')
+  })
+
+  it('surfaces the underlying load error and recovers on retry', async () => {
+    vi.mocked(digestsApi.fetchDigests).mockRejectedValueOnce(new Error('Request failed: 500'))
+    vi.mocked(digestsApi.fetchDigests).mockResolvedValueOnce({ digests: [] })
+    const user = userEvent.setup()
+
+    renderPage()
+
+    expect(await screen.findByText('Request failed: 500')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Retry' }))
+
+    expect(await screen.findByText('No digests yet')).toBeInTheDocument()
+    expect(digestsApi.fetchDigests).toHaveBeenCalledTimes(2)
+  })
+
+  it('retries once on transient network failure before succeeding', async () => {
+    vi.mocked(digestsApi.fetchDigests).mockRejectedValueOnce(new TypeError('Failed to fetch'))
+    vi.mocked(digestsApi.fetchDigests).mockResolvedValueOnce({ digests: [] })
+
+    renderPage()
+
+    expect(await screen.findByText('No digests yet')).toBeInTheDocument()
+    expect(digestsApi.fetchDigests).toHaveBeenCalledTimes(2)
+  })
+
+  it('prepends a generated digest to the list', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    expect(await screen.findByText('No digests yet')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Generate daily digest' }))
+
+    await waitFor(() => {
+      expect(digestsApi.createDigest).toHaveBeenCalledWith('daily')
+    })
+    expect(await screen.findByText('daily digest')).toBeInTheDocument()
+  })
+})

--- a/app/frontend/pages/DigestsIndexPage.tsx
+++ b/app/frontend/pages/DigestsIndexPage.tsx
@@ -1,5 +1,7 @@
 import { Link } from 'react-router-dom'
 import { createDigest, fetchDigests } from '../api/digests'
+import type { DigestSummary } from '../api/digests'
+import { isAbortError, isTransientNetworkError } from '../api/client'
 import EmptyState from '../components/EmptyState'
 import PageShell from '../components/PageShell'
 import PageHeading from '../components/ui/PageHeading'
@@ -8,9 +10,18 @@ import Card from '../components/ui/Card'
 import { useAsyncResource } from '../hooks/useAsyncResource'
 import { useState } from 'react'
 
+async function fetchDigestsWithRetry(signal: AbortSignal): Promise<{ digests: DigestSummary[] }> {
+  try {
+    return await fetchDigests(signal)
+  } catch (err) {
+    if (isAbortError(err) || signal.aborted || !isTransientNetworkError(err)) throw err
+    return await fetchDigests(signal)
+  }
+}
+
 export default function DigestsIndexPage() {
   const { data, loading, error, reload, setData, setError } = useAsyncResource(
-    (signal) => fetchDigests(signal),
+    (signal) => fetchDigestsWithRetry(signal),
     { errorMessage: 'Failed to load digests. Please try again.' }
   )
   const [generating, setGenerating] = useState(false)

--- a/app/views/digests/index.html.erb
+++ b/app/views/digests/index.html.erb
@@ -1,2 +1,1 @@
-﻿<%# Digests index is rendered by React (app/frontend/pages/DigestsIndexPage.tsx) %>
-
+<%# Digests index is rendered by React (app/frontend/pages/DigestsIndexPage.tsx) %>

--- a/app/views/digests/show.html.erb
+++ b/app/views/digests/show.html.erb
@@ -1,2 +1,1 @@
-﻿<%# Digest show is rendered by React (app/frontend/pages/DigestsShowPage.tsx) %>
-
+<%# Digest show is rendered by React (app/frontend/pages/DigestsShowPage.tsx) %>


### PR DESCRIPTION
## Summary

- Surface the underlying `apiRequest` / network error message from `useAsyncResource` instead of always replacing it with a generic string
- Retry Digests index load once on transient network failures (`Failed to fetch`, etc.)
- Add `DigestsIndexPage` coverage for empty, list, error+retry, network retry, and generate
- Strip UTF-8 BOM from digests ERB view shells

Closes #426

## Test plan

- [x] `npm test -- --run DigestsIndexPage.test.tsx useAsyncResource.test.ts client.test.ts BookmarksIndexPage.test.tsx`
- [ ] Open `/digests` with Rails up → empty state (not fatal error)
- [ ] Stop Rails briefly / throttle network → Retry shows actionable message; transient failure recovers after one auto-retry when possible
