### PR TITLE
fix(hooks): keep windows setup on the utf-8 code page (#446)

### DIFF
--- a/docs/PRE_COMMIT_HOOKS.md
+++ b/docs/PRE_COMMIT_HOOKS.md
@@ -100,6 +100,33 @@ If a hook fails, you'll see output explaining what went wrong:
 - **YAML syntax errors**: Fix syntax in the affected YAML file
 - **Message Format failures**: Rewrite the subject to Conventional Commits (examples below)
 
+### `invalid byte sequence in UTF-8` on Windows
+
+If every commit aborts before any hook runs, with a stack trace through `win32_symlink?` and a "Report this bug" banner:
+
+```
+invalid byte sequence in UTF-8
+.../overcommit/utils/file_utils.rb:67:in `win32_symlink?'
+.../overcommit/utils.rb:268:in `broken_symlink?'
+.git/hooks/pre-commit:80:in `<main>'
+```
+
+your console is using a legacy code page. On Windows, Overcommit detects symlinks by shelling out to `dir` and regex-matching the output, but `dir` emits text in the console code page (CP 850 on a pt-BR console) while Ruby tags it as UTF-8. Overcommit checks every modified file this way, so this fires on any commit, not just ones touching symlinks.
+
+Switch the console to UTF-8:
+
+```powershell
+chcp.com 65001
+```
+
+`.\setup-local-env.ps1` does this for you, but only for the console you run it in. To make it permanent, add it to your PowerShell profile:
+
+```powershell
+Add-Content $PROFILE "`nchcp.com 65001 > `$null"
+```
+
+Tracked in [#446](https://github.com/MarcosLorejan/dev-news-aggregator/issues/446); the underlying encoding bug is in Overcommit itself, not this repo.
+
 ### Signature Verification Errors
 If Overcommit reports that the configuration signature changed:
 ```bash

--- a/docs/log.md
+++ b/docs/log.md
@@ -13,6 +13,7 @@ Update this file in the **same PR** when you add or materially change knowledge 
 
 ## 2026-08-06
 
+- Documented the Windows UTF-8 code page requirement for Overcommit in [PRE_COMMIT_HOOKS.md](PRE_COMMIT_HOOKS.md); a legacy code page aborts every commit ([#446](https://github.com/MarcosLorejan/dev-news-aggregator/issues/446)).
 - Raised the Node.js floor from 20 to 24 in [DEVELOPMENT.md](DEVELOPMENT.md) and [REACT_SETUP.md](REACT_SETUP.md); jsdom 30 dropped Node 20 ([#418](https://github.com/MarcosLorejan/dev-news-aggregator/pull/418)).
 
 ## 2026-08-04

--- a/setup-local-env.ps1
+++ b/setup-local-env.ps1
@@ -5,6 +5,17 @@ $ErrorActionPreference = "Stop"
 $root = $PSScriptRoot
 Set-Location $root
 
+# Overcommit detects symlinks by matching `dir` output as UTF-8, so on a console
+# using a legacy code page (CP 850 on pt-BR) every commit aborts with
+# "invalid byte sequence in UTF-8" before any hook runs.
+if ([Console]::OutputEncoding.CodePage -ne 65001) {
+    Write-Host "==> Switching console to the UTF-8 code page (65001)..." -ForegroundColor Cyan
+    chcp.com 65001 | Out-Null
+    Write-Host "    This applies to the current console only. To make it permanent, add" -ForegroundColor DarkGray
+    Write-Host "    'chcp.com 65001 > `$null' to your PowerShell `$PROFILE." -ForegroundColor DarkGray
+    Write-Host "    See docs/PRE_COMMIT_HOOKS.md" -ForegroundColor DarkGray
+}
+
 $envExample = Join-Path $root ".env.example"
 $envFile = Join-Path $root ".env"
 if (-not (Test-Path $envFile)) {
@@ -13,7 +24,7 @@ if (-not (Test-Path $envFile)) {
         Copy-Item $envExample $envFile
         Write-Host "    Fill optional REDDIT_CLIENT_ID / REDDIT_CLIENT_SECRET for OAuth scores." -ForegroundColor DarkGray
     } else {
-        Write-Host "Missing .env.example — skip creating .env." -ForegroundColor Yellow
+        Write-Host "Missing .env.example - skip creating .env." -ForegroundColor Yellow
     }
 } else {
     Write-Host "==> .env already present (left unchanged)." -ForegroundColor DarkGray


### PR DESCRIPTION
## Summary

Closes #446.

Overcommit detects symlinks on Windows by shelling out to `dir` and regex-matching the output as UTF-8. `dir` emits text in the console code page, so on a pt-BR console (CP 850) the bytes are invalid UTF-8 and every `git commit` aborts with `invalid byte sequence in UTF-8` before a single hook runs. It checks every modified file this way, so it is not limited to commits touching symlinks.

- `setup-local-env.ps1` now switches the console to code page 65001 when it is not already UTF-8, and prints how to make it permanent via `$PROFILE`.
- `docs/PRE_COMMIT_HOOKS.md` documents the symptom, the cause, and the fix under "Common Issues", so the stack trace is searchable.
- Logged the Node/Windows prerequisite change in `docs/log.md`.

### Drive-by: `setup-local-env.ps1` was unparseable

While testing the above I found the script does not parse at all under Windows PowerShell 5.1, independent of this issue:

```
A cadeia de caracteres nao tem o terminador: ".
'}' de fechamento ausente no bloco de instrucao ou na definicao de tipo.
```

The file is UTF-8 without a BOM and contained an em-dash (U+2014) inside a double-quoted string. PowerShell 5.1 reads a BOM-less file as CP1252, so those three bytes become `â€"` — and that trailing byte is a right double quotation mark, which terminates the string and cascades into unbalanced braces. Replacing the em-dash with an ASCII hyphen makes the file pure ASCII and it parses cleanly.

`dev.ps1` has two more em-dashes but both are inside comments, so they are harmless; left alone to keep this focused.

## Test plan

- [x] `setup-local-env.ps1` parses under PowerShell 5.1.19041 (`Parser::ParseFile` reports 0 errors; it reported 3 before)
- [x] File is pure ASCII and still UTF-8 without BOM, so the diff stays a normal text diff
- [x] `ruby bin/check-docs` passes
- [x] Committed this branch on a CP 850 console with hooks enabled to confirm the workaround
- [ ] Fresh `.\setup-local-env.ps1` run on a non-UTF-8 console

## Not fixed here

The underlying bug is in Overcommit's `win32_symlink?`, which should scrub the `dir` output before matching. Worth reporting upstream to [sds/overcommit](https://github.com/sds/overcommit/issues); this PR only stops it from biting local contributors.
