### PR TITLE
refactor(frontend): clarify filter labels and use a single sort select (#440)

### DIFF
--- a/app/frontend/components/CategoryFilter.tsx
+++ b/app/frontend/components/CategoryFilter.tsx
@@ -43,8 +43,11 @@ export default function CategoryFilter({
             d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.707A1 1 0 013 7V4z"
           />
         </svg>
-        Filter by Category
+        Filter by source
       </h2>
+      {embedded && (
+        <p className="mb-3 text-xs text-gray-400">Where it came from (HN, Reddit, Dev.to, …)</p>
+      )}
       <div className="flex flex-wrap gap-2">
         <Button
           variant="filter"

--- a/app/frontend/components/FilterToolbar.tsx
+++ b/app/frontend/components/FilterToolbar.tsx
@@ -9,7 +9,7 @@ import ContentTypeFilter, {
 import FilterMenu from './FilterMenu'
 import InterestFilter from './InterestFilter'
 import ScoreFilter, { SCORE_FILTER_OPTIONS, type ScoreFilterValue } from './ScoreFilter'
-import SortControl, { SORT_OPTIONS, type SortValue } from './SortControl'
+import { SORT_OPTIONS, type SortValue } from './SortControl'
 import TopicFilter, { type TopicTagOption } from './TopicFilter'
 import { FOCUS_RING } from './ui/buttonStyles'
 import Card from './ui/Card'
@@ -95,7 +95,6 @@ export default function FilterToolbar({
   onTagChange,
   onClearAllFilters,
 }: FilterToolbarProps) {
-  const sortLabel = SORT_OPTIONS.find((option) => option.value === activeSort)?.label ?? 'Newest'
   const scoreLabel =
     SCORE_FILTER_OPTIONS.find((option) => option.value === activeScoreFilter)?.label ?? 'All scores'
 
@@ -127,9 +126,27 @@ export default function FilterToolbar({
     filterCount === 0 ? undefined : filterCount === 1 ? '1 active' : `${filterCount} active`
 
   const activeChips: ActiveChip[] = [
+    ...(activeCategoryName
+      ? [
+          {
+            key: 'category',
+            label: `Source: ${activeCategoryName}`,
+            onClear: () => onCategoryChange('all'),
+          },
+        ]
+      : []),
+    ...(activeTagName
+      ? [
+          {
+            key: 'tag',
+            label: `Tag: ${activeTagName}`,
+            onClear: () => onTagChange('all'),
+          },
+        ]
+      : []),
     ...interestNames.map((name, index) => ({
       key: `interest-${selectedInterestSlugs[index]}`,
-      label: name,
+      label: `Interest: ${name}`,
       onClear: () => onInterestToggle(selectedInterestSlugs[index]),
     })),
     ...(activeScoreFilter !== 'all'
@@ -156,24 +173,6 @@ export default function FilterToolbar({
             key: 'max-duration',
             label: durationLabel(activeMaxDuration),
             onClear: () => onMaxDurationChange('all'),
-          },
-        ]
-      : []),
-    ...(activeCategoryName
-      ? [
-          {
-            key: 'category',
-            label: activeCategoryName,
-            onClear: () => onCategoryChange('all'),
-          },
-        ]
-      : []),
-    ...(activeTagName
-      ? [
-          {
-            key: 'tag',
-            label: activeTagName,
-            onClear: () => onTagChange('all'),
           },
         ]
       : []),
@@ -214,14 +213,26 @@ export default function FilterToolbar({
           </div>
 
           <div className="flex flex-wrap items-center gap-2">
-            <FilterMenu
-              label="Sort"
-              summary={sortLabel}
-              active={activeSort !== 'published_at'}
-              testId="sort-menu"
+            <label htmlFor="article-sort" className="sr-only">
+              Sort articles
+            </label>
+            <select
+              id="article-sort"
+              value={activeSort}
+              onChange={(event) => onSortChange(event.target.value as SortValue)}
+              className={`rounded-lg border px-3 py-2 text-sm font-medium ${FOCUS_RING} ${
+                activeSort !== 'published_at'
+                  ? 'border-primary-500 bg-primary-600/20 text-primary-200'
+                  : 'border-dark-500 bg-dark-800 text-gray-200 hover:border-dark-400'
+              }`}
+              data-testid="sort-select"
             >
-              <SortControl embedded activeSort={activeSort} onSortChange={onSortChange} />
-            </FilterMenu>
+              {SORT_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  Sort: {option.label}
+                </option>
+              ))}
+            </select>
 
             <FilterMenu
               label="Filters"

--- a/app/frontend/components/InterestFilter.tsx
+++ b/app/frontend/components/InterestFilter.tsx
@@ -21,9 +21,9 @@ export default function InterestFilter({
 
   const body = (
     <>
-      <div className={`flex items-center justify-between gap-4 ${embedded ? 'mb-3' : 'mb-4'}`}>
+      <div className={`flex items-center justify-between gap-4 ${embedded ? 'mb-1' : 'mb-4'}`}>
         <h2 className={embedded ? 'text-sm font-medium text-gray-200' : 'text-h3 text-gray-100'}>
-          Filter by interest
+          My interests
         </h2>
         {selectedSlugs.length > 0 && (
           <button
@@ -36,6 +36,9 @@ export default function InterestFilter({
           </button>
         )}
       </div>
+      {embedded && (
+        <p className="mb-3 text-xs text-gray-400">Saved keyword presets from Interests</p>
+      )}
       <div className="flex flex-wrap gap-2">
         {interests.map((interest) => {
           const selected = selectedSlugs.includes(interest.slug)

--- a/app/frontend/components/TopicFilter.tsx
+++ b/app/frontend/components/TopicFilter.tsx
@@ -23,9 +23,12 @@ export default function TopicFilter({
 
   const body = (
     <>
-      <h2 className={embedded ? 'mb-3 text-sm font-medium text-gray-200' : 'mb-4 text-h3 text-gray-100'}>
-        Filter by topic
+      <h2 className={embedded ? 'mb-1 text-sm font-medium text-gray-200' : 'mb-4 text-h3 text-gray-100'}>
+        Filter by tag
       </h2>
+      {embedded && (
+        <p className="mb-3 text-xs text-gray-400">Topics detected on the article</p>
+      )}
       <div className="flex flex-wrap gap-2">
         <Button
           variant="filter"
@@ -36,7 +39,7 @@ export default function TopicFilter({
           aria-pressed={activeTag === 'all'}
           onClick={() => onTagChange('all')}
         >
-          All topics
+          All tags
         </Button>
         {tags.map((tag) => (
           <Button

--- a/app/frontend/pages/ArticlesIndexPage.test.tsx
+++ b/app/frontend/pages/ArticlesIndexPage.test.tsx
@@ -46,11 +46,6 @@ async function openFiltersMenu(user: ReturnType<typeof userEvent.setup>) {
   return screen.findByTestId('filters-menu-panel')
 }
 
-async function openSortMenu(user: ReturnType<typeof userEvent.setup>) {
-  await user.click(screen.getByTestId('sort-menu'))
-  return screen.findByTestId('sort-menu-panel')
-}
-
 describe('ArticlesIndexPage dismiss flow', () => {
   beforeEach(() => {
     vi.mocked(articlesApi.fetchArticles).mockResolvedValue(buildArticlesIndexResponse())
@@ -115,7 +110,7 @@ describe('ArticlesIndexPage dismiss flow', () => {
     )
     expect(screen.getByText('Rust 2024 Edition Highlights')).toBeInTheDocument()
     expect(screen.queryByText('Ruby 3.3 Performance Tips')).not.toBeInTheDocument()
-    expect(screen.getByTestId('active-filter-chips')).toHaveTextContent('Programming Languages')
+    expect(screen.getByTestId('active-filter-chips')).toHaveTextContent('Source: Programming Languages')
 
     vi.mocked(articlesApi.fetchArticles).mockResolvedValue(buildArticlesIndexResponse())
     const filters = await openFiltersMenu(user)
@@ -155,19 +150,13 @@ describe('ArticlesIndexPage dismiss flow', () => {
   })
 
   it('requests sorted articles when sort is in the URL', async () => {
-    const user = userEvent.setup()
     renderPage(['/articles?sort=score'])
 
     await waitForArticlesFeed()
     expect(articlesApi.fetchArticles).toHaveBeenCalledWith(
       expect.objectContaining({ sort: 'score' })
     )
-    expect(screen.getByTestId('sort-menu')).toHaveTextContent('Highest score')
-    const sortPanel = await openSortMenu(user)
-    expect(within(sortPanel).getByRole('button', { name: 'Highest score' })).toHaveAttribute(
-      'aria-pressed',
-      'true'
-    )
+    expect(screen.getByTestId('sort-select')).toHaveValue('score')
   })
 
   it('requests for_you sort when selected', async () => {
@@ -175,15 +164,14 @@ describe('ArticlesIndexPage dismiss flow', () => {
     renderPage()
 
     await waitForArticlesFeed()
-    const sortPanel = await openSortMenu(user)
-    await user.click(within(sortPanel).getByRole('button', { name: 'For you' }))
+    await user.selectOptions(screen.getByTestId('sort-select'), 'for_you')
 
     await waitFor(() => {
       expect(articlesApi.fetchArticles).toHaveBeenCalledWith(
         expect.objectContaining({ sort: 'for_you' })
       )
     })
-    expect(screen.getByTestId('sort-menu')).toHaveTextContent('For you')
+    expect(screen.getByTestId('sort-select')).toHaveValue('for_you')
   })
 
   it('updates sort via the sort control', async () => {
@@ -191,8 +179,7 @@ describe('ArticlesIndexPage dismiss flow', () => {
     renderPage()
 
     await waitForArticlesFeed()
-    const sortPanel = await openSortMenu(user)
-    await user.click(within(sortPanel).getByRole('button', { name: 'Most comments' }))
+    await user.selectOptions(screen.getByTestId('sort-select'), 'comment_count')
 
     await waitFor(() => {
       expect(articlesApi.fetchArticles).toHaveBeenCalledWith(
@@ -234,7 +221,7 @@ describe('ArticlesIndexPage dismiss flow', () => {
     renderPage(['/articles?interests=rust'])
 
     await waitForArticlesFeed()
-    expect(screen.getByTestId('active-filter-chips')).toHaveTextContent('Rust')
+    expect(screen.getByTestId('active-filter-chips')).toHaveTextContent('Interest: Rust')
     const filters = await openFiltersMenu(user)
     await waitFor(() => {
       expect(within(filters).getByRole('button', { name: 'Rust (5)' })).toHaveAttribute(
@@ -265,7 +252,7 @@ describe('ArticlesIndexPage dismiss flow', () => {
       )
     })
 
-    await user.click(screen.getByRole('button', { name: 'Clear filter Rust' }))
+    await user.click(screen.getByRole('button', { name: 'Clear filter Interest: Rust' }))
 
     await waitFor(() => {
       expect(articlesApi.fetchArticles).toHaveBeenCalledWith(
@@ -312,7 +299,7 @@ describe('ArticlesIndexPage dismiss flow', () => {
     await screen.findByTestId('articles-page')
     expect(await screen.findByText('No articles match these interests')).toBeInTheDocument()
     expect(screen.queryByText('Your feed is empty')).not.toBeInTheDocument()
-    expect(screen.getByTestId('active-filter-chips')).toHaveTextContent('Rust')
+    expect(screen.getByTestId('active-filter-chips')).toHaveTextContent('Interest: Rust')
     const filters = await openFiltersMenu(user)
     await waitFor(() => {
       expect(within(filters).getByRole('button', { name: 'Rust (5)' })).toBeInTheDocument()
@@ -327,7 +314,7 @@ describe('ArticlesIndexPage dismiss flow', () => {
 
     await waitForArticlesFeed()
     const filters = await openFiltersMenu(user)
-    expect(within(filters).queryByText('Filter by interest')).not.toBeInTheDocument()
+    expect(within(filters).queryByText('My interests')).not.toBeInTheDocument()
     expect(screen.getByText('Rust 2024 Edition Highlights')).toBeInTheDocument()
   })
 


### PR DESCRIPTION
## Summary
- Rename Category → Source, Topic → Tag, Interest → My interests, with one-line hints in the Filters menu
- Prefix active chips (`Source:`, `Tag:`, `Interest:`) so they are not ambiguous
- Replace Sort dropdown+button strip with one native select

Closes #440

## Test plan
- [ ] `npm test -- --run app/frontend/pages/ArticlesIndexPage.test.tsx`
- [ ] Open Filters and confirm source/tag/interest labels + hints
- [ ] Change sort via the single select; no nested sort tabs