### PR TITLE
fix(youtube): preserve local channel config on bootstrap

### DIFF
--- a/app/models/news_source.rb
+++ b/app/models/news_source.rb
@@ -29,13 +29,13 @@ class NewsSource < ApplicationRecord
     end
 
     NewsAggregatorConfig.youtube_channels.each do |channel|
-      source = find_or_initialize_by(source_type: "youtube", name: channel[:name])
-      source.active = true if source.new_record?
-      source.config = {
-        "channel_id" => channel[:channel_id],
-        "channel_name" => channel[:name]
-      }
-      source.save!
+      find_or_create_by!(source_type: "youtube", name: channel[:name]) do |source|
+        source.active = true
+        source.config = {
+          "channel_id" => channel[:channel_id],
+          "channel_name" => channel[:name]
+        }
+      end
     end
 
     retire_removed_youtube_defaults!

--- a/test/models/news_source_test.rb
+++ b/test/models/news_source_test.rb
@@ -63,4 +63,34 @@ class NewsSourceTest < ActiveSupport::TestCase
     assert_equal NewsAggregatorConfig.youtube_channels.length,
                  NewsSource.where(source_type: "youtube").count
   end
+
+  test "bootstrap_defaults preserves local YouTube channel_id edits" do
+    default = NewsAggregatorConfig.youtube_channels.first
+    source = NewsSource.create!(
+      name: default[:name],
+      source_type: "youtube",
+      active: true,
+      config: { "channel_id" => "UClocalOverride12345678901", "channel_name" => default[:name] }
+    )
+
+    NewsSource.bootstrap_defaults!
+
+    assert_equal "UClocalOverride12345678901", source.reload.channel_id
+  end
+
+  test "bootstrap_defaults retires removed YouTube defaults without deleting them" do
+    retired = NewsSource.create!(
+      name: "Google for Developers",
+      source_type: "youtube",
+      active: true,
+      config: {
+        "channel_id" => "UC_x5XG1OV2P6uZZ5FSM9Ttw",
+        "channel_name" => "Google for Developers"
+      }
+    )
+
+    NewsSource.bootstrap_defaults!
+
+    assert_not retired.reload.active?
+  end
 end


### PR DESCRIPTION
## Summary
- Stop overwriting YouTube `channel_id` on every `NewsSource.bootstrap_defaults!` (runs on `GET /sources`)
- Keep create-only defaults + retire removed promo/broken channels
- Cover preserve + retire behavior with model tests

## Test plan
- [ ] `bundle exec rails test test/models/news_source_test.rb`
- [ ] Edit a default YouTube channel_id locally, visit `/sources`, confirm it stays