### PR TITLE
feat(youtube): HD thumbs, skip Shorts, retune default channels (#439)

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -155,6 +155,7 @@ class ArticlesController < ApplicationController
     scope = apply_keyword_filter(scope)
     scope = apply_content_type_filter(scope)
     scope = apply_max_duration_filter(scope)
+    scope = apply_shorts_exclusion(scope)
     scope = scope.with_topic_tag(params[:tag])
     scope = helpers.apply_category_filter(scope, params[:category]) if apply_category
     scope = ArticleClusterer.primaries(scope)
@@ -167,6 +168,22 @@ class ArticlesController < ApplicationController
     when "article" then scope.articles_only
     else scope
     end
+  end
+
+  # Hide Shorts even before enrichment: URL/title markers, and known ultra-short durations.
+  def apply_shorts_exclusion(scope)
+    return scope unless NewsAggregatorConfig.youtube_exclude_shorts?
+
+    max_short = NewsAggregatorConfig.youtube_shorts_max_seconds
+    scope = scope.where.not("articles.url ILIKE ?", "%/shorts/%")
+    scope = scope.where.not("articles.title ILIKE ?", "%#shorts%")
+    return scope if max_short <= 0
+
+    scope.where(
+      "articles.content_type != ? OR articles.duration_seconds IS NULL OR articles.duration_seconds > ?",
+      "video",
+      max_short
+    )
   end
 
   # max_duration is in minutes. Text articles are untouched; videos with unknown duration

--- a/app/frontend/components/ArticleCard.test.tsx
+++ b/app/frontend/components/ArticleCard.test.tsx
@@ -177,7 +177,7 @@ describe('ArticleCard', () => {
     expect(thumb).toHaveAttribute('aria-label', 'Watch Hexagonal Architecture in Rails')
     expect(thumb.querySelector('img')).toHaveAttribute(
       'src',
-      'https://i.ytimg.com/vi/abc123/hqdefault.jpg'
+      'https://i.ytimg.com/vi/abc123/maxresdefault.jpg'
     )
     expect(screen.getByTestId('video-duration')).toHaveTextContent('6:12')
     expect(screen.getByTestId('video-channel')).toHaveTextContent('Thoughtbot')

--- a/app/frontend/components/articleCard/VideoThumbnail.tsx
+++ b/app/frontend/components/articleCard/VideoThumbnail.tsx
@@ -1,5 +1,6 @@
-import type { MouseEvent } from 'react'
+import { useState, type MouseEvent } from 'react'
 import { formatDuration } from '../../utils/format'
+import { nextYoutubeThumbnail, preferYoutubeThumbnail } from '../../utils/youtubeThumbnail'
 
 interface VideoThumbnailProps {
   title: string
@@ -19,6 +20,7 @@ export default function VideoThumbnail({
   durationSeconds,
 }: VideoThumbnailProps) {
   const duration = formatDuration(durationSeconds)
+  const [src, setSrc] = useState(() => preferYoutubeThumbnail(thumbnailUrl) ?? thumbnailUrl ?? null)
 
   return (
     <a
@@ -30,13 +32,19 @@ export default function VideoThumbnail({
       data-testid="video-thumbnail"
       aria-label={`Watch ${title}`}
     >
-      {thumbnailUrl ? (
+      {src ? (
         <img
-          src={thumbnailUrl}
+          src={src}
           alt=""
           loading="lazy"
           decoding="async"
           className="h-full w-full object-cover transition-transform duration-200 group-hover/thumb:scale-[1.02]"
+          onError={() => {
+            setSrc((current) => {
+              if (!current) return null
+              return nextYoutubeThumbnail(current)
+            })
+          }}
         />
       ) : (
         <div
@@ -66,7 +74,7 @@ export default function VideoThumbnail({
   )
 }
 
-function PlayIcon({ className }: { className?: string }) {
+function PlayIcon({ className }: { className: string }) {
   return (
     <svg className={className} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
       <path d="M8 5.14v13.72a1 1 0 001.5.86l11-6.86a1 1 0 000-1.72l-11-6.86a1 1 0 00-1.5.86z" />

--- a/app/frontend/utils/youtubeThumbnail.test.ts
+++ b/app/frontend/utils/youtubeThumbnail.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { nextYoutubeThumbnail, preferYoutubeThumbnail } from './youtubeThumbnail'
+
+describe('youtubeThumbnail', () => {
+  it('prefers maxresdefault for known video still URLs', () => {
+    expect(preferYoutubeThumbnail('https://i.ytimg.com/vi/abc123/hqdefault.jpg')).toBe(
+      'https://i.ytimg.com/vi/abc123/maxresdefault.jpg'
+    )
+  })
+
+  it('falls down the quality ladder', () => {
+    expect(nextYoutubeThumbnail('https://i.ytimg.com/vi/abc123/maxresdefault.jpg')).toBe(
+      'https://i.ytimg.com/vi/abc123/sddefault.jpg'
+    )
+    expect(nextYoutubeThumbnail('https://i.ytimg.com/vi/abc123/hqdefault.jpg')).toBe(
+      'https://i.ytimg.com/vi/abc123/mqdefault.jpg'
+    )
+    expect(nextYoutubeThumbnail('https://i.ytimg.com/vi/abc123/default.jpg')).toBeNull()
+  })
+})

--- a/app/frontend/utils/youtubeThumbnail.ts
+++ b/app/frontend/utils/youtubeThumbnail.ts
@@ -1,0 +1,21 @@
+const QUALITY_LADDER = ['maxresdefault', 'sddefault', 'hqdefault', 'mqdefault', 'default'] as const
+
+/** Prefer maxres when we only have a lower Atom-quality still URL. */
+export function preferYoutubeThumbnail(url: string | null | undefined): string | null {
+  if (!url) return null
+  const match = url.match(/\/vi\/([^/]+)\//)
+  if (!match) return url
+  return `https://i.ytimg.com/vi/${match[1]}/maxresdefault.jpg`
+}
+
+/** Next lower YouTube still quality, or null when the ladder is exhausted. */
+export function nextYoutubeThumbnail(url: string): string | null {
+  for (let index = 0; index < QUALITY_LADDER.length - 1; index += 1) {
+    const current = QUALITY_LADDER[index]
+    const next = QUALITY_LADDER[index + 1]
+    if (url.includes(`/${current}.jpg`)) {
+      return url.replace(`/${current}.jpg`, `/${next}.jpg`)
+    }
+  }
+  return null
+}

--- a/app/models/news_aggregator_config.rb
+++ b/app/models/news_aggregator_config.rb
@@ -106,6 +106,16 @@ module NewsAggregatorConfig
       config.dig(:apis, :youtube, :max_duration_seconds) || 1200
     end
 
+    def youtube_exclude_shorts?
+      flag = config.dig(:apis, :youtube, :exclude_shorts)
+      flag.nil? ? true : ActiveModel::Type::Boolean.new.cast(flag)
+    end
+
+    def youtube_shorts_max_seconds
+      seconds = config.dig(:apis, :youtube, :shorts_max_seconds)
+      seconds.nil? ? 60 : [ seconds.to_i, 0 ].max
+    end
+
     def youtube_search
       config.dig(:apis, :youtube, :search) || {}
     end

--- a/app/models/news_source.rb
+++ b/app/models/news_source.rb
@@ -29,13 +29,28 @@ class NewsSource < ApplicationRecord
     end
 
     NewsAggregatorConfig.youtube_channels.each do |channel|
-      find_or_create_by!(source_type: "youtube", name: channel[:name]) do |source|
-        source.active = true
-        source.config = {
-          "channel_id" => channel[:channel_id],
-          "channel_name" => channel[:name]
-        }
-      end
+      source = find_or_initialize_by(source_type: "youtube", name: channel[:name])
+      source.active = true if source.new_record?
+      source.config = {
+        "channel_id" => channel[:channel_id],
+        "channel_name" => channel[:name]
+      }
+      source.save!
+    end
+
+    retire_removed_youtube_defaults!
+  end
+
+  # Defaults we used to ship but no longer recommend (broken IDs / promo-heavy).
+  RETIRED_YOUTUBE_DEFAULTS = [
+    "Confreaks",
+    "Google for Developers",
+    "ThePrimeagen"
+  ].freeze
+
+  def self.retire_removed_youtube_defaults!
+    where(source_type: "youtube", name: RETIRED_YOUTUBE_DEFAULTS, active: true).find_each do |source|
+      source.update!(active: false)
     end
   end
 

--- a/app/services/news_fetchers/youtube_fetcher.rb
+++ b/app/services/news_fetchers/youtube_fetcher.rb
@@ -137,6 +137,11 @@ class NewsFetchers::YoutubeFetcher < NewsFetchers::BaseFetcher
   end
 
   def create_article_from_atom_entry(entry)
+    if NewsAggregatorConfig.youtube_exclude_shorts? && short_entry?(entry)
+      Rails.logger.info "Skipping YouTube Short #{entry[:video_id]} from #{@channel_id}"
+      return
+    end
+
     published_at = Time.iso8601(entry[:published_at])
     source_type = source_key
 
@@ -148,7 +153,7 @@ class NewsFetchers::YoutubeFetcher < NewsFetchers::BaseFetcher
       external_id: entry[:video_id],
       source_type: source_type,
       content_type: "video",
-      thumbnail_url: entry[:thumbnail_url],
+      thumbnail_url: YoutubeThumbnail.preferred_url(entry[:thumbnail_url], video_id: entry[:video_id]),
       author: entry[:author],
       comment_count: 0
     }
@@ -163,5 +168,11 @@ class NewsFetchers::YoutubeFetcher < NewsFetchers::BaseFetcher
     @articles << article if article.persisted?
   rescue StandardError => e
     Rails.logger.error "Error creating YouTube video #{entry[:video_id]}: #{e.message}"
+  end
+
+  def short_entry?(entry)
+    url = entry[:url].to_s
+    title = entry[:title].to_s
+    url.match?(%r{/shorts/}i) || title.match?(/#\s*shorts\b/i)
   end
 end

--- a/app/services/youtube_keyword_discovery.rb
+++ b/app/services/youtube_keyword_discovery.rb
@@ -134,7 +134,7 @@ class YoutubeKeywordDiscovery
       source_type: self.class.source_key_for(filter),
       published_at: published_at,
       content_type: "video",
-      thumbnail_url: thumbnail,
+      thumbnail_url: YoutubeThumbnail.preferred_url(thumbnail, video_id: video_id),
       author: snippet["channelTitle"].presence,
       score: 0,
       comment_count: 0

--- a/app/services/youtube_thumbnail.rb
+++ b/app/services/youtube_thumbnail.rb
@@ -1,0 +1,19 @@
+# Prefer higher-res YouTube stills. Atom feeds usually ship hqdefault; maxres may 404
+# for some videos — the UI falls back down the quality ladder on image error.
+class YoutubeThumbnail
+  HOST = "https://i.ytimg.com"
+
+  def self.preferred_url(thumbnail_url = nil, video_id: nil)
+    id = video_id.to_s.strip.presence || extract_video_id(thumbnail_url)
+    return thumbnail_url.presence if id.blank?
+
+    "#{HOST}/vi/#{id}/maxresdefault.jpg"
+  end
+
+  def self.extract_video_id(url)
+    return if url.blank?
+
+    url.to_s[%r{/vi/([^/]+)/}, 1].presence ||
+      url.to_s[/[?&]v=([^&]+)/, 1].presence
+  end
+end

--- a/app/services/youtube_video_enricher.rb
+++ b/app/services/youtube_video_enricher.rb
@@ -61,11 +61,26 @@ class YoutubeVideoEnricher
 
       article.update!(attributes)
       updated += 1
-      discard_if_too_long!(article)
+      discard_if_short!(article)
+      discard_if_too_long!(article) unless article.destroyed?
     rescue StandardError => e
       Rails.logger.error "Failed to enrich YouTube video #{article.external_id}: #{e.message}"
     end
     updated
+  end
+
+  def discard_if_short!(article)
+    return unless NewsAggregatorConfig.youtube_exclude_shorts?
+
+    max_short = NewsAggregatorConfig.youtube_shorts_max_seconds
+    return if max_short <= 0
+    return if article.duration_seconds.blank? || article.duration_seconds > max_short
+    return if article.bookmarked? || article.read?
+
+    Rails.logger.info(
+      "Discarding YouTube Short #{article.external_id} (#{article.duration_seconds}s ≤ #{max_short}s)"
+    )
+    article.destroy!
   end
 
   def discard_if_too_long!(article)
@@ -84,7 +99,7 @@ class YoutubeVideoEnricher
     response = HTTParty.get(
       API_URL,
       query: {
-        part: "contentDetails,statistics",
+        part: "contentDetails,statistics,snippet",
         id: ids.join(","),
         key: self.class.api_key
       },
@@ -112,6 +127,11 @@ class YoutubeVideoEnricher
       attributes[:score] = stats["viewCount"].to_i if stats.key?("viewCount")
       attributes[:comment_count] = stats["commentCount"].to_i if stats.key?("commentCount")
     end
+
+    thumb = item.dig("snippet", "thumbnails", "maxres", "url").presence ||
+            item.dig("snippet", "thumbnails", "standard", "url").presence ||
+            item.dig("snippet", "thumbnails", "high", "url").presence
+    attributes[:thumbnail_url] = thumb if thumb.present?
 
     attributes
   end

--- a/config/news_aggregator.yml
+++ b/config/news_aggregator.yml
@@ -80,6 +80,9 @@ development: &default
       enrich_max_per_run: 100
       # After enrichment, drop videos longer than this (seconds). 0 disables.
       max_duration_seconds: 1200
+      # Drop Shorts (URL/title heuristics + duration ≤ shorts_max_seconds after enrich).
+      exclude_shorts: true
+      shorts_max_seconds: 60
       # Keyword search discovery (search.list). Disabled by default — burns ~100 units/call.
       search:
         enabled: false
@@ -91,15 +94,22 @@ development: &default
         relevance_language: en
         region_code: US
         published_after_days: 7 # used when a filter has never been searched
+      # Tools / languages first — skip corporate AI promo defaults.
       channels:
-        - channel_id: "UCWnPjmqvljcafA0QXblOU1A"
-          name: "Confreaks"
         - channel_id: "UCsBjURrPoezykLs9EqgamOA"
           name: "Fireship"
-        - channel_id: "UC_x5XG1OV2P6uZZ5FSM9Ttw"
-          name: "Google for Developers"
-        - channel_id: "UCUyeluBRhGPCW4rPe7MhPUA"
-          name: "ThePrimeagen"
+        - channel_id: "UC29ju8bIPH5as8OGnQzwJyA"
+          name: "Traversy Media"
+        - channel_id: "UCFbNIlppjAuEX4znoulh0Cw"
+          name: "Web Dev Simplified"
+        - channel_id: "UC8butISFwT-Wl7EV0hUK0BQ"
+          name: "freeCodeCamp.org"
+        - channel_id: "UCmEzz-dPBVrsy4ZluSsYHDg"
+          name: "Hyperplexed"
+        - channel_id: "UCbRP3c757lWg9M-U7TyEkXA"
+          name: "Theo - t3.gg"
+        - channel_id: "UCCezIgC97PvUuR4_gbFUs5g"
+          name: "Corey Schafer"
 
 test:
   <<: *default

--- a/docs/REPO_STRUCTURE.md
+++ b/docs/REPO_STRUCTURE.md
@@ -120,6 +120,7 @@ dev-news-aggregator/
 | `article_summarizer.rb` | Pluggable article summarizer facade (`none` / `heuristic` / `openai` / `ollama`) |
 | `summarizers/` | Provider implementations for `ArticleSummarizer` |
 | `youtube_video_enricher.rb` | Optional YouTube `videos.list` duration/stats enrichment |
+| `youtube_thumbnail.rb` | Prefer `maxresdefault` still URLs from Atom/API thumbnails |
 
 ### Jobs
 

--- a/docs/YOUTUBE.md
+++ b/docs/YOUTUBE.md
@@ -70,6 +70,8 @@ Do not commit real keys.
 | `enrich_batch_size` | `50` | IDs per `videos.list` call (clamped 1–50) |
 | `enrich_max_per_run` | `100` | Max videos enriched per job run |
 | `max_duration_seconds` | `1200` | After enrichment, destroy non-bookmarked/non-read videos longer than this (`0` disables) |
+| `exclude_shorts` | `true` | Skip `/shorts/` URLs and `#shorts` titles on ingest; hide them in the feed |
+| `shorts_max_seconds` | `60` | After enrichment, destroy non-bookmarked/non-read videos at or below this length |
 | `search.enabled` | `false` | Keyword `search.list` discovery |
 | `search.daily_call_budget` | `20` | Hard cap on search calls per UTC day |
 | `search.min_interval_hours` | `12` | Per-interest minimum gap between searches |

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -359,14 +359,14 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "index JSON max_duration keeps text articles and short or unknown videos" do
-    short = Article.create!(
-      title: "Short tip",
+    under_cap = Article.create!(
+      title: "Five minute tip",
       url: "https://www.youtube.com/watch?v=short1",
       external_id: "short1",
       source_type: "youtube_UCtest",
       published_at: Time.current,
       content_type: "video",
-      duration_seconds: 60
+      duration_seconds: 300
     )
     long = Article.create!(
       title: "Long talk",
@@ -392,7 +392,7 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
 
     ids = JSON.parse(response.body)["articles"].map { |item| item["id"] }
     assert_includes ids, @article.id
-    assert_includes ids, short.id
+    assert_includes ids, under_cap.id
     assert_includes ids, unknown.id
     assert_not_includes ids, long.id
   end

--- a/test/services/news_fetchers/youtube_fetcher_test.rb
+++ b/test/services/news_fetchers/youtube_fetcher_test.rb
@@ -52,10 +52,55 @@ class NewsFetchers::YoutubeFetcherTest < ActiveSupport::TestCase
     assert_equal "https://www.youtube.com/watch?v=abc123XYZ", article.url
     assert_equal "video", article.content_type
     assert_equal "Confreaks", article.author
-    assert_equal "https://i.ytimg.com/vi/abc123XYZ/hqdefault.jpg", article.thumbnail_url
+    assert_equal "https://i.ytimg.com/vi/abc123XYZ/maxresdefault.jpg", article.thumbnail_url
     assert_equal 1234, article.score
     assert_equal 0, article.comment_count
     assert_equal "A talk about Rails performance.", article.description
+  end
+
+  test "fetch_articles skips Shorts by URL or #shorts title" do
+    stub_youtube_feed(<<~ATOM)
+      <feed xmlns:yt="http://www.youtube.com/xml/schemas/2015"
+            xmlns:media="http://search.yahoo.com/mrss/"
+            xmlns="http://www.w3.org/2005/Atom">
+        <entry>
+          <yt:videoId>shortAAA</yt:videoId>
+          <title>Quick tip</title>
+          <link rel="alternate" href="https://www.youtube.com/shorts/shortAAA"/>
+          <published>2024-06-01T12:00:00+00:00</published>
+          <media:group>
+            <media:thumbnail url="https://i.ytimg.com/vi/shortAAA/hqdefault.jpg"/>
+          </media:group>
+        </entry>
+        <entry>
+          <yt:videoId>shortBBB</yt:videoId>
+          <title>Another tip #shorts</title>
+          <link rel="alternate" href="https://www.youtube.com/watch?v=shortBBB"/>
+          <published>2024-06-01T13:00:00+00:00</published>
+          <media:group>
+            <media:thumbnail url="https://i.ytimg.com/vi/shortBBB/hqdefault.jpg"/>
+          </media:group>
+        </entry>
+        <entry>
+          <yt:videoId>longCCC</yt:videoId>
+          <title>Full tutorial</title>
+          <link rel="alternate" href="https://www.youtube.com/watch?v=longCCC"/>
+          <published>2024-06-01T14:00:00+00:00</published>
+          <media:group>
+            <media:thumbnail url="https://i.ytimg.com/vi/longCCC/hqdefault.jpg"/>
+          </media:group>
+        </entry>
+      </feed>
+    ATOM
+
+    assert_difference "Article.count", 1 do
+      articles = @fetcher.fetch_articles
+      assert_equal 1, articles.length
+    end
+
+    assert Article.exists?(external_id: "longCCC", source_type: "youtube_#{@channel_id}")
+    assert_not Article.exists?(external_id: "shortAAA")
+    assert_not Article.exists?(external_id: "shortBBB")
   end
 
   test "fetch_articles updates existing videos without wiping a higher score when views are missing" do

--- a/test/services/youtube_keyword_discovery_test.rb
+++ b/test/services/youtube_keyword_discovery_test.rb
@@ -63,7 +63,7 @@ class YoutubeKeywordDiscoveryTest < ActiveSupport::TestCase
     assert_equal "video", ruby_video.content_type
     assert_equal "youtube_search_ruby", ruby_video.source_type
     assert_equal "Confreaks", ruby_video.author
-    assert_equal "https://i.ytimg.com/vi/rubyVid001/hqdefault.jpg", ruby_video.thumbnail_url
+    assert_equal "https://i.ytimg.com/vi/rubyVid001/maxresdefault.jpg", ruby_video.thumbnail_url
 
     assert FetchRun.exists?(source_key: "youtube_search_ruby", status: "success")
     assert FetchRun.exists?(source_key: "youtube_search_rust", status: "success")

--- a/test/services/youtube_thumbnail_test.rb
+++ b/test/services/youtube_thumbnail_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class YoutubeThumbnailTest < ActiveSupport::TestCase
+  test "preferred_url upgrades Atom hqdefault stills to maxresdefault" do
+    url = YoutubeThumbnail.preferred_url(
+      "https://i.ytimg.com/vi/abc123XYZ/hqdefault.jpg",
+      video_id: "abc123XYZ"
+    )
+
+    assert_equal "https://i.ytimg.com/vi/abc123XYZ/maxresdefault.jpg", url
+  end
+
+  test "preferred_url derives video id from thumbnail path" do
+    url = YoutubeThumbnail.preferred_url("https://i.ytimg.com/vi/abc123XYZ/mqdefault.jpg")
+
+    assert_equal "https://i.ytimg.com/vi/abc123XYZ/maxresdefault.jpg", url
+  end
+
+  test "preferred_url returns original when video id is missing" do
+    assert_equal "https://example.com/thumb.jpg", YoutubeThumbnail.preferred_url("https://example.com/thumb.jpg")
+    assert_nil YoutubeThumbnail.preferred_url(nil)
+  end
+end

--- a/test/services/youtube_video_enricher_test.rb
+++ b/test/services/youtube_video_enricher_test.rb
@@ -119,11 +119,33 @@ class YoutubeVideoEnricherTest < ActiveSupport::TestCase
     assert_nil Article.find_by(id: @video.id)
   end
 
+  test "enrich! discards Shorts by duration when exclude_shorts is enabled" do
+    stub_videos_list(
+      items: [
+        {
+          "id" => "abc123XYZ",
+          "contentDetails" => { "duration" => "PT45S" },
+          "statistics" => { "viewCount" => "9", "commentCount" => "0" },
+          "snippet" => {
+            "thumbnails" => {
+              "maxres" => { "url" => "https://i.ytimg.com/vi/abc123XYZ/maxresdefault.jpg" }
+            }
+          }
+        }
+      ]
+    )
+
+    result = YoutubeVideoEnricher.enrich!
+
+    assert_equal 1, result[:enriched]
+    assert_nil Article.find_by(id: @video.id)
+  end
+
   private
 
   def stub_videos_list(items:)
     stub_request(:get, %r{https://www\.googleapis\.com/youtube/v3/videos})
-      .with(query: hash_including("part" => "contentDetails,statistics", "key" => "test-key"))
+      .with(query: hash_including("part" => "contentDetails,statistics,snippet", "key" => "test-key"))
       .to_return(
         status: 200,
         body: { items: items }.to_json,


### PR DESCRIPTION
## Summary
- Prefer `maxresdefault` thumbnails (Atom + UI fallback ladder; API snippet when enriching)
- Exclude Shorts on ingest (`/shorts/`, `#shorts`) and after enrich (≤60s); hide them in the feed
- Replace Google for Developers / broken Confreaks / ThePrimeagen defaults with tools/language channels; retire old defaults on bootstrap

Closes #439

## Test plan
- [ ] `bundle exec rails test test/services/youtube_* test/services/news_fetchers/youtube_fetcher_test.rb`
- [ ] `npm test -- --run app/frontend/utils/youtubeThumbnail.test.ts app/frontend/components/ArticleCard.test.tsx`
- [ ] Visit `/sources`, confirm new channels and Google for Developers inactive
- [ ] Videos filter shows no Shorts; thumbs look sharper