### PR TITLE
fix(reddit): load allowlisted .env secrets so OAuth can activate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,8 +39,10 @@ SECRET_KEY_BASE=your_secret_key_base_here
 # DEVTO_API_KEY=
 
 # Optional Reddit OAuth (script/web app credentials from https://www.reddit.com/prefs/apps).
-# When both are set, Reddit fetchers use oauth.reddit.com JSON listings and persist
-# score / comment_count. Without them, public Atom RSS is used (scores stay 0).
+# When both are set AND loaded into the Rails process, Reddit fetchers use
+# oauth.reddit.com JSON listings and persist score / comment_count.
+# Loaders: LocalEnv (dev initializer), bin/dev, .\dev.ps1 — see docs/DEVELOPMENT.md.
+# Without them, public Atom RSS is used (scores stay 0). Verify: bin/rails news:reddit_oauth_status
 # REDDIT_CLIENT_ID=
 # REDDIT_CLIENT_SECRET=
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,4 +48,6 @@ jobs:
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
           MUTATING_AUTH_USERNAME: ${{ secrets.MUTATING_AUTH_USERNAME }}
           MUTATING_AUTH_PASSWORD: ${{ secrets.MUTATING_AUTH_PASSWORD }}
+          REDDIT_CLIENT_ID: ${{ secrets.REDDIT_CLIENT_ID }}
+          REDDIT_CLIENT_SECRET: ${{ secrets.REDDIT_CLIENT_SECRET }}
         run: bundle exec kamal deploy

--- a/.kamal/secrets
+++ b/.kamal/secrets
@@ -17,3 +17,7 @@ RAILS_MASTER_KEY=${RAILS_MASTER_KEY:-$(cat config/master.key)}
 # Mutating API HTTP Basic (uncomment and set when deploying publicly)
 # MUTATING_AUTH_USERNAME=$MUTATING_AUTH_USERNAME
 # MUTATING_AUTH_PASSWORD=$MUTATING_AUTH_PASSWORD
+
+# Optional Reddit OAuth (scores/comments via oauth.reddit.com). Leave unset for Atom RSS.
+# REDDIT_CLIENT_ID=$REDDIT_CLIENT_ID
+# REDDIT_CLIENT_SECRET=$REDDIT_CLIENT_SECRET

--- a/bin/dev
+++ b/bin/dev
@@ -2,4 +2,10 @@
 # Rails-only: runs `bin/rails server`. Does not start Vite.
 # Full stack: `npm run dev` + Rails, or `.\dev.ps1` on Windows.
 # See docs/DEVELOPMENT.md and AGENTS.md.
+#
+# Loads allowlisted keys from `.env` into ENV (when unset) so optional
+# secrets like REDDIT_CLIENT_* reach the Rails process without dotenv-rails.
+require_relative "../lib/local_env"
+LocalEnv.load!
+
 exec "./bin/rails", "server", *ARGV

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -33,8 +33,11 @@ registry:
 env:
   secret:
     - RAILS_MASTER_KEY
-    # For public deploys, also add MUTATING_AUTH_USERNAME and MUTATING_AUTH_PASSWORD
-    # here and define them in .kamal/secrets (see docs/DEVELOPMENT.md).
+    # Optional — uncomment when defined in .kamal/secrets (see docs/DEVELOPMENT.md):
+    # - MUTATING_AUTH_USERNAME
+    # - MUTATING_AUTH_PASSWORD
+    # - REDDIT_CLIENT_ID
+    # - REDDIT_CLIENT_SECRET
   clear:
     # Run the Solid Queue Supervisor inside the web server's Puma process to do jobs.
     # When you start using multiple servers, you should split out job processing to a dedicated machine.

--- a/config/initializers/local_env.rb
+++ b/config/initializers/local_env.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Development-only: load allowlisted keys from `.env` into ENV when unset.
+# Production uses Kamal secrets; tests set ENV explicitly.
+require Rails.root.join("lib/local_env")
+
+LocalEnv.load! if Rails.env.development?

--- a/dev.ps1
+++ b/dev.ps1
@@ -106,6 +106,50 @@ function Get-NpmCmdPath {
     return $npmCmd
 }
 
+# Allowlisted keys mirrored from lib/local_env.rb / .env.example.
+$script:LocalEnvAllowlist = @(
+    "POSTGRES_USER", "POSTGRES_PASSWORD", "POSTGRES_DB",
+    "DB_HOST", "DB_PORT", "DB_USERNAME", "DB_PASSWORD",
+    "SECRET_KEY_BASE", "APP_HOSTS",
+    "MUTATING_AUTH_USERNAME", "MUTATING_AUTH_PASSWORD",
+    "ERROR_WEBHOOK_URL",
+    "REDDIT_CLIENT_ID", "REDDIT_CLIENT_SECRET",
+    "YOUTUBE_API_KEY",
+    "ARTICLE_SUMMARIZER_PROVIDER",
+    "OPENAI_API_KEY", "OPENAI_API_URL", "OPENAI_MODEL",
+    "OLLAMA_BASE_URL", "OLLAMA_MODEL"
+)
+
+function Import-LocalDotEnv {
+    param([string]$Path = (Join-Path $root ".env"))
+
+    if (-not (Test-Path $Path)) { return 0 }
+
+    $script:DotEnvLoadedCount = 0
+    Get-Content -Path $Path -Encoding UTF8 | ForEach-Object {
+        $line = $_.Trim()
+        if ([string]::IsNullOrWhiteSpace($line) -or $line.StartsWith("#")) { return }
+        $eq = $line.IndexOf("=")
+        if ($eq -lt 1) { return }
+
+        $key = $line.Substring(0, $eq).Trim()
+        if ($script:LocalEnvAllowlist -notcontains $key) { return }
+
+        $existing = [Environment]::GetEnvironmentVariable($key, "Process")
+        if (-not [string]::IsNullOrWhiteSpace($existing)) { return }
+
+        $value = $line.Substring($eq + 1).Trim()
+        if (($value.StartsWith('"') -and $value.EndsWith('"')) -or
+            ($value.StartsWith("'") -and $value.EndsWith("'"))) {
+            $value = $value.Substring(1, $value.Length - 2)
+        }
+
+        Set-Item -Path "Env:$key" -Value $value
+        $script:DotEnvLoadedCount++
+    }
+    return $script:DotEnvLoadedCount
+}
+
 function Start-NpmRunDev {
     param([string]$WorkingDirectory)
 
@@ -160,6 +204,13 @@ function Start-BrowserWhenReady {
 }
 
 Disable-ConsoleQuickEdit
+
+$dotenvLoaded = Import-LocalDotEnv
+if ($dotenvLoaded -gt 0) {
+    Write-Host "Loaded $dotenvLoaded allowlisted key(s) from .env into the process." -ForegroundColor DarkGray
+} elseif (-not (Test-Path (Join-Path $root ".env"))) {
+    Write-Host "No .env found. Copy .env.example to .env for optional secrets (Reddit OAuth, YouTube, etc.)." -ForegroundColor DarkGray
+}
 
 Start-PostgresIfNeeded
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -82,6 +82,9 @@ bin/rails news:fetch
 # Show last fetch outcome per source
 bin/rails news:fetch_status
 
+# Reddit OAuth: present?/length only (never prints secrets)
+bin/rails news:reddit_oauth_status
+
 # Show latest 10 articles
 bin/rails news:latest
 
@@ -249,7 +252,7 @@ config/schedule.rb                      # Cron job definitions
 
 **Dev.to**: Uses REST API (`dev.to/api/articles`) with query params for pagination and filtering by top posts from last 7 days.
 
-**Reddit**: Multiple instances for different subreddits. Each subreddit is treated as a separate source type in the database. By default, fetchers read the public Atom feed (`/r/{subreddit}/.rss`) because unauthenticated `.json` listings return HTTP 403 (Atom has no score fields, so new articles seed `score`/`comment_count` to 0). Set `REDDIT_CLIENT_ID` and `REDDIT_CLIENT_SECRET` to switch to OAuth JSON listings on `oauth.reddit.com`, which persist real scores and comment counts. Requests share a configurable throttle (`apis.reddit.min_request_interval_seconds`, default 2.5s); HTTP 429 responses are retried with backoff (`apis.reddit.rate_limit_max_retries`) and failures are recorded on `FetchRun` instead of silent zero-article success.
+**Reddit**: Multiple instances for different subreddits. Each subreddit is treated as a separate source type in the database. By default, fetchers read the public Atom feed (`/r/{subreddit}/.rss`) because unauthenticated `.json` listings return HTTP 403 (Atom has no score fields, so new articles seed `score`/`comment_count` to 0). Set `REDDIT_CLIENT_ID` and `REDDIT_CLIENT_SECRET` in `.env` (loaded into the Rails process by `LocalEnv` / `dev.ps1` / `bin/dev` — see Environment configuration) to switch to OAuth JSON listings on `oauth.reddit.com`, which persist real scores and comment counts. Check with `bin/rails news:reddit_oauth_status` (prints present/length only, never secret values). Requests share a configurable throttle (`apis.reddit.min_request_interval_seconds`); HTTP 429 responses are retried with backoff (`apis.reddit.rate_limit_max_retries`) and failures are recorded on `FetchRun` instead of silent zero-article success.
 
 **YouTube**: Channel uploads via public Atom feeds (no API key). Optional `YOUTUBE_API_KEY` enables `videos.list` enrichment (duration/stats) and opt-in keyword `search.list` discovery with a hard daily budget. Manage channels at `/sources`. Full quota/config details: [YOUTUBE.md](YOUTUBE.md).
 
@@ -265,12 +268,24 @@ Articles table uses generic fields to accommodate all news sources:
 
 ### Environment configuration
 
-Copy `.env.example` to `.env` before starting the stack. Docker Compose reads it to create the PostgreSQL container:
+Copy `.env.example` to `.env` before starting the stack (`.\setup-local-env.ps1` creates `.env` from the example when missing). Docker Compose reads `.env` to create the PostgreSQL container:
 - `POSTGRES_USER`: dev_news_user
 - `POSTGRES_PASSWORD`: dev_password
 - `POSTGRES_DB`: dev_news_aggregator_development
 
-`config/database.yml` falls back to those same credentials (`DB_USERNAME`, `DB_PASSWORD`, `DB_HOST`, `DB_PORT`), so Rails connects to the container with no extra setup. Rails does not load `.env` itself — export `DB_*` in your shell only when pointing Rails at a different database. Windows setup (`setup-local-env.ps1`) uses the same credentials.
+`config/database.yml` falls back to those same credentials (`DB_USERNAME`, `DB_PASSWORD`, `DB_HOST`, `DB_PORT`), so Rails connects to the container with no extra setup.
+
+**Important:** there is no `dotenv-rails` gem. Putting secrets only in the `.env` file is not enough unless something loads them into the process:
+
+| Loader | When |
+|--------|------|
+| `LocalEnv` (`lib/local_env.rb`) via `config/initializers/local_env.rb` | Development Rails boot (`bin/rails`, console, runners) |
+| `bin/dev` | Before `bin/rails server` |
+| `.\dev.ps1` | Before starting Vite + Rails on Windows |
+
+Only allowlisted keys from `.env.example` are imported, and existing ENV values are never overwritten. Export `DB_*` in your shell only when pointing Rails at a different database.
+
+For Reddit OAuth scores: set both `REDDIT_CLIENT_ID` and `REDDIT_CLIENT_SECRET` in `.env`, restart the app, then run `bin/rails news:reddit_oauth_status` and confirm `oauth_configured: true` / `fetch_path: oauth_json`. New Reddit apps may require Reddit’s API approval (Responsible Builder Policy); that is outside this repo.
 
 ### Key features
 
@@ -362,7 +377,8 @@ CD is implemented as `.github/workflows/deploy.yml` (manual `workflow_dispatch`)
 | Variable | `KAMAL_SERVER_HOST` | Host/IP for `ssh-keyscan` (same as `servers.web`) |
 | Secret | `SSH_PRIVATE_KEY` | Private key for the deploy user |
 | Secret | `RAILS_MASTER_KEY` | Production credentials key |
-| Secret | `MUTATING_AUTH_USERNAME` / `MUTATING_AUTH_PASSWORD` | Optional; enable mutating Basic auth |
+| Secret | `MUTATING_AUTH_USERNAME` / `MUTATING_AUTH_PASSWORD` | Optional; enable mutating Basic auth (uncomment in `config/deploy.yml` + `.kamal/secrets`) |
+| Secret | `REDDIT_CLIENT_ID` / `REDDIT_CLIENT_SECRET` | Optional; Reddit OAuth JSON listings with scores (uncomment in `config/deploy.yml` + `.kamal/secrets`) |
 
 Images push to `ghcr.io/marcoslorejan/dev-news-aggregator` using `GITHUB_TOKEN`. Use a GitHub Environment named `production` for optional approval gates.
 

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -194,7 +194,8 @@ dev-news-aggregator/
 | Path | Purpose |
 |------|---------|
 | `lib/docs_knowledge_check.rb` | Dependency-free docs link + knowledge-map orphan checks |
-| `lib/tasks/news.rake` | `news:fetch`, `news:fetch_status`, `news:latest`, `news:clean` rake tasks |
+| `lib/local_env.rb` | Allowlisted `.env` → ENV loader (no dotenv gem; used by `bin/dev` + dev initializer) |
+| `lib/tasks/news.rake` | `news:fetch`, `news:fetch_status`, `news:reddit_oauth_status`, `news:latest`, `news:clean` rake tasks |
 
 ## `test/`
 
@@ -249,12 +250,12 @@ dev-news-aggregator/
 | `.env.example` | Template for local env vars (Postgres, `SECRET_KEY_BASE`, optional API keys) |
 | `Gemfile` / `Gemfile.lock` | Ruby gems |
 | `package.json` / `package-lock.json` | Node packages |
-| `bin/dev` | Rails-only server wrapper (`bin/rails server`); does **not** start Vite |
+| `bin/dev` | Rails-only server wrapper; loads allowlisted `.env` keys then `bin/rails server`; does **not** start Vite |
 | `bin/validate` | Local CI-equivalent checks (includes `bin/check-docs`) |
 | `bin/check-docs` | Docs relative-link + knowledge-map orphan checker |
-| `dev.ps1` | Windows helper that starts Postgres (if needed), Vite + Rails, and opens the browser |
+| `dev.ps1` | Windows helper: loads `.env`, starts Postgres (if needed), Vite + Rails, opens the browser |
 | `start-app.bat` | Double-click launcher for `dev.ps1` (full stack) |
-| `setup-local-env.ps1` | Windows one-time/repeat setup (bundle, npm, Postgres, `db:prepare`) |
+| `setup-local-env.ps1` | Windows one-time/repeat setup (creates `.env` from example if missing, bundle, npm, Postgres, `db:prepare`) |
 | `docker-compose.yml` | Local PostgreSQL container |
 | `Dockerfile` | Production/container image |
 | `.trivyignore` | Baselined Trivy CVEs for CI `docker_scan` |

--- a/lib/local_env.rb
+++ b/lib/local_env.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+# Loads allowlisted KEY=VALUE pairs from a local `.env` into ENV when unset.
+# Rails has no dotenv gem; Docker Compose reads `.env` for Postgres only.
+# See docs/DEVELOPMENT.md (Environment configuration).
+module LocalEnv
+  ROOT = File.expand_path("..", __dir__)
+  DEFAULT_PATH = File.join(ROOT, ".env")
+
+  # Optional app secrets / toggles documented in `.env.example`.
+  # Postgres keys are listed so `bin/dev` / `dev.ps1` can expose them to Rails
+  # when pointing at a non-default DB; Compose still reads `.env` for the container.
+  ALLOWLIST = %w[
+    POSTGRES_USER
+    POSTGRES_PASSWORD
+    POSTGRES_DB
+    DB_HOST
+    DB_PORT
+    DB_USERNAME
+    DB_PASSWORD
+    SECRET_KEY_BASE
+    APP_HOSTS
+    MUTATING_AUTH_USERNAME
+    MUTATING_AUTH_PASSWORD
+    ERROR_WEBHOOK_URL
+    REDDIT_CLIENT_ID
+    REDDIT_CLIENT_SECRET
+    YOUTUBE_API_KEY
+    ARTICLE_SUMMARIZER_PROVIDER
+    OPENAI_API_KEY
+    OPENAI_API_URL
+    OPENAI_MODEL
+    OLLAMA_BASE_URL
+    OLLAMA_MODEL
+  ].freeze
+
+  module_function
+
+  def load!(path: DEFAULT_PATH, overwrite: false)
+    return 0 unless File.file?(path)
+
+    loaded = 0
+    File.foreach(path, encoding: "UTF-8") do |raw|
+      line = raw.strip
+      next if line.empty? || line.start_with?("#")
+
+      key, value = line.split("=", 2)
+      next if key.nil? || value.nil?
+
+      key = key.strip
+      next unless ALLOWLIST.include?(key)
+      next if !overwrite && env_set?(key)
+
+      ENV[key] = unquote(value.strip)
+      loaded += 1
+    end
+    loaded
+  end
+
+  def env_set?(key)
+    value = ENV[key]
+    !(value.nil? || value.to_s.strip.empty?)
+  end
+
+  def unquote(value)
+    if (value.start_with?('"') && value.end_with?('"')) ||
+       (value.start_with?("'") && value.end_with?("'"))
+      return value[1..-2]
+    end
+
+    value
+  end
+
+  def present_masked(key)
+    value = ENV[key].to_s
+    return { key: key, present: false, length: 0 } if value.strip.empty?
+
+    { key: key, present: true, length: value.length }
+  end
+end

--- a/lib/tasks/news.rake
+++ b/lib/tasks/news.rake
@@ -54,4 +54,44 @@ namespace :news do
     end
     puts "Removed #{count} articles older than #{retention_days} days (before #{cutoff.to_date})"
   end
+
+  desc "Show Reddit OAuth status without printing secrets"
+  task reddit_oauth_status: :environment do
+    require Rails.root.join("lib/local_env")
+    LocalEnv.load! if Rails.env.development?
+
+    id = LocalEnv.present_masked("REDDIT_CLIENT_ID")
+    secret = LocalEnv.present_masked("REDDIT_CLIENT_SECRET")
+    configured = NewsFetchers::RedditFetcher.oauth_configured?
+    path = configured ? "oauth_json" : "atom_rss"
+
+    puts "Reddit OAuth status (values never printed):"
+    puts "  REDDIT_CLIENT_ID:     present=#{id[:present]} length=#{id[:length]}"
+    puts "  REDDIT_CLIENT_SECRET: present=#{secret[:present]} length=#{secret[:length]}"
+    puts "  oauth_configured:     #{configured}"
+    puts "  fetch_path:           #{path}"
+
+    if configured
+      puts "  hint: new Reddit articles should persist score/comment_count from JSON listings."
+    else
+      puts "  hint: copy .env.example → .env, set both REDDIT_* keys, restart Rails (dev.ps1 / bin/dev load .env)."
+      puts "  Without credentials, Atom RSS is used and scores stay 0 on create."
+    end
+
+    begin
+      reddit_runs = FetchRun.where("source_key LIKE ?", "reddit_%").order(:source_key)
+      if reddit_runs.any?
+        puts "\nRecent Reddit FetchRun outcomes:"
+        reddit_runs.each do |run|
+          line = "  #{run.source_key}: #{run.status} (#{run.articles_count} articles) at #{run.finished_at}"
+          line += " — #{run.error_class}" if run.failure?
+          puts line
+        end
+      else
+        puts "\nNo Reddit FetchRun rows yet. Run: bin/rails news:fetch"
+      end
+    rescue ActiveRecord::ConnectionNotEstablished, ActiveRecord::NoDatabaseError => e
+      puts "\nSkipped FetchRun lookup (database unavailable): #{e.class}"
+    end
+  end
 end

--- a/setup-local-env.ps1
+++ b/setup-local-env.ps1
@@ -5,6 +5,20 @@ $ErrorActionPreference = "Stop"
 $root = $PSScriptRoot
 Set-Location $root
 
+$envExample = Join-Path $root ".env.example"
+$envFile = Join-Path $root ".env"
+if (-not (Test-Path $envFile)) {
+    if (Test-Path $envExample) {
+        Write-Host "==> Creating .env from .env.example..." -ForegroundColor Cyan
+        Copy-Item $envExample $envFile
+        Write-Host "    Fill optional REDDIT_CLIENT_ID / REDDIT_CLIENT_SECRET for OAuth scores." -ForegroundColor DarkGray
+    } else {
+        Write-Host "Missing .env.example — skip creating .env." -ForegroundColor Yellow
+    }
+} else {
+    Write-Host "==> .env already present (left unchanged)." -ForegroundColor DarkGray
+}
+
 Write-Host "==> Installing Ruby gems..." -ForegroundColor Cyan
 bundle install
 

--- a/test/lib/local_env_test.rb
+++ b/test/lib/local_env_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class LocalEnvTest < ActiveSupport::TestCase
+  def setup
+    @path = Rails.root.join("tmp/local_env_test.env")
+    @previous = LocalEnv::ALLOWLIST.index_with { |key| ENV[key] }
+  end
+
+  def teardown
+    FileUtils.rm_f(@path)
+    LocalEnv::ALLOWLIST.each do |key|
+      previous = @previous[key]
+      if previous.nil?
+        ENV.delete(key)
+      else
+        ENV[key] = previous
+      end
+    end
+  end
+
+  test "load! sets allowlisted keys from dotenv file when unset" do
+    ENV.delete("REDDIT_CLIENT_ID")
+    ENV.delete("REDDIT_CLIENT_SECRET")
+    ENV.delete("YOUTUBE_API_KEY")
+
+    File.write(@path, <<~ENV)
+      # comment
+      REDDIT_CLIENT_ID=abc123
+      REDDIT_CLIENT_SECRET="sec ret"
+      YOUTUBE_API_KEY='yt-key'
+      UNKNOWN_SHOULD_IGNORE=nope
+    ENV
+
+    loaded = LocalEnv.load!(path: @path.to_s)
+    assert_operator loaded, :>=, 3
+    assert_equal "abc123", ENV["REDDIT_CLIENT_ID"]
+    assert_equal "sec ret", ENV["REDDIT_CLIENT_SECRET"]
+    assert_equal "yt-key", ENV["YOUTUBE_API_KEY"]
+    assert_nil ENV["UNKNOWN_SHOULD_IGNORE"]
+  end
+
+  test "load! does not overwrite existing ENV by default" do
+    ENV["REDDIT_CLIENT_ID"] = "already-set"
+    File.write(@path, "REDDIT_CLIENT_ID=from-file\n")
+
+    LocalEnv.load!(path: @path.to_s)
+    assert_equal "already-set", ENV["REDDIT_CLIENT_ID"]
+  end
+
+  test "present_masked never returns the secret value" do
+    ENV["REDDIT_CLIENT_SECRET"] = "super-secret-value"
+    masked = LocalEnv.present_masked("REDDIT_CLIENT_SECRET")
+
+    assert_equal true, masked[:present]
+    assert_equal "super-secret-value".length, masked[:length]
+    assert_equal "REDDIT_CLIENT_SECRET", masked[:key]
+    assert_nil masked[:value]
+    refute_includes masked.inspect, "super-secret-value"
+  end
+end

--- a/test/tasks/news_rake_test.rb
+++ b/test/tasks/news_rake_test.rb
@@ -83,4 +83,61 @@ class NewsRakeTest < ActiveSupport::TestCase
   ensure
     Rake::Task["news:clean"].reenable
   end
+
+  test "news:reddit_oauth_status reports masked configuration without secrets" do
+    previous_id = ENV["REDDIT_CLIENT_ID"]
+    previous_secret = ENV["REDDIT_CLIENT_SECRET"]
+    ENV.delete("REDDIT_CLIENT_ID")
+    ENV.delete("REDDIT_CLIENT_SECRET")
+    NewsFetchers::RedditFetcher.reset_oauth_token!
+
+    output = capture_io do
+      Rake::Task["news:reddit_oauth_status"].invoke
+    end.join
+
+    assert_match(/oauth_configured:\s+false/, output)
+    assert_match(/fetch_path:\s+atom_rss/, output)
+    assert_match(/present=false/, output)
+    refute_match(/REDDIT_CLIENT_SECRET=\S+/, output)
+  ensure
+    if previous_id
+      ENV["REDDIT_CLIENT_ID"] = previous_id
+    else
+      ENV.delete("REDDIT_CLIENT_ID")
+    end
+    if previous_secret
+      ENV["REDDIT_CLIENT_SECRET"] = previous_secret
+    else
+      ENV.delete("REDDIT_CLIENT_SECRET")
+    end
+    Rake::Task["news:reddit_oauth_status"].reenable
+  end
+
+  test "news:reddit_oauth_status reports oauth path when both credentials present" do
+    previous_id = ENV["REDDIT_CLIENT_ID"]
+    previous_secret = ENV["REDDIT_CLIENT_SECRET"]
+    ENV["REDDIT_CLIENT_ID"] = "test-client-id"
+    ENV["REDDIT_CLIENT_SECRET"] = "test-client-secret-value"
+
+    output = capture_io do
+      Rake::Task["news:reddit_oauth_status"].invoke
+    end.join
+
+    assert_match(/oauth_configured:\s+true/, output)
+    assert_match(/fetch_path:\s+oauth_json/, output)
+    assert_match(/present=true length=#{ENV['REDDIT_CLIENT_SECRET'].length}/, output)
+    refute_includes output, "test-client-secret-value"
+  ensure
+    if previous_id
+      ENV["REDDIT_CLIENT_ID"] = previous_id
+    else
+      ENV.delete("REDDIT_CLIENT_ID")
+    end
+    if previous_secret
+      ENV["REDDIT_CLIENT_SECRET"] = previous_secret
+    else
+      ENV.delete("REDDIT_CLIENT_SECRET")
+    end
+    Rake::Task["news:reddit_oauth_status"].reenable
+  end
 end


### PR DESCRIPTION
## Summary

- Root cause: Rails never loaded `.env`, so `REDDIT_CLIENT_*` never reached `oauth_configured?` (Atom path forever).
- Add `LocalEnv` allowlisted loader + development initializer, `bin/dev` / `dev.ps1` / `setup-local-env.ps1` hooks.
- Add `bin/rails news:reddit_oauth_status` (present/length only — never prints secrets).
- Document env loading; wire optional Reddit secrets in Kamal/CI (commented until set).

## Test plan

- [x] Standalone `LocalEnv` smoke (no secrets leaked)
- [x] RuboCop on changed Ruby files
- [ ] With Docker/Postgres: `bin/rails test test/lib/local_env_test.rb test/tasks/news_rake_test.rb`
- [ ] Copy `.env.example` → `.env`, set both `REDDIT_*`, restart via `.\dev.ps1` or `bin/dev`
- [ ] `bin/rails news:reddit_oauth_status` → `oauth_configured: true` / `fetch_path: oauth_json`
- [ ] `bin/rails news:fetch` then confirm new Reddit articles have non-zero scores when OAuth works
